### PR TITLE
Re-add PHP validator JSON Guard

### DIFF
--- a/implementations.html
+++ b/implementations.html
@@ -62,6 +62,7 @@ permalink: /implementations
 		<li><a id="link-impl-php-json-schema" href="https://github.com/hasbridge/php-json-schema">php-json-schema</a> (MIT)</li>
 		<li><a id="link-impl-json-schema" href="https://github.com/justinrainbow/json-schema">json-schema</a> (Berkeley)</li>
 		<li><a id="link-impl-jval" href="https://github.com/stefk/jval">JVal</a> - <em>supports version 4</em>  (MIT)</li>
+		<li><a id="link-impl-json-guard" href="https://github.com/thephpleague/json-guard">JSON Guard</a> - <em>supports version 4</em> (MIT)</li>
 	</ul>
 	</li>
 	<li>.NET


### PR DESCRIPTION
My validator got removed when the site was ported to Jekyll.