### PR TITLE
Draft 05 meta-schemas

### DIFF
--- a/draft-05/hyper-schema
+++ b/draft-05/hyper-schema
@@ -1,0 +1,158 @@
+{
+    "$schema": "http://json-schema.org/draft-04/hyper-schema#",
+    "id": "http://json-schema.org/draft-04/hyper-schema#",
+    "title": "JSON Hyper-Schema",
+    "allOf": [
+        {
+            "$ref": "http://json-schema.org/draft-04/schema#"
+        }
+    ],
+    "properties": {
+        "additionalItems": {
+            "anyOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#"
+                }
+            ]
+        },
+        "additionalProperties": {
+            "anyOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#"
+                }
+            ]
+        },
+        "dependencies": {
+            "additionalProperties": {
+                "anyOf": [
+                    {
+                        "$ref": "#"
+                    },
+                    {
+                        "type": "array"
+                    }
+                ]
+            }
+        },
+        "items": {
+            "anyOf": [
+                {
+                    "$ref": "#"
+                },
+                {
+                    "$ref": "#/definitions/schemaArray"
+                }
+            ]
+        },
+        "definitions": {
+            "additionalProperties": {
+                "$ref": "#"
+            }
+        },
+        "patternProperties": {
+            "additionalProperties": {
+                "$ref": "#"
+            }
+        },
+        "properties": {
+            "additionalProperties": {
+                "$ref": "#"
+            }
+        },
+        "allOf": {
+            "$ref": "#/definitions/schemaArray"
+        },
+        "anyOf": {
+            "$ref": "#/definitions/schemaArray"
+        },
+        "oneOf": {
+            "$ref": "#/definitions/schemaArray"
+        },
+        "not": {
+            "$ref": "#"
+        },
+
+        "links": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/linkDescription"
+            }
+        },
+        "fragmentResolution": {
+            "type": "string"
+        },
+        "media": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "description": "A media type, as described in RFC 2046",
+                    "type": "string"
+                },
+                "binaryEncoding": {
+                    "description": "A content encoding scheme, as described in RFC 2045",
+                    "type": "string"
+                }
+            }
+        },
+        "pathStart": {
+            "description": "Instances' URIs must start with this value for this schema to apply to them",
+            "type": "string",
+            "format": "uri"
+        }
+    },
+    "definitions": {
+        "schemaArray": {
+            "type": "array",
+            "items": {
+                "$ref": "#"
+            }
+        },
+        "linkDescription": {
+            "title": "Link Description Object",
+            "type": "object",
+            "required": [ "href", "rel" ],
+            "properties": {
+                "href": {
+                    "description": "a URI template, as defined by RFC 6570, with the addition of the $, ( and ) characters for pre-processing",
+                    "type": "string"
+                },
+                "rel": {
+                    "description": "relation to the target resource of the link",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "a title for the link",
+                    "type": "string"
+                },
+                "targetSchema": {
+                    "description": "JSON Schema describing the link target",
+                    "$ref": "#"
+                },
+                "mediaType": {
+                    "description": "media type (as defined by RFC 2046) describing the link target",
+                    "type": "string"
+                },
+                "method": {
+                    "description": "method for requesting the target of the link (e.g. for HTTP this might be \"GET\" or \"DELETE\")",
+                    "type": "string"
+                },
+                "encType": {
+                    "description": "The media type in which to submit data along with the request",
+                    "type": "string",
+                    "default": "application/json"
+                },
+                "schema": {
+                    "description": "Schema describing the data to submit along with the request",
+                    "$ref": "#"
+                }
+            }
+        }
+    }
+}
+

--- a/draft-05/hyper-schema
+++ b/draft-05/hyper-schema
@@ -128,6 +128,11 @@
             "type": "boolean",
             "default": "false"
         }
-    }
+    },
+    "links": [
+        {
+            "rel": "self",
+            "href": "{+id}"
+        }
+    ]
 }
-

--- a/draft-05/hyper-schema
+++ b/draft-05/hyper-schema
@@ -2,6 +2,52 @@
     "$schema": "http://json-schema.org/draft-04/hyper-schema#",
     "id": "http://json-schema.org/draft-04/hyper-schema#",
     "title": "JSON Hyper-Schema",
+    "definitions": {
+        "schemaArray": {
+            "type": "array",
+            "items": { "$ref": "#" }
+        },
+        "linkDescription": {
+            "title": "Link Description Object",
+            "type": "object",
+            "required": [ "href", "rel" ],
+            "properties": {
+                "href": {
+                    "description": "a URI template, as defined by RFC 6570, with the addition of the $, ( and ) characters for pre-processing",
+                    "type": "string"
+                },
+                "rel": {
+                    "description": "relation to the target resource of the link",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "a title for the link",
+                    "type": "string"
+                },
+                "targetSchema": {
+                    "description": "JSON Schema describing the link target",
+                    "allOf": [ { "$ref": "#" } ]
+                },
+                "mediaType": {
+                    "description": "media type (as defined by RFC 2046) describing the link target",
+                    "type": "string"
+                },
+                "method": {
+                    "description": "method for requesting the target of the link (e.g. for HTTP this might be \"GET\" or \"DELETE\")",
+                    "type": "string"
+                },
+                "encType": {
+                    "description": "The media type in which to submit data along with the request",
+                    "type": "string",
+                    "default": "application/json"
+                },
+                "schema": {
+                    "description": "Schema describing the data to submit along with the request",
+                    "allOf": [ { "$ref": "#" } ]
+                }
+            }
+        }
+    },
     "allOf": [ { "$ref": "http://json-schema.org/draft-04/schema#" } ],
     "properties": {
         "additionalItems": {
@@ -73,52 +119,6 @@
             "description": "If true, indicates that the value of this property is controlled by the server.",
             "type": "boolean",
             "default": "false"
-        }
-    },
-    "definitions": {
-        "schemaArray": {
-            "type": "array",
-            "items": { "$ref": "#" }
-        },
-        "linkDescription": {
-            "title": "Link Description Object",
-            "type": "object",
-            "required": [ "href", "rel" ],
-            "properties": {
-                "href": {
-                    "description": "a URI template, as defined by RFC 6570, with the addition of the $, ( and ) characters for pre-processing",
-                    "type": "string"
-                },
-                "rel": {
-                    "description": "relation to the target resource of the link",
-                    "type": "string"
-                },
-                "title": {
-                    "description": "a title for the link",
-                    "type": "string"
-                },
-                "targetSchema": {
-                    "description": "JSON Schema describing the link target",
-                    "allOf": [ { "$ref": "#" } ]
-                },
-                "mediaType": {
-                    "description": "media type (as defined by RFC 2046) describing the link target",
-                    "type": "string"
-                },
-                "method": {
-                    "description": "method for requesting the target of the link (e.g. for HTTP this might be \"GET\" or \"DELETE\")",
-                    "type": "string"
-                },
-                "encType": {
-                    "description": "The media type in which to submit data along with the request",
-                    "type": "string",
-                    "default": "application/json"
-                },
-                "schema": {
-                    "description": "Schema describing the data to submit along with the request",
-                    "allOf": [ { "$ref": "#" } ]
-                }
-            }
         }
     }
 }

--- a/draft-05/hyper-schema
+++ b/draft-05/hyper-schema
@@ -2,87 +2,51 @@
     "$schema": "http://json-schema.org/draft-04/hyper-schema#",
     "id": "http://json-schema.org/draft-04/hyper-schema#",
     "title": "JSON Hyper-Schema",
-    "allOf": [
-        {
-            "$ref": "http://json-schema.org/draft-04/schema#"
-        }
-    ],
+    "allOf": [ { "$ref": "http://json-schema.org/draft-04/schema#" } ],
     "properties": {
         "additionalItems": {
             "anyOf": [
-                {
-                    "type": "boolean"
-                },
-                {
-                    "$ref": "#"
-                }
+                { "type": "boolean" },
+                { "$ref": "#" }
             ]
         },
         "additionalProperties": {
             "anyOf": [
-                {
-                    "type": "boolean"
-                },
-                {
-                    "$ref": "#"
-                }
+                { "type": "boolean" },
+                { "$ref": "#" }
             ]
         },
         "dependencies": {
             "additionalProperties": {
                 "anyOf": [
-                    {
-                        "$ref": "#"
-                    },
-                    {
-                        "type": "array"
-                    }
+                    { "$ref": "#" },
+                    { "type": "array" }
                 ]
             }
         },
         "items": {
             "anyOf": [
-                {
-                    "$ref": "#"
-                },
-                {
-                    "$ref": "#/definitions/schemaArray"
-                }
+                { "$ref": "#" },
+                { "$ref": "#/definitions/schemaArray" }
             ]
         },
         "definitions": {
-            "additionalProperties": {
-                "$ref": "#"
-            }
+            "additionalProperties": { "$ref": "#" }
         },
         "patternProperties": {
-            "additionalProperties": {
-                "$ref": "#"
-            }
+            "additionalProperties": { "$ref": "#" }
         },
         "properties": {
-            "additionalProperties": {
-                "$ref": "#"
-            }
+            "additionalProperties": { "$ref": "#" }
         },
-        "allOf": {
-            "$ref": "#/definitions/schemaArray"
-        },
-        "anyOf": {
-            "$ref": "#/definitions/schemaArray"
-        },
-        "oneOf": {
-            "$ref": "#/definitions/schemaArray"
-        },
-        "not": {
-            "$ref": "#"
-        },
+        "allOf": { "$ref": "#/definitions/schemaArray" },
+        "anyOf": { "$ref": "#/definitions/schemaArray" },
+        "oneOf": { "$ref": "#/definitions/schemaArray" },
+        "not": { "$ref": "#" },
 
         "links": {
             "type": "array",
-            "items": {
-                "$ref": "#/definitions/linkDescription"
-            }
+            "items": { "$ref": "#/definitions/linkDescription" }
         },
         "fragmentResolution": {
             "type": "string"
@@ -104,14 +68,17 @@
             "description": "Instances' URIs must start with this value for this schema to apply to them",
             "type": "string",
             "format": "uri"
+        },
+        "readOnly": {
+            "description": "If true, indicates that the value of this property is controlled by the server.",
+            "type": "boolean",
+            "default": "false"
         }
     },
     "definitions": {
         "schemaArray": {
             "type": "array",
-            "items": {
-                "$ref": "#"
-            }
+            "items": { "$ref": "#" }
         },
         "linkDescription": {
             "title": "Link Description Object",
@@ -132,7 +99,7 @@
                 },
                 "targetSchema": {
                     "description": "JSON Schema describing the link target",
-                    "$ref": "#"
+                    "allOf": [ { "$ref": "#" } ]
                 },
                 "mediaType": {
                     "description": "media type (as defined by RFC 2046) describing the link target",
@@ -149,7 +116,7 @@
                 },
                 "schema": {
                     "description": "Schema describing the data to submit along with the request",
-                    "$ref": "#"
+                    "allOf": [ { "$ref": "#" } ]
                 }
             }
         }

--- a/draft-05/hyper-schema
+++ b/draft-05/hyper-schema
@@ -1,6 +1,6 @@
 {
-    "$schema": "http://json-schema.org/draft-04/hyper-schema#",
-    "id": "http://json-schema.org/draft-04/hyper-schema#",
+    "$schema": "http://json-schema.org/draft-05/hyper-schema#",
+    "id": "http://json-schema.org/draft-05/hyper-schema#",
     "title": "JSON Hyper-Schema",
     "definitions": {
         "schemaArray": {
@@ -10,7 +10,7 @@
         "linkDescription": {
             "title": "Link Description Object",
             "type": "object",
-            "required": [ "href", "rel" ],
+            "required": [ "href" ],
             "properties": {
                 "href": {
                     "description": "a URI template, as defined by RFC 6570, with the addition of the $, ( and ) characters for pre-processing",
@@ -33,7 +33,7 @@
                     "type": "string"
                 },
                 "method": {
-                    "description": "method for requesting the target of the link (e.g. for HTTP this might be \"GET\" or \"DELETE\")",
+                    "description": "specifies that the client can construct a templated query (\"get\") or non-idempotent request (\"post\") to a resource.",
                     "type": "string"
                 },
                 "encType": {
@@ -48,7 +48,7 @@
             }
         }
     },
-    "allOf": [ { "$ref": "http://json-schema.org/draft-04/schema#" } ],
+    "allOf": [ { "$ref": "http://json-schema.org/draft-05/schema#" } ],
     "properties": {
         "additionalItems": {
             "anyOf": [
@@ -90,12 +90,13 @@
         "oneOf": { "$ref": "#/definitions/schemaArray" },
         "not": { "$ref": "#" },
 
+        "base": {
+            "description": "URI Template resolved as for the 'href' keyword in the Link Description Object.  The resulting URI Reference is resolved against the current URI base and sets the new URI base for URI references within the instance.",
+            "type": "string"
+        },
         "links": {
             "type": "array",
             "items": { "$ref": "#/definitions/linkDescription" }
-        },
-        "fragmentResolution": {
-            "type": "string"
         },
         "media": {
             "type": "object",
@@ -109,11 +110,6 @@
                     "type": "string"
                 }
             }
-        },
-        "pathStart": {
-            "description": "Instances' URIs must start with this value for this schema to apply to them",
-            "type": "string",
-            "format": "uri"
         },
         "readOnly": {
             "description": "If true, indicates that the value of this property is controlled by the server.",

--- a/draft-05/hyper-schema
+++ b/draft-05/hyper-schema
@@ -5,7 +5,7 @@
     "definitions": {
         "schemaArray": {
             "type": "array",
-            "items": { "$ref": "#" }
+            "items": { "$ref": "#/definitions/subSchema" }
         },
         "linkDescription": {
             "title": "Link Description Object",
@@ -26,7 +26,7 @@
                 },
                 "targetSchema": {
                     "description": "JSON Schema describing the link target",
-                    "allOf": [ { "$ref": "#" } ]
+                    "allOf": [ { "$ref": "#/definitions/subSchema" } ]
                 },
                 "mediaType": {
                     "description": "media type (as defined by RFC 2046) describing the link target",
@@ -43,52 +43,64 @@
                 },
                 "schema": {
                     "description": "Schema describing the data to submit along with the request",
-                    "allOf": [ { "$ref": "#" } ]
+                    "allOf": [ { "$ref": "#/definitions/subSchema" } ]
                 }
             }
+        },
+        "subSchema": {
+            "oneOf": [
+                {
+                    "allOf": [
+                        { "$ref": "#" },
+                        { "$ref": "http://json-schema.org/draft-05/schema#/definitions/notJsonReference" }
+                    ]
+                },
+                { "$ref": "http://json-schema.org/draft-05/schema#/definitions/notJsonReference#/definitions/jsonReference" }
+            ]
         }
     },
+
     "allOf": [ { "$ref": "http://json-schema.org/draft-05/schema#" } ],
     "properties": {
         "additionalItems": {
             "anyOf": [
                 { "type": "boolean" },
-                { "$ref": "#" }
+                { "$ref": "#/definitions/subSchema" }
             ]
         },
         "additionalProperties": {
             "anyOf": [
                 { "type": "boolean" },
-                { "$ref": "#" }
+                { "$ref": "#/definitions/subSchema" }
             ]
         },
         "dependencies": {
             "additionalProperties": {
                 "anyOf": [
-                    { "$ref": "#" },
+                    { "$ref": "#/definitions/subSchema" },
                     { "type": "array" }
                 ]
             }
         },
         "items": {
             "anyOf": [
-                { "$ref": "#" },
+                { "$ref": "#/definitions/subSchema" },
                 { "$ref": "#/definitions/schemaArray" }
             ]
         },
         "definitions": {
-            "additionalProperties": { "$ref": "#" }
+            "additionalProperties": { "$ref": "#/definitions/subSchema" }
         },
         "patternProperties": {
-            "additionalProperties": { "$ref": "#" }
+            "additionalProperties": { "$ref": "#/definitions/subSchema" }
         },
         "properties": {
-            "additionalProperties": { "$ref": "#" }
+            "additionalProperties": { "$ref": "#/definitions/subSchema" }
         },
         "allOf": { "$ref": "#/definitions/schemaArray" },
         "anyOf": { "$ref": "#/definitions/schemaArray" },
         "oneOf": { "$ref": "#/definitions/schemaArray" },
-        "not": { "$ref": "#" },
+        "not": { "$ref": "#/definitions/subSchema" },
 
         "base": {
             "description": "URI Template resolved as for the 'href' keyword in the Link Description Object.  The resulting URI Reference is resolved against the current URI base and sets the new URI base for URI references within the instance.",

--- a/draft-05/links
+++ b/draft-05/links
@@ -1,0 +1,42 @@
+{
+    "$schema": "http://json-schema.org/draft-04/hyper-schema#",
+    "id": "http://json-schema.org/draft-04/links#",
+    "title": "Link Description Object",
+    "type": "object",
+    "required": [ "href", "rel" ],
+    "properties": {
+        "href": {
+            "description": "a URI template, as defined by RFC 6570, with the addition of the $, ( and ) characters for pre-processing",
+            "type": "string"
+        },
+        "rel": {
+            "description": "relation to the target resource of the link",
+            "type": "string"
+        },
+        "title": {
+            "description": "a title for the link",
+            "type": "string"
+        },
+        "targetSchema": {
+            "description": "JSON Schema describing the link target",
+            "$ref": "hyper-schema#"
+        },
+        "mediaType": {
+            "description": "media type (as defined by RFC 2046) describing the link target",
+            "type": "string"
+        },
+        "method": {
+            "description": "method for requesting the target of the link (e.g. for HTTP this might be \"GET\" or \"DELETE\")",
+            "type": "string"
+        },
+        "encType": {
+            "description": "The media type in which to submit data along with the request",
+            "type": "string",
+            "default": "application/json"
+        },
+        "schema": {
+            "description": "Schema describing the data to submit along with the request",
+            "$ref": "hyper-schema#"
+        }
+    }
+}

--- a/draft-05/links
+++ b/draft-05/links
@@ -19,7 +19,7 @@
         },
         "targetSchema": {
             "description": "JSON Schema describing the link target",
-            "$ref": "hyper-schema#"
+            "allOf": [ { "$ref": "hyper-schema#" } ]
         },
         "mediaType": {
             "description": "media type (as defined by RFC 2046) describing the link target",
@@ -36,7 +36,7 @@
         },
         "schema": {
             "description": "Schema describing the data to submit along with the request",
-            "$ref": "hyper-schema#"
+            "allOf": [ { "$ref": "hyper-schema#" } ]
         }
     }
 }

--- a/draft-05/links
+++ b/draft-05/links
@@ -1,9 +1,9 @@
 {
-    "$schema": "http://json-schema.org/draft-04/hyper-schema#",
-    "id": "http://json-schema.org/draft-04/links#",
+    "$schema": "http://json-schema.org/draft-05/hyper-schema#",
+    "id": "http://json-schema.org/draft-05/links#",
     "title": "Link Description Object",
     "type": "object",
-    "required": [ "href", "rel" ],
+    "required": [ "href" ],
     "properties": {
         "href": {
             "description": "a URI template, as defined by RFC 6570, with the addition of the $, ( and ) characters for pre-processing",
@@ -26,7 +26,7 @@
             "type": "string"
         },
         "method": {
-            "description": "method for requesting the target of the link (e.g. for HTTP this might be \"GET\" or \"DELETE\")",
+                    "description": "specifies that the client can construct a templated query (\"get\") or non-idempotent request (\"post\") to a resource.",
             "type": "string"
         },
         "encType": {

--- a/draft-05/schema
+++ b/draft-05/schema
@@ -1,0 +1,150 @@
+{
+    "id": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "Core schema meta-schema",
+    "definitions": {
+        "schemaArray": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "$ref": "#" }
+        },
+        "positiveInteger": {
+            "type": "integer",
+            "minimum": 0
+        },
+        "positiveIntegerDefault0": {
+            "allOf": [ { "$ref": "#/definitions/positiveInteger" }, { "default": 0 } ]
+        },
+        "simpleTypes": {
+            "enum": [ "array", "boolean", "integer", "null", "number", "object", "string" ]
+        },
+        "stringArray": {
+            "type": "array",
+            "items": { "type": "string" },
+            "minItems": 1,
+            "uniqueItems": true
+        }
+    },
+    "type": "object",
+    "properties": {
+        "id": {
+            "type": "string",
+            "format": "uri"
+        },
+        "$schema": {
+            "type": "string",
+            "format": "uri"
+        },
+        "title": {
+            "type": "string"
+        },
+        "description": {
+            "type": "string"
+        },
+        "default": {},
+        "multipleOf": {
+            "type": "number",
+            "minimum": 0,
+            "exclusiveMinimum": true
+        },
+        "maximum": {
+            "type": "number"
+        },
+        "exclusiveMaximum": {
+            "type": "boolean",
+            "default": false
+        },
+        "minimum": {
+            "type": "number"
+        },
+        "exclusiveMinimum": {
+            "type": "boolean",
+            "default": false
+        },
+        "maxLength": { "$ref": "#/definitions/positiveInteger" },
+        "minLength": { "$ref": "#/definitions/positiveIntegerDefault0" },
+        "pattern": {
+            "type": "string",
+            "format": "regex"
+        },
+        "additionalItems": {
+            "anyOf": [
+                { "type": "boolean" },
+                { "$ref": "#" }
+            ],
+            "default": {}
+        },
+        "items": {
+            "anyOf": [
+                { "$ref": "#" },
+                { "$ref": "#/definitions/schemaArray" }
+            ],
+            "default": {}
+        },
+        "maxItems": { "$ref": "#/definitions/positiveInteger" },
+        "minItems": { "$ref": "#/definitions/positiveIntegerDefault0" },
+        "uniqueItems": {
+            "type": "boolean",
+            "default": false
+        },
+        "maxProperties": { "$ref": "#/definitions/positiveInteger" },
+        "minProperties": { "$ref": "#/definitions/positiveIntegerDefault0" },
+        "required": { "$ref": "#/definitions/stringArray" },
+        "additionalProperties": {
+            "anyOf": [
+                { "type": "boolean" },
+                { "$ref": "#" }
+            ],
+            "default": {}
+        },
+        "definitions": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+        "properties": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+        "patternProperties": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+        "dependencies": {
+            "type": "object",
+            "additionalProperties": {
+                "anyOf": [
+                    { "$ref": "#" },
+                    { "$ref": "#/definitions/stringArray" }
+                ]
+            }
+        },
+        "enum": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true
+        },
+        "type": {
+            "anyOf": [
+                { "$ref": "#/definitions/simpleTypes" },
+                {
+                    "type": "array",
+                    "items": { "$ref": "#/definitions/simpleTypes" },
+                    "minItems": 1,
+                    "uniqueItems": true
+                }
+            ]
+        },
+        "allOf": { "$ref": "#/definitions/schemaArray" },
+        "anyOf": { "$ref": "#/definitions/schemaArray" },
+        "oneOf": { "$ref": "#/definitions/schemaArray" },
+        "not": { "$ref": "#" }
+    },
+    "dependencies": {
+        "exclusiveMaximum": [ "maximum" ],
+        "exclusiveMinimum": [ "minimum" ]
+    },
+    "default": {}
+}

--- a/draft-05/schema
+++ b/draft-05/schema
@@ -1,6 +1,6 @@
 {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-05/schema#",
+    "id": "http://json-schema.org/draft-05/schema#",
     "title": "Core schema meta-schema",
     "definitions": {
         "schemaArray": {
@@ -40,7 +40,7 @@
     "properties": {
         "id": {
             "type": "string",
-            "format": "uri"
+            "format": "uriref"
         },
         "$schema": {
             "type": "string",

--- a/draft-05/schema
+++ b/draft-05/schema
@@ -1,7 +1,7 @@
 {
-    "id": "http://json-schema.org/draft-04/schema#",
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "description": "Core schema meta-schema",
+    "id": "http://json-schema.org/draft-04/schema#",
+    "title": "Core schema meta-schema",
     "definitions": {
         "schemaArray": {
             "type": "array",
@@ -13,10 +13,21 @@
             "minimum": 0
         },
         "positiveIntegerDefault0": {
-            "allOf": [ { "$ref": "#/definitions/positiveInteger" }, { "default": 0 } ]
+            "allOf": [
+                { "$ref": "#/definitions/positiveInteger" },
+                { "default": 0 }
+            ]
         },
         "simpleTypes": {
-            "enum": [ "array", "boolean", "integer", "null", "number", "object", "string" ]
+            "enum": [
+                "array",
+                "boolean",
+                "integer",
+                "null",
+                "number",
+                "object",
+                "string"
+            ]
         },
         "stringArray": {
             "type": "array",
@@ -137,6 +148,7 @@
                 }
             ]
         },
+        "format": { "type": "string" },
         "allOf": { "$ref": "#/definitions/schemaArray" },
         "anyOf": { "$ref": "#/definitions/schemaArray" },
         "oneOf": { "$ref": "#/definitions/schemaArray" },

--- a/draft-05/schema
+++ b/draft-05/schema
@@ -3,10 +3,25 @@
     "id": "http://json-schema.org/draft-05/schema#",
     "title": "Core schema meta-schema",
     "definitions": {
+        "jsonReferece": {
+            "type": "object",
+            "properties": {
+                "$ref": {
+                    "type": "string",
+                    "format": "uriref"
+                }
+            },
+            "required": [ "$ref" ]
+        },
+        "notJsonReference": {
+            "not": {
+                "required": [ "$ref" ]
+            }
+        },
         "schemaArray": {
             "type": "array",
             "minItems": 1,
-            "items": { "$ref": "#" }
+            "items": { "$ref": "#/definitions/subSchema" }
         },
         "positiveInteger": {
             "type": "integer",
@@ -34,6 +49,17 @@
             "items": { "type": "string" },
             "minItems": 1,
             "uniqueItems": true
+        },
+        "subSchema": {
+            "oneOf": [
+                {
+                    "allOf": [
+                        { "$ref": "#" },
+                        { "$ref": "#/definitions/notJsonReference" }
+                    ]
+                },
+                { "$ref": "#/definitions/jsonReference" }
+            ]
         }
     },
     "type": "object",
@@ -81,13 +107,13 @@
         "additionalItems": {
             "anyOf": [
                 { "type": "boolean" },
-                { "$ref": "#" }
+                { "$ref": "#/definitions/subSchema" }
             ],
             "default": {}
         },
         "items": {
             "anyOf": [
-                { "$ref": "#" },
+                { "$ref": "#/definitions/subSchema" },
                 { "$ref": "#/definitions/schemaArray" }
             ],
             "default": {}
@@ -104,30 +130,30 @@
         "additionalProperties": {
             "anyOf": [
                 { "type": "boolean" },
-                { "$ref": "#" }
+                { "$ref": "#/definitions/subSchema" }
             ],
             "default": {}
         },
         "definitions": {
             "type": "object",
-            "additionalProperties": { "$ref": "#" },
+            "additionalProperties": { "$ref": "#/definitions/subSchema" },
             "default": {}
         },
         "properties": {
             "type": "object",
-            "additionalProperties": { "$ref": "#" },
+            "additionalProperties": { "$ref": "#/definitions/subSchema" },
             "default": {}
         },
         "patternProperties": {
             "type": "object",
-            "additionalProperties": { "$ref": "#" },
+            "additionalProperties": { "$ref": "#/definitions/subSchema" },
             "default": {}
         },
         "dependencies": {
             "type": "object",
             "additionalProperties": {
                 "anyOf": [
-                    { "$ref": "#" },
+                    { "$ref": "#/definitions/subSchema" },
                     { "$ref": "#/definitions/stringArray" }
                 ]
             }
@@ -152,7 +178,7 @@
         "allOf": { "$ref": "#/definitions/schemaArray" },
         "anyOf": { "$ref": "#/definitions/schemaArray" },
         "oneOf": { "$ref": "#/definitions/schemaArray" },
-        "not": { "$ref": "#" }
+        "not": { "$ref": "#/definitions/subSchema" }
     },
     "dependencies": {
         "exclusiveMaximum": [ "maximum" ],


### PR DESCRIPTION
@Relequestual Here is the meta-schema PR that we discussed this morning (for me) / last night (for you).

This collects a lot of cleanup and updates for draft-05's meta-schema in a series of commits for easier review.

The first commit just copies the draft-04 files with no changes.

The remaining commit (except for the last) make bugfixes and feature changes in several steps for easy-to-read diffs.  I'm not 100% sure about removing the empty fragment on "$schema" and "id" and the corresponding references, but as best I can tell from reviewing RFC 3986, an absolute URI must not have a fragment, and and empty fragment cannot be normalized away.  So I think this is correct.

The final commit copies the completed draft-05 meta-schemas to the top level directory and bumps the number in the documentation.  The documentation reference the top level directory URIs for the meta-schemas rather than the numbered URIs, so I left them as-is.