### PR TITLE
sort sections by 'programming language'

### DIFF
--- a/_sass/minima.scss
+++ b/_sass/minima.scss
@@ -39,5 +39,6 @@ $on-laptop:        800px !default;
 @import
   "minima/base",
   "minima/layout",
-  "minima/prism"
+  "minima/prism",
+  "minima/intra-navigation"
 ;

--- a/_sass/minima/_intra-navigation.scss
+++ b/_sass/minima/_intra-navigation.scss
@@ -1,0 +1,29 @@
+nav.intra {    
+    margin: 0 25px 15px 25px;
+    padding: 10px 0;
+    > ul {
+        list-style-type: none;
+        margin: 0px;
+        overflow: auto;
+        > li {
+            border-radius: 2px;
+            background-color: $brand-color;
+            float: left;
+            height: 25px;
+            margin: 2px;
+            text-align: center;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            width: 17%;
+        }
+    }
+    a {
+        color: $background-color
+    }
+    a:hover {
+        text-decoration: none;
+    }
+    a:visited {
+        color: $background-color
+    }
+}

--- a/implementations.html
+++ b/implementations.html
@@ -15,64 +15,84 @@ permalink: /implementations
 </div>
 
 <h2>Validators</h2>
+<h3>Libraries</h3>
+<nav class="intra">
+	<ul>
+		<li><a href="#validator-dotnet">.NET</a></li>
+		<li><a href="#validator-action-script-3">Action Script 3</a></li>
+		<li><a href="#validator-c">C</a></li>
+		<li><a href="#validator-cpp">C++</a></li>
+		<li><a href="#validator-clojure">Clojure</a></li>
+		<li><a href="#validator-clojure">Dart</a></li>
+		<li><a href="#validator-erlang">Erlang</a></li>
+		<li><a href="#validator-go">Go</a></li>
+		<li><a href="#validator-haskell">Haskell</a></li>
+		<li><a href="#validator-java">Java</a></li>
+		<li><a href="#validator-javascript">JavaScript</a></li>
+		<li><a href="#validator-php">PHP</a></li>
+		<li><a href="#validator-perl">Perl</a></li>
+		<li><a href="#validator-python">Python</a></li>
+		<li><a href="#validator-ruby">Ruby</a></li>	
+	</ul>
+</nav>
 <ul>
-	<li>.NET
+	<li id="validator-dotnet">.NET
 	<ul>
 		<li><a id="link-impl-json-net" href="http://james.newtonking.com/projects/json-net.aspx">Json.NET</a> (MIT)</li>
 		<li><a id="link-impl-n-json-schema" href="http://NJsonSchema.org">NJsonSchema</a> - <em>supports version 4</em> (Ms-PL)</li>
 	</ul>
 	</li>
-	<li>ActionScript 3
+	<li id="validator-action-script-3">ActionScript 3
 	<ul>
 		<li><a id="link-impl-frigga" href="https://github.com/raulbajales/Frigga">Frigga</a> (MIT)</li>
 	</ul>
 	</li>
-	<li>C
+	<li id="validator-c">C
 	<ul>
 		<li><a id="link-impl-wjelement" href="https://github.com/netmail-open/wjelement">WJElement</a> (LGPLv3)</li>
 	</ul>
 	</li>
-	<li>C++
+	<li id="validator-cpp">C++
 	<ul>
 		<li><a id="link-impl-wjelement" href="https://github.com/petehug/wjelement-cpp">wjelement-cpp</a> - <em>supports version 4</em> (LGPLv3)</li>
 		<li><a id="link-impl-valijson" href="https://github.com/tristanpenman/valijson">Header-only C++ library for JSON Schema validation</a> - <em>supports only version 4</em> (BSD-2-Clause)</li>
 		<li><a id="link-impl-modern-c++-validator" href="https://github.com/pboettch/json-schema-validator">Modern C++ JSON schema validator</a> - <em>supports only version 4</em> based on JSON for Modern C++ (MIT)</li>
 	</ul>
 	</li>
-	<li>Clojure
+	<li id="validator-clojure">Clojure
 	<ul>
 		<li><a id="link-impl-metosin-scjsv" href="https://github.com/metosin/scjsv">scjsv</a> - <em>supports version 4</em> (wrapper for <a href="https://github.com/fge/json-schema-validator">fge/json-schema-validator</a>) (Eclipse Public License v1.0)</li>
 	</ul>
 	</li>
-	<li>Dart
+	<li id="validator-dart">Dart
 	<ul>
 		<li><a id="link-impl-dart-jsonschema" href="https://github.com/patefacio/json_schema">json_schema</a> <em>supports  version 4</em> (BSL-1.0)</li>
 	</ul>
 	</li>
-	<li>Erlang
+	<li id="validator-erlang">Erlang
 	<ul>
 		<li><a id="link-impl-jesse" href="https://github.com/for-GET/jesse">JeSSE</a> (Apache 2.0)</li>
 	</ul>
 	</li>
-	<li>Go
+	<li id="validator-go">Go
 	<ul>
 		<li><a id="link-impl-gojsonschema" href="https://github.com/sigu-399/gojsonschema">gojsonschema</a> (Apache 2.0)</li>
 	</ul>
 	</li>
-	<li>Haskell
+	<li id="validator-haskell">Haskell
 	<ul>
 		<li><a id="link-impl-aeson-schema" href="https://github.com/timjb/aeson-schema">aeson-schema</a> (MIT)</li>
 		<li><a id="link-impl-hjsonschema" href="https://github.com/seagreen/hjsonschema">hjsonschema</a> - <em>supports version 4</em> (MIT)</li>
 	</ul>
 	</li>
-	<li>Java
+	<li id="validator-java">Java
 	<ul>
 		<li><a id="link-impl-fge-json-schema-validator" href="https://github.com/fge/json-schema-validator">json-schema-validator</a> - <em>supports version 4</em> (LGPLv3)</li>
 		<li><a id="link-impl-everit-json-schema" href="https://github.com/everit-org/json-schema">json-schema (implementation based on the org.json API)</a> - <em>supports version 4</em> (Apache License 2.0)</li>
 		<li><a id="link-impl-networknt-json-schema" href="https://github.com/networknt/json-schema-validator">json-schema-validator</a> - <em>supports version 4</em> (Apache License 2.0)</li>
 	</ul>
 	</li>
-	<li>JavaScript
+	<li id="validator-javascript">JavaScript
 	<ul>
 		<li><a id="link-impl-ajv" href="https://github.com/epoberezkin/ajv">ajv</a> for Node.js and the browser - <em>supports version 4, validation keywords and $data reference from <a href="https://github.com/json-schema/json-schema/wiki/v5-Proposals">version 5 proposals</a></em> (MIT)</li>
 		<li><a id="link-impl-tdegrunt-jsonschema" href="https://github.com/tdegrunt/jsonschema">jsonschema</a> for Node.js - <em>supports version 4</em> (MIT)</li>
@@ -88,7 +108,7 @@ permalink: /implementations
 		<li><a id="link-impl-jsen" href="https://github.com/bugventure/jsen">JSEN</a> for Node.js - <em>supports version 4</em> (MIT)</li>
 	</ul>
 	</li>
-	<li>PHP
+	<li id="validator-php">PHP
 	<ul>
 		<li><a id="link-impl-jsv4-php" href="https://github.com/geraintluff/jsv4-php">jsv4-php</a> - <em>supports version 4</em>  (Public Domain / MIT)</li>
 		<li><a id="link-impl-php-json-schema" href="https://github.com/hasbridge/php-json-schema">php-json-schema</a> (MIT)</li>
@@ -97,31 +117,29 @@ permalink: /implementations
 		<li><a id="link-impl-json-guard" href="https://github.com/thephpleague/json-guard">JSON Guard</a> - <em>supports version 4</em> (MIT)</li>
 	</ul>
 	</li>
-	<li>Perl
+	<li id="validator-perl">Perl
 	<ul>
 		<li><a id="link-impl-perl-json-schema" href="https://metacpan.org/module/JSON::Schema">JSON::Schema</a> (MIT)</li>
 	</ul>
 	</li>
-	<li>Python
+	<li id="validator-python">Python
 	<ul>
 		<li><a id="link-impl-jsonschema" href="https://github.com/Julian/jsonschema">jsonschema</a> - <em>supports version 4</em> (MIT)</li>
 		<li><a id="link-impl-zyga-json-schema-validator" href="https://github.com/zyga/json-schema-validator">json-schema-validator</a> (LGPL)</li>
 	</ul>
 	</li>
-	<li>Ruby
+	<li id="validator-ruby">Ruby
 	<ul>
 		<li><a id="link-impl-ruby-jsonchema" href="https://github.com/Constellation/ruby-jsonchema">ruby-jsonschema</a> (MIT)</li>
 		<li><a id="link-impl-ruby-hoxworth-json-schema" href="https://github.com/hoxworth/json-schema">json-schema</a> - <em>supports version 4</em> (MIT)</li>
 	</ul>
 	</li>
-	<li>Online (web tool)
-	<ul>
-		<li><a id="link-impl-jsonschemalint" href="http://jsonschemalint.com/">JSON Schema Lint</a> - validate against your own schemas</li>
-		<li><a id="link-impl-schemastore" href="http://schemastore.org/validator/">SchemaStore.org</a> - validate against common JSON Schemas</li>
-	</ul>
-	</li>	
 </ul>
-
+<h3>Online</h3>
+<ul>
+	<li><a id="link-impl-jsonschemalint" href="http://jsonschemalint.com/">JSON Schema Lint</a> - validate against your own schemas</li>
+	<li><a id="link-impl-schemastore" href="http://schemastore.org/validator/">SchemaStore.org</a> - validate against common JSON Schemas</li>
+</ul>
 
 <h2>Validation benchmarks</h2>
 <ul>

--- a/implementations.html
+++ b/implementations.html
@@ -16,60 +16,6 @@ permalink: /implementations
 
 <h2>Validators</h2>
 <ul>
-	<li>JavaScript
-	<ul>
-		<li><a id="link-impl-ajv" href="https://github.com/epoberezkin/ajv">ajv</a> for Node.js and the browser - <em>supports version 4, validation keywords and $data reference from <a href="https://github.com/json-schema/json-schema/wiki/v5-Proposals">version 5 proposals</a></em> (MIT)</li>
-		<li><a id="link-impl-tdegrunt-jsonschema" href="https://github.com/tdegrunt/jsonschema">jsonschema</a> for Node.js - <em>supports version 4</em> (MIT)</li>
-		<li><a id="link-impl-is-my-json-valid" href="https://github.com/mafintosh/is-my-json-valid">is-my-json-valid</a> - <em>supports version 4</em> (MIT)</li>
-		<li><a id="link-impl-tv4" href="http://geraintluff.github.com/tv4/">tv4</a> - <em>supports version 4</em> (Public Domain)</li>
-		<li><a id="link-impl-jayschema" href="https://github.com/natesilva/jayschema">JaySchema</a> for Node.js - <em>supports version 4</em> (BSD)</li>
-		<li><a id="link-impl-z-schema" href="https://github.com/zaggino/z-schema">z-schema</a> for Node.js - <em>supports version 4</em> (MIT)</li>
-		<li><a id="link-impl-direct-schema" href="http://github.com/IreneKnapp/direct-schema">direct-schema</a> (BSD)</li>
-		<li><a id="link-impl-jsv" href="http://github.com/garycourt/JSV">JSV</a> (BSD)</li>
-		<li><a id="link-impl-kriszyp-jsonschema" href="http://github.com/kriszyp/json-schema">json-schema</a> (AFL or BSD) as part of <a id="link-impl-persvr" href="http://www.persvr.org/">Persevere</a></li>
-		<li><a id="link-impl-schema-js" href="https://github.com/akidee/schema.js">schema.js</a> (MIT)</li>
-		<li><a id="link-impl-json-gate" href="https://github.com/oferei/json-gate">json-gate</a> (MIT)</li>
-		<li><a id="link-impl-jsen" href="https://github.com/bugventure/jsen">JSEN</a> for Node.js - <em>supports version 4</em> (MIT)</li>
-	</ul>
-	</li>
-	<li>Java
-	<ul>
-		<li><a id="link-impl-fge-json-schema-validator" href="https://github.com/fge/json-schema-validator">json-schema-validator</a> - <em>supports version 4</em> (LGPLv3)</li>
-		<li><a id="link-impl-everit-json-schema" href="https://github.com/everit-org/json-schema">json-schema (implementation based on the org.json API)</a> - <em>supports version 4</em> (Apache License 2.0)</li>
-		<li><a id="link-impl-networknt-json-schema" href="https://github.com/networknt/json-schema-validator">json-schema-validator</a> - <em>supports version 4</em> (Apache License 2.0)</li>
-	</ul>
-	</li>
-	<li>Clojure
-	<ul>
-		<li><a id="link-impl-metosin-scjsv" href="https://github.com/metosin/scjsv">scjsv</a> - <em>supports version 4</em> (wrapper for <a href="https://github.com/fge/json-schema-validator">fge/json-schema-validator</a>) (Eclipse Public License v1.0)</li>
-	</ul>
-	</li>
-	<li>Python
-	<ul>
-		<li><a id="link-impl-jsonschema" href="https://github.com/Julian/jsonschema">jsonschema</a> - <em>supports version 4</em> (MIT)</li>
-		<li><a id="link-impl-zyga-json-schema-validator" href="https://github.com/zyga/json-schema-validator">json-schema-validator</a> (LGPL)</li>
-	</ul>
-	</li>
-	<li>Ruby
-	<ul>
-		<li><a id="link-impl-ruby-jsonchema" href="https://github.com/Constellation/ruby-jsonchema">ruby-jsonschema</a> (MIT)</li>
-		<li><a id="link-impl-ruby-hoxworth-json-schema" href="https://github.com/hoxworth/json-schema">json-schema</a> - <em>supports version 4</em> (MIT)</li>
-	</ul>
-	</li>
-	<li>Perl
-	<ul>
-		<li><a id="link-impl-perl-json-schema" href="https://metacpan.org/module/JSON::Schema">JSON::Schema</a> (MIT)</li>
-	</ul>
-	</li>
-	<li>PHP
-	<ul>
-		<li><a id="link-impl-jsv4-php" href="https://github.com/geraintluff/jsv4-php">jsv4-php</a> - <em>supports version 4</em>  (Public Domain / MIT)</li>
-		<li><a id="link-impl-php-json-schema" href="https://github.com/hasbridge/php-json-schema">php-json-schema</a> (MIT)</li>
-		<li><a id="link-impl-json-schema" href="https://github.com/justinrainbow/json-schema">json-schema</a> (Berkeley)</li>
-		<li><a id="link-impl-jval" href="https://github.com/stefk/jval">JVal</a> - <em>supports version 4</em>  (MIT)</li>
-		<li><a id="link-impl-json-guard" href="https://github.com/thephpleague/json-guard">JSON Guard</a> - <em>supports version 4</em> (MIT)</li>
-	</ul>
-	</li>
 	<li>.NET
 	<ul>
 		<li><a id="link-impl-json-net" href="http://james.newtonking.com/projects/json-net.aspx">Json.NET</a> (MIT)</li>
@@ -93,10 +39,14 @@ permalink: /implementations
 		<li><a id="link-impl-modern-c++-validator" href="https://github.com/pboettch/json-schema-validator">Modern C++ JSON schema validator</a> - <em>supports only version 4</em> based on JSON for Modern C++ (MIT)</li>
 	</ul>
 	</li>
-	<li>Haskell
+	<li>Clojure
 	<ul>
-		<li><a id="link-impl-aeson-schema" href="https://github.com/timjb/aeson-schema">aeson-schema</a> (MIT)</li>
-		<li><a id="link-impl-hjsonschema" href="https://github.com/seagreen/hjsonschema">hjsonschema</a> - <em>supports version 4</em> (MIT)</li>
+		<li><a id="link-impl-metosin-scjsv" href="https://github.com/metosin/scjsv">scjsv</a> - <em>supports version 4</em> (wrapper for <a href="https://github.com/fge/json-schema-validator">fge/json-schema-validator</a>) (Eclipse Public License v1.0)</li>
+	</ul>
+	</li>
+	<li>Dart
+	<ul>
+		<li><a id="link-impl-dart-jsonschema" href="https://github.com/patefacio/json_schema">json_schema</a> <em>supports  version 4</em> (BSL-1.0)</li>
 	</ul>
 	</li>
 	<li>Erlang
@@ -109,9 +59,59 @@ permalink: /implementations
 		<li><a id="link-impl-gojsonschema" href="https://github.com/sigu-399/gojsonschema">gojsonschema</a> (Apache 2.0)</li>
 	</ul>
 	</li>
-	<li>Dart
+	<li>Haskell
 	<ul>
-		<li><a id="link-impl-dart-jsonschema" href="https://github.com/patefacio/json_schema">json_schema</a> <em>supports  version 4</em> (BSL-1.0)</li>
+		<li><a id="link-impl-aeson-schema" href="https://github.com/timjb/aeson-schema">aeson-schema</a> (MIT)</li>
+		<li><a id="link-impl-hjsonschema" href="https://github.com/seagreen/hjsonschema">hjsonschema</a> - <em>supports version 4</em> (MIT)</li>
+	</ul>
+	</li>
+	<li>Java
+	<ul>
+		<li><a id="link-impl-fge-json-schema-validator" href="https://github.com/fge/json-schema-validator">json-schema-validator</a> - <em>supports version 4</em> (LGPLv3)</li>
+		<li><a id="link-impl-everit-json-schema" href="https://github.com/everit-org/json-schema">json-schema (implementation based on the org.json API)</a> - <em>supports version 4</em> (Apache License 2.0)</li>
+		<li><a id="link-impl-networknt-json-schema" href="https://github.com/networknt/json-schema-validator">json-schema-validator</a> - <em>supports version 4</em> (Apache License 2.0)</li>
+	</ul>
+	</li>
+	<li>JavaScript
+	<ul>
+		<li><a id="link-impl-ajv" href="https://github.com/epoberezkin/ajv">ajv</a> for Node.js and the browser - <em>supports version 4, validation keywords and $data reference from <a href="https://github.com/json-schema/json-schema/wiki/v5-Proposals">version 5 proposals</a></em> (MIT)</li>
+		<li><a id="link-impl-tdegrunt-jsonschema" href="https://github.com/tdegrunt/jsonschema">jsonschema</a> for Node.js - <em>supports version 4</em> (MIT)</li>
+		<li><a id="link-impl-is-my-json-valid" href="https://github.com/mafintosh/is-my-json-valid">is-my-json-valid</a> - <em>supports version 4</em> (MIT)</li>
+		<li><a id="link-impl-tv4" href="http://geraintluff.github.com/tv4/">tv4</a> - <em>supports version 4</em> (Public Domain)</li>
+		<li><a id="link-impl-jayschema" href="https://github.com/natesilva/jayschema">JaySchema</a> for Node.js - <em>supports version 4</em> (BSD)</li>
+		<li><a id="link-impl-z-schema" href="https://github.com/zaggino/z-schema">z-schema</a> for Node.js - <em>supports version 4</em> (MIT)</li>
+		<li><a id="link-impl-direct-schema" href="http://github.com/IreneKnapp/direct-schema">direct-schema</a> (BSD)</li>
+		<li><a id="link-impl-jsv" href="http://github.com/garycourt/JSV">JSV</a> (BSD)</li>
+		<li><a id="link-impl-kriszyp-jsonschema" href="http://github.com/kriszyp/json-schema">json-schema</a> (AFL or BSD) as part of <a id="link-impl-persvr" href="http://www.persvr.org/">Persevere</a></li>
+		<li><a id="link-impl-schema-js" href="https://github.com/akidee/schema.js">schema.js</a> (MIT)</li>
+		<li><a id="link-impl-json-gate" href="https://github.com/oferei/json-gate">json-gate</a> (MIT)</li>
+		<li><a id="link-impl-jsen" href="https://github.com/bugventure/jsen">JSEN</a> for Node.js - <em>supports version 4</em> (MIT)</li>
+	</ul>
+	</li>
+	<li>PHP
+	<ul>
+		<li><a id="link-impl-jsv4-php" href="https://github.com/geraintluff/jsv4-php">jsv4-php</a> - <em>supports version 4</em>  (Public Domain / MIT)</li>
+		<li><a id="link-impl-php-json-schema" href="https://github.com/hasbridge/php-json-schema">php-json-schema</a> (MIT)</li>
+		<li><a id="link-impl-json-schema" href="https://github.com/justinrainbow/json-schema">json-schema</a> (Berkeley)</li>
+		<li><a id="link-impl-jval" href="https://github.com/stefk/jval">JVal</a> - <em>supports version 4</em>  (MIT)</li>
+		<li><a id="link-impl-json-guard" href="https://github.com/thephpleague/json-guard">JSON Guard</a> - <em>supports version 4</em> (MIT)</li>
+	</ul>
+	</li>
+	<li>Perl
+	<ul>
+		<li><a id="link-impl-perl-json-schema" href="https://metacpan.org/module/JSON::Schema">JSON::Schema</a> (MIT)</li>
+	</ul>
+	</li>
+	<li>Python
+	<ul>
+		<li><a id="link-impl-jsonschema" href="https://github.com/Julian/jsonschema">jsonschema</a> - <em>supports version 4</em> (MIT)</li>
+		<li><a id="link-impl-zyga-json-schema-validator" href="https://github.com/zyga/json-schema-validator">json-schema-validator</a> (LGPL)</li>
+	</ul>
+	</li>
+	<li>Ruby
+	<ul>
+		<li><a id="link-impl-ruby-jsonchema" href="https://github.com/Constellation/ruby-jsonchema">ruby-jsonschema</a> (MIT)</li>
+		<li><a id="link-impl-ruby-hoxworth-json-schema" href="https://github.com/hoxworth/json-schema">json-schema</a> - <em>supports version 4</em> (MIT)</li>
 	</ul>
 	</li>
 	<li>Online (web tool)
@@ -119,10 +119,18 @@ permalink: /implementations
 		<li><a id="link-impl-jsonschemalint" href="http://jsonschemalint.com/">JSON Schema Lint</a> - validate against your own schemas</li>
 		<li><a id="link-impl-schemastore" href="http://schemastore.org/validator/">SchemaStore.org</a> - validate against common JSON Schemas</li>
 	</ul>
+	</li>	
 </ul>
 
 
 <h2>Validation benchmarks</h2>
+<ul>
+	<li>Java
+		<ul>
+			<li><a id="link-bench-networknt" href="https://github.com/networknt/json-schema-validator-perftest">json-schema-validator-benchmark</a> - compares performance of three JSON schema validator implementations in Java(Apache 2.0)</li>
+		</ul>
+	</li>
+</ul>
 <ul>
 	<li>JavaScript
 	<ul>
@@ -130,13 +138,6 @@ permalink: /implementations
 		<li><a id="link-bench-z-schema" href="https://github.com/zaggino/z-schema#benchmarks">z-schema validator benchmark</a> - compares performance in the individual tests from JSON-Schema Test Suite (MIT)</li>
 		<li><a id="link-bench-jsck" href="https://github.com/pandastrike/jsck#benchmarks">JSCK validator benchmark</a> - shows performance for JSON-schemas of different complexity (MIT)</li>
 	</ul>
-	</li>
-</ul>
-<ul>
-	<li>Java
-		<ul>
-			<li><a id="link-bench-networknt" href="https://github.com/networknt/json-schema-validator-perftest">json-schema-validator-benchmark</a> - compares performance of three JSON schema validator implementations in Java(Apache 2.0)</li>
-		</ul>
 	</li>
 </ul>
 
@@ -149,23 +150,6 @@ permalink: /implementations
 		<li><a id="link-impl-n-json-schema" href="http://NJsonSchema.org">NJsonSchema</a> - <em>supports version 4</em> (Ms-PL) - generates schemas from .NET types</li>
 	</ul>
 	</li>
-	<li>Online (web tool)
-	<ul>
-		<li><a href="http://www.jsonschema.net/">jsonschema.net</a> - generates schemas from example data</li>
-		<li><a id="link-impl-guru-ui" href="http://schemaguru.snowplowanalytics.com/">Schema Guru Web UI</a> - derives precise Schemas using several JSON instances. Based on <a href="link-impl-guru">Schema Guru</a></li>
-	</ul>
-	</li>
-	<li>TypeScript
-	<ul>
-		<li><a id="link-impl-typescript-json-schema" href="https://github.com/YousefED/typescript-json-schema">typescript-json-schema</a></li>
-		<li><a id="link-impl-typson" href="https://github.com/lbovet/typson">Typson</a> (Apache 2.0)</li>
-	</ul>
-	</li>
-	<li>Visual Studio
-	<ul>
-		<li><a id="link-impl-vs" href="http://visualstudiogallery.msdn.microsoft.com/b4515ef8-a518-41ca-b48c-bb1fd4e6faf7">JSON Schema Generator</a> - free extension</li>
-	</ul>
-	</li>
 	<li>Python
 	<ul>
 		<li><a id="link-impl-jsl" href="https://github.com/aromanovich/jsl">JSL</a> (BSD) - a Python DSL for defining JSON Schemas</li>
@@ -175,6 +159,24 @@ permalink: /implementations
 	<ul>
 		<li><a id="link-impl-guru" href="https://github.com/snowplow/schema-guru">Schema Guru</a> (Apache 2.0) - CLI util, Spark Job and Web UI for deriving JSON Schemas out of corpus of JSON instances</li>
 	</ul>
+	</li>	
+	<li>TypeScript
+	<ul>
+		<li><a id="link-impl-typescript-json-schema" href="https://github.com/YousefED/typescript-json-schema">typescript-json-schema</a></li>
+		<li><a id="link-impl-typson" href="https://github.com/lbovet/typson">Typson</a> (Apache 2.0)</li>
+	</ul>
+	</li>
+	<li>Online (web tool)
+	<ul>
+		<li><a href="http://www.jsonschema.net/">jsonschema.net</a> - generates schemas from example data</li>
+		<li><a id="link-impl-guru-ui" href="http://schemaguru.snowplowanalytics.com/">Schema Guru Web UI</a> - derives precise Schemas using several JSON instances. Based on <a href="link-impl-guru">Schema Guru</a></li>
+	</ul>
+	</li>
+	<li>Visual Studio
+	<ul>
+		<li><a id="link-impl-vs" href="http://visualstudiogallery.msdn.microsoft.com/b4515ef8-a518-41ca-b48c-bb1fd4e6faf7">JSON Schema Generator</a> - free extension</li>
+	</ul>
+	</li>
 </ul>
 
 <h2>Data parsing</h2>


### PR DESCRIPTION
The list of validators exceeds the visual part of the
»Software« page. In order to find the right (sub) list
sort it by 'programming language' with common order.

Non programming languages, mainly 'Online (web tool)',
were shifted to the end of the list.