### PR TITLE
This PR changes ensures that some schema files have the correct content type

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -25,6 +25,9 @@ github_username:  json-schema-org
 markdown: kramdown
 #theme: minima
 
+gems:
+  - jekyll-redirect-from
+
 collections:
   docs:
     output: true

--- a/calendar.json
+++ b/calendar.json
@@ -1,3 +1,6 @@
+---
+redirect_from: "/calendar"
+---
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "description": "A representation of an event",

--- a/card.json
+++ b/card.json
@@ -1,3 +1,6 @@
+---
+redirect_from: "/card"
+---
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "description": "A representation of a person, company, organization, or place",

--- a/documentation.html
+++ b/documentation.html
@@ -49,19 +49,19 @@ layout: page
     <p>
     <table class="key-value">
         <tr>
-            <td class="key"><a href="http://json-schema.org/geo">Geographic Coordinate</a></td>
+            <td class="key"><a href="http://json-schema.org/geo.json">Geographic Coordinate</a></td>
             <td class="value">a location as longitude and latitude</td>
         </tr>
         <tr>
-            <td class="key"><a href="http://json-schema.org/card">Card</a></td>
+            <td class="key"><a href="http://json-schema.org/card.json">Card</a></td>
             <td class="value">a microformat-style representation of a person, company, organization, or place</td>
         </tr>
         <tr>
-            <td class="key"><a href="http://json-schema.org/calendar">Calendar</a></td>
+            <td class="key"><a href="http://json-schema.org/calendar.json">Calendar</a></td>
             <td class="value">a microformat-style representation of an event</td>
         </tr>
         <tr>
-            <td class="key"><a href="http://json-schema.org/address">Address</a></td>
+            <td class="key"><a href="http://json-schema.org/address.json">Address</a></td>
             <td class="value">a microformat-style representation of a street address</td>
         </tr>
     </table>

--- a/geo.json
+++ b/geo.json
@@ -1,3 +1,6 @@
+---
+redirect_from: "/geo"
+---
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "description": "A geographical coordinate",


### PR DESCRIPTION
I did this simply by renaming files like /card to /card.json.
I also used the `redirect_from` github plugin so that people who are
already linking to the old url will redirect to the new url.
