### PR TITLE
Re-add draft 04 docs

### DIFF
--- a/draft-04/json-schema-core.html
+++ b/draft-04/json-schema-core.html
@@ -1,0 +1,1091 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html lang="en"><head><title>JSON Schema: core definitions and terminology</title>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<meta name="description" content="JSON Schema: core definitions and terminology">
+<meta name="keywords" content="JSON, Schema, Hyper Schema, Hypermedia">
+<meta name="generator" content="xml2rfc v1.36 (http://xml.resource.org/)">
+<style type='text/css'><!--
+        body {
+                font-family: verdana, charcoal, helvetica, arial, sans-serif;
+                font-size: small; color: #000; background-color: #FFF;
+                margin: 2em;
+        }
+        h1, h2, h3, h4, h5, h6 {
+                font-family: helvetica, monaco, "MS Sans Serif", arial, sans-serif;
+                font-weight: bold; font-style: normal;
+        }
+        h1 { color: #900; background-color: transparent; text-align: right; }
+        h3 { color: #333; background-color: transparent; }
+
+        td.RFCbug {
+                font-size: x-small; text-decoration: none;
+                width: 30px; height: 30px; padding-top: 2px;
+                text-align: justify; vertical-align: middle;
+                background-color: #000;
+        }
+        td.RFCbug span.RFC {
+                font-family: monaco, charcoal, geneva, "MS Sans Serif", helvetica, verdana, sans-serif;
+                font-weight: bold; color: #666;
+        }
+        td.RFCbug span.hotText {
+                font-family: charcoal, monaco, geneva, "MS Sans Serif", helvetica, verdana, sans-serif;
+                font-weight: normal; text-align: center; color: #FFF;
+        }
+
+        table.TOCbug { width: 30px; height: 15px; }
+        td.TOCbug {
+                text-align: center; width: 30px; height: 15px;
+                color: #FFF; background-color: #900;
+        }
+        td.TOCbug a {
+                font-family: monaco, charcoal, geneva, "MS Sans Serif", helvetica, sans-serif;
+                font-weight: bold; font-size: x-small; text-decoration: none;
+                color: #FFF; background-color: transparent;
+        }
+
+        td.header {
+                font-family: arial, helvetica, sans-serif; font-size: x-small;
+                vertical-align: top; width: 33%;
+                color: #FFF; background-color: #666;
+        }
+        td.author { font-weight: bold; font-size: x-small; margin-left: 4em; }
+        td.author-text { font-size: x-small; }
+
+        /* info code from SantaKlauss at http://www.madaboutstyle.com/tooltip2.html */
+        a.info {
+                /* This is the key. */
+                position: relative;
+                z-index: 24;
+                text-decoration: none;
+        }
+        a.info:hover {
+                z-index: 25;
+                color: #FFF; background-color: #900;
+        }
+        a.info span { display: none; }
+        a.info:hover span.info {
+                /* The span will display just on :hover state. */
+                display: block;
+                position: absolute;
+                font-size: smaller;
+                top: 2em; left: -5em; width: 15em;
+                padding: 2px; border: 1px solid #333;
+                color: #900; background-color: #EEE;
+                text-align: left;
+        }
+
+        a { font-weight: bold; }
+        a:link    { color: #900; background-color: transparent; }
+        a:visited { color: #633; background-color: transparent; }
+        a:active  { color: #633; background-color: transparent; }
+
+        p { margin-left: 2em; margin-right: 2em; }
+        p.copyright { font-size: x-small; }
+        p.toc { font-size: small; font-weight: bold; margin-left: 3em; }
+        table.toc { margin: 0 0 0 3em; padding: 0; border: 0; vertical-align: text-top; }
+        td.toc { font-size: small; font-weight: bold; vertical-align: text-top; }
+
+        ol.text { margin-left: 2em; margin-right: 2em; }
+        ul.text { margin-left: 2em; margin-right: 2em; }
+        li      { margin-left: 3em; }
+
+        /* RFC-2629 <spanx>s and <artwork>s. */
+        em     { font-style: italic; }
+        strong { font-weight: bold; }
+        dfn    { font-weight: bold; font-style: normal; }
+        cite   { font-weight: normal; font-style: normal; }
+        tt     { color: #036; }
+        tt, pre, pre dfn, pre em, pre cite, pre span {
+                font-family: "Courier New", Courier, monospace; font-size: small;
+        }
+        pre {
+                text-align: left; padding: 4px;
+                color: #000; background-color: #CCC;
+        }
+        pre dfn  { color: #900; }
+        pre em   { color: #66F; background-color: #FFC; font-weight: normal; }
+        pre .key { color: #33C; font-weight: bold; }
+        pre .id  { color: #900; }
+        pre .str { color: #000; background-color: #CFF; }
+        pre .val { color: #066; }
+        pre .rep { color: #909; }
+        pre .oth { color: #000; background-color: #FCF; }
+        pre .err { background-color: #FCC; }
+
+        /* RFC-2629 <texttable>s. */
+        table.all, table.full, table.headers, table.none {
+                font-size: small; text-align: center; border-width: 2px;
+                vertical-align: top; border-collapse: collapse;
+        }
+        table.all, table.full { border-style: solid; border-color: black; }
+        table.headers, table.none { border-style: none; }
+        th {
+                font-weight: bold; border-color: black;
+                border-width: 2px 2px 3px 2px;
+        }
+        table.all th, table.full th { border-style: solid; }
+        table.headers th { border-style: none none solid none; }
+        table.none th { border-style: none; }
+        table.all td {
+                border-style: solid; border-color: #333;
+                border-width: 1px 2px;
+        }
+        table.full td, table.headers td, table.none td { border-style: none; }
+
+        hr { height: 1px; }
+        hr.insert {
+                width: 80%; border-style: none; border-width: 0;
+                color: #CCC; background-color: #CCC;
+        }
+--></style>
+</head>
+<body>
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<table summary="layout" width="66%" border="0" cellpadding="0" cellspacing="0"><tr><td><table summary="layout" width="100%" border="0" cellpadding="2" cellspacing="1">
+<tr><td class="header">Internet Engineering Task Force</td><td class="header">fge. Galiegue</td></tr>
+<tr><td class="header">Internet-Draft</td><td class="header">&nbsp;</td></tr>
+<tr><td class="header">Intended status: Informational</td><td class="header">K. Zyp, Ed.</td></tr>
+<tr><td class="header">Expires: August 3, 2013</td><td class="header">SitePen (USA)</td></tr>
+<tr><td class="header">&nbsp;</td><td class="header">G. Court</td></tr>
+<tr><td class="header">&nbsp;</td><td class="header">January 30, 2013</td></tr>
+</table></td></tr></table>
+<h1><br />JSON Schema: core definitions and terminology<br />json-schema-core</h1>
+
+<h3>Abstract</h3>
+
+<p>
+                JSON Schema defines the media type "application/schema+json", a JSON based format
+                for defining the structure of JSON data. JSON Schema provides a contract for what
+                JSON data is required for a given application and how to interact with it. JSON
+                Schema is intended to define validation, documentation, hyperlink navigation, and
+                interaction control of JSON data.
+            
+</p>
+<h3>Status of This Memo</h3>
+<p>
+This Internet-Draft is submitted  in full
+conformance with the provisions of BCP&nbsp;78 and BCP&nbsp;79.</p>
+<p>
+Internet-Drafts are working documents of the Internet Engineering
+Task Force (IETF).  Note that other groups may also distribute
+working documents as Internet-Drafts.  The list of current
+Internet-Drafts is at http://datatracker.ietf.org/drafts/current/.</p>
+<p>
+Internet-Drafts are draft documents valid for a maximum of six months
+and may be updated, replaced, or obsoleted by other documents at any time.
+It is inappropriate to use Internet-Drafts as reference material or to cite
+them other than as &ldquo;work in progress.&rdquo;</p>
+<p>
+This Internet-Draft will expire on August 3, 2013.</p>
+
+<h3>Copyright Notice</h3>
+<p>
+Copyright (c) 2013 IETF Trust and the persons identified as the
+document authors.  All rights reserved.</p>
+<p>
+This document is subject to BCP 78 and the IETF Trust's Legal
+Provisions Relating to IETF Documents
+(http://trustee.ietf.org/license-info) in effect on the date of
+publication of this document.  Please review these documents
+carefully, as they describe your rights and restrictions with respect
+to this document. Code Components extracted from this document must
+include Simplified BSD License text as described in Section 4.e of
+the Trust Legal Provisions and are provided without warranty as
+described in the Simplified BSD License.</p>
+<a name="toc"></a><br /><hr />
+<h3>Table of Contents</h3>
+<p class="toc">
+<a href="#anchor1">1.</a>&nbsp;
+Introduction<br />
+<a href="#anchor2">2.</a>&nbsp;
+Conventions and Terminology<br />
+<a href="#anchor3">3.</a>&nbsp;
+Core terminology<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor4">3.1.</a>&nbsp;
+Property, item<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor5">3.2.</a>&nbsp;
+JSON Schema, keywords<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor6">3.3.</a>&nbsp;
+Empty schema<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor7">3.4.</a>&nbsp;
+Root schema, subschema<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor8">3.5.</a>&nbsp;
+JSON Schema primitive types<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor9">3.6.</a>&nbsp;
+JSON value equality<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor10">3.7.</a>&nbsp;
+Instance<br />
+<a href="#anchor11">4.</a>&nbsp;
+Overview<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor12">4.1.</a>&nbsp;
+Validation<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor13">4.2.</a>&nbsp;
+Hypermedia and linking<br />
+<a href="#anchor14">5.</a>&nbsp;
+General considerations<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor15">5.1.</a>&nbsp;
+Applicability to all JSON values<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor16">5.2.</a>&nbsp;
+Programming language independence<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor17">5.3.</a>&nbsp;
+JSON Schema and HTTP<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor18">5.4.</a>&nbsp;
+JSON Schema and other protocols<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor19">5.5.</a>&nbsp;
+Mathematical integers<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor20">5.6.</a>&nbsp;
+Extending JSON Schema<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor21">5.7.</a>&nbsp;
+Security considerations<br />
+<a href="#anchor22">6.</a>&nbsp;
+The "$schema" keyword<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor23">6.1.</a>&nbsp;
+Purpose<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor24">6.2.</a>&nbsp;
+Customization<br />
+<a href="#anchor25">7.</a>&nbsp;
+URI resolution scopes and dereferencing<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor26">7.1.</a>&nbsp;
+Definition<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor27">7.2.</a>&nbsp;
+URI resolution scope alteration with the "id" keyword<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor28">7.2.1.</a>&nbsp;
+Valid values<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor29">7.2.2.</a>&nbsp;
+Usage<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor30">7.2.3.</a>&nbsp;
+Canonical dereferencing and inline dereferencing<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor31">7.2.4.</a>&nbsp;
+Inline dereferencing and fragments<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor32">7.3.</a>&nbsp;
+Security considerations<br />
+<a href="#anchor33">8.</a>&nbsp;
+Recommended correlation mechanisms for use with the HTTP protocol<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor34">8.1.</a>&nbsp;
+Correlation by means of the "Content-Type" header<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor35">8.2.</a>&nbsp;
+Correlation by means of the "Link" header<br />
+<a href="#anchor36">9.</a>&nbsp;
+IANA Considerations<br />
+<a href="#rfc.references1">10.</a>&nbsp;
+References<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#rfc.references1">10.1.</a>&nbsp;
+Normative References<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#rfc.references2">10.2.</a>&nbsp;
+Informative References<br />
+<a href="#anchor39">Appendix&nbsp;A.</a>&nbsp;
+ChangeLog<br />
+</p>
+<br clear="all" />
+
+<a name="anchor1"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.1"></a><h3>1.&nbsp;
+Introduction</h3>
+
+<p>
+                JSON Schema is a JSON media type for defining the structure of JSON data. JSON
+                Schema provides a contract for what JSON data is required for a given application
+                and how to interact with it. JSON Schema is intended to define validation,
+                documentation, hyperlink navigation, and interaction control of JSON data.
+            
+</p>
+<p>
+                This specification defines JSON Schema core terminology and mechanisms; related
+                specifications build upon this specification and define different applications of
+                JSON Schema.
+            
+</p>
+<a name="anchor2"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.2"></a><h3>2.&nbsp;
+Conventions and Terminology</h3>
+
+<p>
+                
+
+                The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+                "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
+                interpreted as described in <a class='info' href='#RFC2119'>RFC 2119<span> (</span><span class='info'>Bradner, S., &ldquo;Key words for use in RFCs to Indicate Requirement Levels,&rdquo; March&nbsp;1997.</span><span>)</span></a> [RFC2119].
+            
+</p>
+<p>
+                The terms "JSON", "JSON text", "JSON value", "member", "element", "object", "array",
+                "number", "string", "boolean", "true", "false", and "null" in this document are to
+                be interpreted as defined in <a class='info' href='#RFC4627'>RFC 4627<span> (</span><span class='info'>Crockford, D., &ldquo;The application/json Media Type for JavaScript Object Notation (JSON),&rdquo; July&nbsp;2006.</span><span>)</span></a> [RFC4627].
+            
+</p>
+<a name="anchor3"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3"></a><h3>3.&nbsp;
+Core terminology</h3>
+
+<a name="anchor4"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.1"></a><h3>3.1.&nbsp;
+Property, item</h3>
+
+<p>
+                    When refering to a JSON Object, as defined by <a class='info' href='#RFC4627'>[RFC4627]<span> (</span><span class='info'>Crockford, D., &ldquo;The application/json Media Type for JavaScript Object Notation (JSON),&rdquo; July&nbsp;2006.</span><span>)</span></a>, the
+                    terms "member" and "property" may be used interchangeably.
+                
+</p>
+<p>
+                    When refering to a JSON Array, as defined by <a class='info' href='#RFC4627'>[RFC4627]<span> (</span><span class='info'>Crockford, D., &ldquo;The application/json Media Type for JavaScript Object Notation (JSON),&rdquo; July&nbsp;2006.</span><span>)</span></a>, the terms
+                    "element" and "item" may be used interchangeably.
+                
+</p>
+<a name="anchor5"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.2"></a><h3>3.2.&nbsp;
+JSON Schema, keywords</h3>
+
+<p>
+                    A JSON Schema is a JSON document, and that document MUST be an object. Object
+                    members (or properties) defined by JSON Schema (this specification, or related
+                    specifications) are called keywords, or schema keywords.
+                
+</p>
+<p>
+                    A JSON Schema MAY contain properties which are not schema keywords.
+                
+</p>
+<a name="anchor6"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.3"></a><h3>3.3.&nbsp;
+Empty schema</h3>
+
+<p>
+                    An empty schema is a JSON Schema with no properties, or with properties which
+                    are not schema keywords.
+                
+</p>
+<a name="anchor7"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.4"></a><h3>3.4.&nbsp;
+Root schema, subschema</h3>
+
+<p>
+                    This example of a JSON Schema has no subschemas:
+                
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+
+{
+    "title": "root"
+}
+
+</pre></div>
+<p>
+                    JSON Schemas can also be nested, as in this example:
+                
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+
+{
+    "title": "root",
+    "otherSchema": {
+        "title": "nested",
+        "anotherSchema": {
+            "title": "alsoNested"
+        }
+    }
+}
+
+</pre></div>
+<p>
+                    In this example, "nested" and "alsoNested" are subschemas, and "root" is a root
+                    schema.
+                
+</p>
+<a name="anchor8"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.5"></a><h3>3.5.&nbsp;
+JSON Schema primitive types</h3>
+
+<p>
+                    JSON Schema defines seven primitive types for JSON values:
+                    </p>
+<blockquote class="text"><dl>
+<dt>array</dt>
+<dd>A JSON array.
+</dd>
+<dt>boolean</dt>
+<dd>A JSON boolean.
+</dd>
+<dt>integer</dt>
+<dd>A JSON number without a fraction or exponent part.
+</dd>
+<dt>number</dt>
+<dd>Any JSON number. Number includes integer.
+</dd>
+<dt>null</dt>
+<dd>The JSON null value.
+</dd>
+<dt>object</dt>
+<dd>A JSON object.
+</dd>
+<dt>string</dt>
+<dd>A JSON string.
+</dd>
+</dl></blockquote><p>
+                
+</p>
+<a name="anchor9"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.6"></a><h3>3.6.&nbsp;
+JSON value equality</h3>
+
+<p>
+                    Two JSON values are said to be equal if and only if:
+
+                    </p>
+<blockquote class="text">
+<p>both are nulls; or
+</p>
+<p>both are booleans, and have the same value; or
+</p>
+<p>both are strings, and have the same value; or
+</p>
+<p>both are numbers, and have the same mathematical value; or
+</p>
+<p>both are arrays, and:
+                            </p>
+<blockquote class="text">
+<p>have the same number of items; and
+</p>
+<p>items at the same index are equal according to this definition;
+                                or
+</p>
+</blockquote>
+                        
+
+<p>both are objects, and:
+                            </p>
+<blockquote class="text">
+<p>have the same set of property names; and
+</p>
+<p>values for a same property name are equal according to this
+                                definition.
+</p>
+</blockquote>
+                        
+
+</blockquote><p>
+                
+</p>
+<a name="anchor10"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.7"></a><h3>3.7.&nbsp;
+Instance</h3>
+
+<p>
+                    An instance is any JSON value. An instance may be described by one or more
+                    schemas.
+                
+</p>
+<p>
+                    An instance may also be referred to as "JSON instance", or "JSON data".
+                
+</p>
+<a name="anchor11"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.4"></a><h3>4.&nbsp;
+Overview</h3>
+
+<p>
+                This document proposes a new media type "application/schema+json" to identify JSON
+                Schema for describing JSON data. JSON Schemas are themselves written in JSON.  This,
+                and related specifications, define keywords allowing to describe this data in terms
+                of allowable values, textual descriptions and interpreting relations with other
+                resources. The following sections are a summary of features defined by related
+                specifications.
+            
+</p>
+<a name="anchor12"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.4.1"></a><h3>4.1.&nbsp;
+Validation</h3>
+
+<p>
+                    JSON Schema allows applications to validate instances, either non interactively
+                    or interactively. For instance, an application may collect JSON data and check
+                    that this data matches a given set of constraints; another application may use a
+                    JSON Schema to build an interactive interface in order to collect user input
+                    according to constraints described by JSON Schema.
+                
+</p>
+<a name="anchor13"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.4.2"></a><h3>4.2.&nbsp;
+Hypermedia and linking</h3>
+
+<p>
+                    JSON Schema provides a method for extracting link relations from instances to
+                    other resources, as well as describing interpretations of instances as
+                    multimedia data. This allows JSON data to be interpreted as rich hypermedia
+                    documents, placed in the context of a larger set of related resources.
+                
+</p>
+<a name="anchor14"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5"></a><h3>5.&nbsp;
+General considerations</h3>
+
+<a name="anchor15"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.1"></a><h3>5.1.&nbsp;
+Applicability to all JSON values</h3>
+
+<p>
+                    It is acknowledged that an instance may be any valid JSON value as defined
+                    by <a class='info' href='#RFC4627'>[RFC4627]<span> (</span><span class='info'>Crockford, D., &ldquo;The application/json Media Type for JavaScript Object Notation (JSON),&rdquo; July&nbsp;2006.</span><span>)</span></a>. As such, JSON Schema does not mandate that an
+                    instance be of a particular type: JSON Schema can describe any JSON value,
+                    including null.
+                
+</p>
+<a name="anchor16"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.2"></a><h3>5.2.&nbsp;
+Programming language independence</h3>
+
+<p>
+                    JSON Schema is programming language agnostic. The only limitations are the ones
+                    expressed by <a class='info' href='#RFC4627'>[RFC4627]<span> (</span><span class='info'>Crockford, D., &ldquo;The application/json Media Type for JavaScript Object Notation (JSON),&rdquo; July&nbsp;2006.</span><span>)</span></a> and those of the host programming
+                    language.
+                
+</p>
+<a name="anchor17"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.3"></a><h3>5.3.&nbsp;
+JSON Schema and HTTP</h3>
+
+<p>
+                    This specification acknowledges the role of <a class='info' href='#RFC2616'>HTTP<span> (</span><span class='info'>Fielding, R., Gettys, J., Mogul, J., Frystyk, H., Masinter, L., Leach, P., and T. Berners-Lee, &ldquo;Hypertext Transfer Protocol -- HTTP/1.1,&rdquo; June&nbsp;1999.</span><span>)</span></a> [RFC2616]
+                    as the dominant protocol in use on the Internet, and the wealth of
+                    official specifications related to it.
+                
+</p>
+<p>
+                    This specification uses a subset of these specifications to recommend a set of
+                    mechanisms, usable by this protocol, to associate JSON instances to one or more
+                    schemas.
+                
+</p>
+<a name="anchor18"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.4"></a><h3>5.4.&nbsp;
+JSON Schema and other protocols</h3>
+
+<p>
+                    JSON Schema does not define any semantics for the client-server interface for
+                    any other protocols than HTTP. These semantics are application dependent, or
+                    subject to agreement between the parties involved in the use of JSON Schema for
+                    their own needs.
+                
+</p>
+<a name="anchor19"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.5"></a><h3>5.5.&nbsp;
+Mathematical integers</h3>
+
+<p>
+                    It is acknowledged by this specification that some programming languages, and
+                    their associated parsers, use different internal representations for floating
+                    point numbers and integers, while others do not.
+                
+</p>
+<p>
+                    As a consequence, for interoperability reasons, JSON values used in the context
+                    of JSON Schema, whether that JSON be a JSON Schema or an instance, SHOULD ensure
+                    that mathematical integers be represented as integers as defined by this
+                    specification.
+                
+</p>
+<a name="anchor20"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.6"></a><h3>5.6.&nbsp;
+Extending JSON Schema</h3>
+
+<p>
+                    Implementations MAY choose to define additional keywords to JSON Schema. Save
+                    for explicit agreement, schema authors SHALL NOT expect these additional
+                    keywords to be supported by peer implementations. Implementations SHOULD ignore
+                    keywords they do not support.
+                
+</p>
+<a name="anchor21"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.7"></a><h3>5.7.&nbsp;
+Security considerations</h3>
+
+<p>
+                    Both schemas and instances are JSON values. As such, all security considerations
+                    defined in <a class='info' href='#RFC4627'>RFC 4627<span> (</span><span class='info'>Crockford, D., &ldquo;The application/json Media Type for JavaScript Object Notation (JSON),&rdquo; July&nbsp;2006.</span><span>)</span></a> [RFC4627] apply.
+                
+</p>
+<a name="anchor22"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.6"></a><h3>6.&nbsp;
+The "$schema" keyword</h3>
+
+<a name="anchor23"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.6.1"></a><h3>6.1.&nbsp;
+Purpose</h3>
+
+<p>
+                    The "$schema" keyword is both used as a JSON Schema version identifier and the
+                    location of a resource which is itself a JSON Schema, which describes any schema
+                    written for this particular version.
+                
+</p>
+<p>
+                    This keyword MUST be located at the root of a JSON Schema. The value of this
+                    keyword MUST be a <a class='info' href='#RFC3986'>URI<span> (</span><span class='info'>Berners-Lee, T., Fielding, R., and L. Masinter, &ldquo;Uniform Resource Identifier (URI): Generic Syntax,&rdquo; January&nbsp;2005.</span><span>)</span></a> [RFC3986] and a valid <a class='info' href='#json-reference'>JSON Reference<span> (</span><span class='info'>Bryan, P. and K. Zyp, &ldquo;JSON Reference (work in progress),&rdquo; September&nbsp;2012.</span><span>)</span></a> [json&#8209;reference]; this URI MUST be both absolute
+                    and normalized. The resource located at this URI MUST successfully describe
+                    itself. It is RECOMMENDED that schema authors include this keyword in their
+                    schemas.
+                
+</p>
+<p>
+                    The following values are predefined:
+
+                    </p>
+<blockquote class="text"><dl>
+<dt>http://json-schema.org/schema#</dt>
+<dd>JSON Schema written against
+                        the current version of the specification.
+</dd>
+<dt>http://json-schema.org/hyper-schema#</dt>
+<dd>JSON Schema written
+                        against the current version of the specification.
+</dd>
+<dt>http://json-schema.org/draft-04/schema#</dt>
+<dd>JSON Schema written
+                        against this version.
+</dd>
+<dt>http://json-schema.org/draft-04/hyper-schema#</dt>
+<dd>JSON Schema hyperschema
+                        written against this version.
+</dd>
+<dt>http://json-schema.org/draft-03/schema#</dt>
+<dd> JSON Schema written
+                        against <a class='info' href='#json-schema-03'>JSON Schema, draft v3<span> (</span><span class='info'>Court, G. and K. Zyp, &ldquo;JSON Schema, draft 3,&rdquo; September&nbsp;2012.</span><span>)</span></a> [json&#8209;schema&#8209;03].
+</dd>
+<dt>http://json-schema.org/draft-03/hyper-schema#</dt>
+<dd> JSON Schema hyperschema
+                        written against <a class='info' href='#json-schema-03'>JSON Schema, draft
+                        v3<span> (</span><span class='info'>Court, G. and K. Zyp, &ldquo;JSON Schema, draft 3,&rdquo; September&nbsp;2012.</span><span>)</span></a> [json&#8209;schema&#8209;03].
+</dd>
+</dl></blockquote><p>
+                
+</p>
+<a name="anchor24"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.6.2"></a><h3>6.2.&nbsp;
+Customization</h3>
+
+<p>
+                    When extending JSON Schema with custom keywords, schema authors SHOULD define a
+                    custom URI for "$schema". This custom URI MUST NOT be one of the predefined
+                    values.
+                
+</p>
+<a name="anchor25"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.7"></a><h3>7.&nbsp;
+URI resolution scopes and dereferencing</h3>
+
+<a name="anchor26"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.7.1"></a><h3>7.1.&nbsp;
+Definition</h3>
+
+<p>
+                    JSON Schema uses <a class='info' href='#json-reference'>JSON Reference<span> (</span><span class='info'>Bryan, P. and K. Zyp, &ldquo;JSON Reference (work in progress),&rdquo; September&nbsp;2012.</span><span>)</span></a> [json&#8209;reference] as a
+                    mechanism for schema addressing. It extends this specification in two ways:
+                    
+                    </p>
+<blockquote class="text">
+<p>JSON Schema offers facilities to alter the base URI against which a
+                        reference must resolve by the means of the "id" keyword;
+</p>
+<p>it defines a specific dereferencing mechanism extending JSON Reference to
+                        accept arbitrary fragment parts.
+</p>
+</blockquote><p>
+
+                
+</p>
+<p>
+                    Altering the URI within a schema is called defining a new resolution scope. The
+                    initial resolution scope of a schema is the URI of the schema itself, if any, or
+                    the empty URI if the schema was not loaded from a URI.
+                
+</p>
+<a name="anchor27"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.7.2"></a><h3>7.2.&nbsp;
+URI resolution scope alteration with the "id" keyword</h3>
+
+<a name="anchor28"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.7.2.1"></a><h3>7.2.1.&nbsp;
+Valid values</h3>
+
+<p>
+                        The value for this keyword MUST be a string, and MUST be a valid URI. This
+                        URI MUST be normalized, and SHOULD NOT be an empty fragment (#) or the empty
+                        URI.
+                    
+</p>
+<a name="anchor29"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.7.2.2"></a><h3>7.2.2.&nbsp;
+Usage</h3>
+
+<p>
+                        The "id" keyword (or "id", for short) is used to alter the resolution scope.
+                        When an id is encountered, an implementation MUST resolve this id against
+                        the most immediate parent scope. The resolved URI will be the new resolution
+                        scope for this subschema and all its children, until another id is
+                        encountered.
+                    
+</p>
+<p>
+                        When using "id" to alter resolution scopes, schema authors SHOULD ensure
+                        that resolution scopes are unique within the schema.
+                    
+</p>
+<p>
+                        This schema will be taken as an example:
+                    
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+
+{
+    "id": "http://x.y.z/rootschema.json#",
+    "schema1": {
+        "id": "#foo"
+    },
+    "schema2": {
+        "id": "otherschema.json",
+        "nested": {
+            "id": "#bar"
+        },
+        "alsonested": {
+            "id": "t/inner.json#a"
+        }
+    },
+    "schema3": {
+        "id": "some://where.else/completely#"
+    }
+}
+
+</pre></div>
+<p>
+                        Subschemas at the following URI-encoded <a class='info' href='#json-pointer'>JSON
+                        Pointer<span> (</span><span class='info'>Bryan, P. and K. Zyp, &ldquo;JSON Pointer (work in progress),&rdquo; September&nbsp;2012.</span><span>)</span></a> [json&#8209;pointer]s (starting from the root schema) define the following
+                        resolution scopes:
+    
+                        </p>
+<blockquote class="text"><dl>
+<dt># (document root)</dt>
+<dd>http://x.y.z/rootschema.json#
+</dd>
+<dt>#/schema1</dt>
+<dd>http://x.y.z/rootschema.json#foo
+</dd>
+<dt>#/schema2</dt>
+<dd>http://x.y.z/otherschema.json#
+</dd>
+<dt>#/schema2/nested</dt>
+<dd>http://x.y.z/otherschema.json#bar
+</dd>
+<dt>#/schema2/alsonested</dt>
+<dd>http://x.y.z/t/inner.json#a
+</dd>
+<dt>#/schema3</dt>
+<dd>some://where.else/completely#
+</dd>
+</dl></blockquote><p>
+                    
+</p>
+<a name="anchor30"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.7.2.3"></a><h3>7.2.3.&nbsp;
+Canonical dereferencing and inline dereferencing</h3>
+
+<p>
+                        When resolving a URI against a resolution scope, an implementation may
+                        choose two modes of operation:
+
+                        </p>
+<blockquote class="text"><dl>
+<dt>canonical dereferencing</dt>
+<dd>The implementation dereferences
+                            all resolved URIs.
+</dd>
+<dt>inline dereferencing</dt>
+<dd>The implementation chooses to
+                            dereference URIs within the schema.
+</dd>
+</dl></blockquote><p>
+                    
+</p>
+<p>
+                        Implementations MUST support canonical dereferencing, and MAY support inline
+                        dereferencing.
+                    
+</p>
+<p>
+                        For example, consider this schema:
+                    
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+
+{
+    "id": "http://my.site/myschema#",
+    "definitions": {
+        "schema1": {
+            "id": "schema1",
+            "type": "integer"
+        },
+        "schema2", {
+            "type": "array",
+            "items": { "$ref": "schema1" }
+        }
+    }
+}
+
+</pre></div>
+<p>
+                        When an implementation encounters the "schema1" reference, it resolves it
+                        against the most immediate parent scope, leading to URI
+                        "http://my.site/schema1#". The way to process this URI will differ
+                        according to the chosen dereferencing mode:
+
+                        </p>
+<blockquote class="text">
+<p>if canonical dereferencing is used, the implementation will
+                            dereference this URI, and fetch the content at this URI;
+</p>
+<p>if inline dereferencing is used, the implementation will notice that
+                            URI scope "http://my.site/schema1#" is already defined within the
+                            schema, and choose to use the appropriate subschema.
+</p>
+</blockquote><p>
+                    
+</p>
+<a name="anchor31"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.7.2.4"></a><h3>7.2.4.&nbsp;
+Inline dereferencing and fragments</h3>
+
+<p>
+                        When using inline dereferencing, a resolution scope may lead to a URI which
+                        has a non empty fragment part which is not a JSON Pointer, as in this
+                        example:
+                    
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+
+{
+    "id": "http://some.site/schema#",
+    "not": { "$ref": "#inner" },
+    "definitions": {
+        "schema1": {
+            "id": "#inner",
+            "type": "boolean"
+        }
+    }
+}
+
+</pre></div>
+<p>
+                        An implementation choosing to support inline dereferencing SHOULD be able to
+                        use this kind of reference. Implementations choosing to use canonical
+                        dereferencing, however, are not required to support it.
+                    
+</p>
+<a name="anchor32"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.7.3"></a><h3>7.3.&nbsp;
+Security considerations</h3>
+
+<p>
+                    Inline dereferencing can produce canonical URIs which differ from the canonical URI
+                    of the root schema. Schema authors SHOULD ensure that implementations using
+                    canonical dereferencing obtain the same content as implementations using inline
+                    dereferencing.
+                
+</p>
+<p>
+                    Extended JSON References using fragments which are not JSON Pointers are not
+                    dereferenceable by implementations choosing not to support inline dereferencing.
+                    This kind of reference is defined for backwards compatibility, and SHOULD NOT be
+                    used in new schemas.
+                
+</p>
+<a name="anchor33"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.8"></a><h3>8.&nbsp;
+Recommended correlation mechanisms for use with the HTTP protocol</h3>
+
+<p>
+                It is acknowledged by this specification that the majority of interactive JSON
+                Schema processing will be over HTTP. This section therefore gives recommendations
+                for materializing an instance/schema correlation using mechanisms currently
+                available for this protocol. An instance is said to be described by one (or more)
+                schema(s).
+            
+</p>
+<a name="anchor34"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.8.1"></a><h3>8.1.&nbsp;
+Correlation by means of the "Content-Type" header</h3>
+
+<p>
+                    It is RECOMMENDED that a MIME type parameter by the name of "profile" be
+                    appended to the "Content-Type" header of the instance being processed. If
+                    present, the value of this parameter MUST be a valid URI, and this URI SHOULD
+                    resolve to a valid JSON Schema. The MIME type MUST be "application/json", or any
+                    other subtype.
+                
+</p>
+<p>
+                    An example of such a header would be:
+                
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+
+Content-Type: application/my-media-type+json;
+          profile=http://example.com/my-hyper-schema#
+
+</pre></div>
+<a name="anchor35"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.8.2"></a><h3>8.2.&nbsp;
+Correlation by means of the "Link" header</h3>
+
+<p>
+                    When using the "Link" header, the relation type used MUST be "describedBy", as
+                    defined by <a class='info' href='#RFC5988'>RFC 5988, section 5.3<span> (</span><span class='info'>Nottingham, M., &ldquo;Web Linking,&rdquo; October&nbsp;2010.</span><span>)</span></a> [RFC5988]. The target URI
+                    of the "Link" header MUST be a valid JSON Schema.
+                
+</p>
+<p>
+                    An example of such a header would be:
+                
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+
+Link: &lt;http://example.com/my-hyper-schema#&gt;; rel="describedBy"
+
+</pre></div>
+<a name="anchor36"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.9"></a><h3>9.&nbsp;
+IANA Considerations</h3>
+
+<p>
+                The proposed MIME media type for JSON Schema is defined as follows:
+
+                </p>
+<blockquote class="text">
+<p>type name: application;
+</p>
+<p>subtype name: schema+json.
+</p>
+</blockquote><p>
+            
+</p>
+<a name="rfc.references"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.10"></a><h3>10.&nbsp;
+References</h3>
+
+<a name="rfc.references1"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<h3>10.1.&nbsp;Normative References</h3>
+<table width="99%" border="0">
+<tr><td class="author-text" valign="top"><a name="RFC2119">[RFC2119]</a></td>
+<td class="author-text"><a href="mailto:sob@harvard.edu">Bradner, S.</a>, &ldquo;<a href="http://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>,&rdquo; BCP&nbsp;14, RFC&nbsp;2119, March&nbsp;1997 (<a href="http://www.rfc-editor.org/rfc/rfc2119.txt">TXT</a>, <a href="http://xml.resource.org/public/rfc/html/rfc2119.html">HTML</a>, <a href="http://xml.resource.org/public/rfc/xml/rfc2119.xml">XML</a>).</td></tr>
+</table>
+
+<a name="rfc.references2"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<h3>10.2.&nbsp;Informative References</h3>
+<table width="99%" border="0">
+<tr><td class="author-text" valign="top"><a name="RFC2616">[RFC2616]</a></td>
+<td class="author-text"><a href="mailto:fielding@ics.uci.edu">Fielding, R.</a>, <a href="mailto:jg@w3.org">Gettys, J.</a>, <a href="mailto:mogul@wrl.dec.com">Mogul, J.</a>, <a href="mailto:frystyk@w3.org">Frystyk, H.</a>, <a href="mailto:masinter@parc.xerox.com">Masinter, L.</a>, <a href="mailto:paulle@microsoft.com">Leach, P.</a>, and <a href="mailto:timbl@w3.org">T. Berners-Lee</a>, &ldquo;<a href="http://tools.ietf.org/html/rfc2616">Hypertext Transfer Protocol -- HTTP/1.1</a>,&rdquo; RFC&nbsp;2616, June&nbsp;1999 (<a href="http://www.rfc-editor.org/rfc/rfc2616.txt">TXT</a>, <a href="http://www.rfc-editor.org/rfc/rfc2616.ps">PS</a>, <a href="http://www.rfc-editor.org/rfc/rfc2616.pdf">PDF</a>, <a href="http://xml.resource.org/public/rfc/html/rfc2616.html">HTML</a>, <a href="http://xml.resource.org/public/rfc/xml/rfc2616.xml">XML</a>).</td></tr>
+<tr><td class="author-text" valign="top"><a name="RFC3986">[RFC3986]</a></td>
+<td class="author-text"><a href="mailto:timbl@w3.org">Berners-Lee, T.</a>, <a href="mailto:fielding@gbiv.com">Fielding, R.</a>, and <a href="mailto:LMM@acm.org">L. Masinter</a>, &ldquo;<a href="http://tools.ietf.org/html/rfc3986">Uniform Resource Identifier (URI): Generic Syntax</a>,&rdquo; STD&nbsp;66, RFC&nbsp;3986, January&nbsp;2005 (<a href="http://www.rfc-editor.org/rfc/rfc3986.txt">TXT</a>, <a href="http://xml.resource.org/public/rfc/html/rfc3986.html">HTML</a>, <a href="http://xml.resource.org/public/rfc/xml/rfc3986.xml">XML</a>).</td></tr>
+<tr><td class="author-text" valign="top"><a name="RFC4627">[RFC4627]</a></td>
+<td class="author-text">Crockford, D., &ldquo;<a href="http://tools.ietf.org/html/rfc4627">The application/json Media Type for JavaScript Object Notation (JSON)</a>,&rdquo; RFC&nbsp;4627, July&nbsp;2006 (<a href="http://www.rfc-editor.org/rfc/rfc4627.txt">TXT</a>).</td></tr>
+<tr><td class="author-text" valign="top"><a name="RFC5988">[RFC5988]</a></td>
+<td class="author-text">Nottingham, M., &ldquo;<a href="http://tools.ietf.org/html/rfc5988">Web Linking</a>,&rdquo; RFC&nbsp;5988, October&nbsp;2010 (<a href="http://www.rfc-editor.org/rfc/rfc5988.txt">TXT</a>).</td></tr>
+<tr><td class="author-text" valign="top"><a name="json-reference">[json-reference]</a></td>
+<td class="author-text">Bryan, P. and K. Zyp, &ldquo;<a href="http://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03">JSON Reference (work in progress)</a>,&rdquo; September&nbsp;2012.</td></tr>
+<tr><td class="author-text" valign="top"><a name="json-pointer">[json-pointer]</a></td>
+<td class="author-text">Bryan, P. and K. Zyp, &ldquo;<a href="http://tools.ietf.org/html/draft-ietf-appsawg-json-pointer-07">JSON Pointer (work in progress)</a>,&rdquo; September&nbsp;2012.</td></tr>
+<tr><td class="author-text" valign="top"><a name="json-schema-03">[json-schema-03]</a></td>
+<td class="author-text">Court, G. and K. Zyp, &ldquo;<a href="http://tools.ietf.org/html/draft-zyp-json-schema-03">JSON Schema, draft 3</a>,&rdquo; September&nbsp;2012.</td></tr>
+</table>
+
+<a name="anchor39"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.A"></a><h3>Appendix A.&nbsp;
+ChangeLog</h3>
+
+<p>
+                </p>
+<blockquote class="text"><dl>
+<dt>draft-00</dt>
+<dd>
+                        
+<ul class="text">
+<li>Initial draft.
+</li>
+<li>Salvaged from draft v3.
+</li>
+<li>Mandate the use of JSON Reference, JSON Pointer.
+</li>
+<li>Define the role of "id". Define URI resolution scope.
+</li>
+<li>Add interoperability considerations.
+</li>
+</ul>
+                    
+</dd>
+</dl></blockquote><p>
+            
+</p>
+<a name="rfc.authors"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<h3>Authors' Addresses</h3>
+<table width="99%" border="0" cellpadding="0" cellspacing="0">
+<tr><td class="author-text">&nbsp;</td>
+<td class="author-text">Francis Galiegue</td></tr>
+<tr><td class="author" align="right">EMail:&nbsp;</td>
+<td class="author-text"><a href="mailto:fgaliegue@gmail.com">fgaliegue@gmail.com</a></td></tr>
+<tr cellpadding="3"><td>&nbsp;</td><td>&nbsp;</td></tr>
+<tr><td class="author-text">&nbsp;</td>
+<td class="author-text">Kris Zyp (editor)</td></tr>
+<tr><td class="author-text">&nbsp;</td>
+<td class="author-text">SitePen (USA)</td></tr>
+<tr><td class="author-text">&nbsp;</td>
+<td class="author-text">530 Lytton Avenue</td></tr>
+<tr><td class="author-text">&nbsp;</td>
+<td class="author-text">Palo Alto, CA 94301</td></tr>
+<tr><td class="author-text">&nbsp;</td>
+<td class="author-text">USA</td></tr>
+<tr><td class="author" align="right">Phone:&nbsp;</td>
+<td class="author-text">+1 650 968 8787</td></tr>
+<tr><td class="author" align="right">EMail:&nbsp;</td>
+<td class="author-text"><a href="mailto:kris@sitepen.com">kris@sitepen.com</a></td></tr>
+<tr cellpadding="3"><td>&nbsp;</td><td>&nbsp;</td></tr>
+<tr><td class="author-text">&nbsp;</td>
+<td class="author-text">Gary Court</td></tr>
+<tr><td class="author-text">&nbsp;</td>
+<td class="author-text">Calgary, AB</td></tr>
+<tr><td class="author-text">&nbsp;</td>
+<td class="author-text">Canada</td></tr>
+<tr><td class="author" align="right">EMail:&nbsp;</td>
+<td class="author-text"><a href="mailto:gary.court@gmail.com">gary.court@gmail.com</a></td></tr>
+</table>
+</body></html>

--- a/draft-04/json-schema-hypermedia.html
+++ b/draft-04/json-schema-hypermedia.html
@@ -1,0 +1,1541 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html lang="en"><head><title>JSON Hyper-Schema: Hypertext definitions for JSON Schema</title>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<meta name="description" content="JSON Hyper-Schema: Hypertext definitions for JSON Schema">
+<meta name="keywords" content="JSON, Schema, JavaScript, Object, Notation, Hyper Schema, Hypermedia">
+<meta name="generator" content="xml2rfc v1.36 (http://xml.resource.org/)">
+<style type='text/css'><!--
+        body {
+                font-family: verdana, charcoal, helvetica, arial, sans-serif;
+                font-size: small; color: #000; background-color: #FFF;
+                margin: 2em;
+        }
+        h1, h2, h3, h4, h5, h6 {
+                font-family: helvetica, monaco, "MS Sans Serif", arial, sans-serif;
+                font-weight: bold; font-style: normal;
+        }
+        h1 { color: #900; background-color: transparent; text-align: right; }
+        h3 { color: #333; background-color: transparent; }
+
+        td.RFCbug {
+                font-size: x-small; text-decoration: none;
+                width: 30px; height: 30px; padding-top: 2px;
+                text-align: justify; vertical-align: middle;
+                background-color: #000;
+        }
+        td.RFCbug span.RFC {
+                font-family: monaco, charcoal, geneva, "MS Sans Serif", helvetica, verdana, sans-serif;
+                font-weight: bold; color: #666;
+        }
+        td.RFCbug span.hotText {
+                font-family: charcoal, monaco, geneva, "MS Sans Serif", helvetica, verdana, sans-serif;
+                font-weight: normal; text-align: center; color: #FFF;
+        }
+
+        table.TOCbug { width: 30px; height: 15px; }
+        td.TOCbug {
+                text-align: center; width: 30px; height: 15px;
+                color: #FFF; background-color: #900;
+        }
+        td.TOCbug a {
+                font-family: monaco, charcoal, geneva, "MS Sans Serif", helvetica, sans-serif;
+                font-weight: bold; font-size: x-small; text-decoration: none;
+                color: #FFF; background-color: transparent;
+        }
+
+        td.header {
+                font-family: arial, helvetica, sans-serif; font-size: x-small;
+                vertical-align: top; width: 33%;
+                color: #FFF; background-color: #666;
+        }
+        td.author { font-weight: bold; font-size: x-small; margin-left: 4em; }
+        td.author-text { font-size: x-small; }
+
+        /* info code from SantaKlauss at http://www.madaboutstyle.com/tooltip2.html */
+        a.info {
+                /* This is the key. */
+                position: relative;
+                z-index: 24;
+                text-decoration: none;
+        }
+        a.info:hover {
+                z-index: 25;
+                color: #FFF; background-color: #900;
+        }
+        a.info span { display: none; }
+        a.info:hover span.info {
+                /* The span will display just on :hover state. */
+                display: block;
+                position: absolute;
+                font-size: smaller;
+                top: 2em; left: -5em; width: 15em;
+                padding: 2px; border: 1px solid #333;
+                color: #900; background-color: #EEE;
+                text-align: left;
+        }
+
+        a { font-weight: bold; }
+        a:link    { color: #900; background-color: transparent; }
+        a:visited { color: #633; background-color: transparent; }
+        a:active  { color: #633; background-color: transparent; }
+
+        p { margin-left: 2em; margin-right: 2em; }
+        p.copyright { font-size: x-small; }
+        p.toc { font-size: small; font-weight: bold; margin-left: 3em; }
+        table.toc { margin: 0 0 0 3em; padding: 0; border: 0; vertical-align: text-top; }
+        td.toc { font-size: small; font-weight: bold; vertical-align: text-top; }
+
+        ol.text { margin-left: 2em; margin-right: 2em; }
+        ul.text { margin-left: 2em; margin-right: 2em; }
+        li      { margin-left: 3em; }
+
+        /* RFC-2629 <spanx>s and <artwork>s. */
+        em     { font-style: italic; }
+        strong { font-weight: bold; }
+        dfn    { font-weight: bold; font-style: normal; }
+        cite   { font-weight: normal; font-style: normal; }
+        tt     { color: #036; }
+        tt, pre, pre dfn, pre em, pre cite, pre span {
+                font-family: "Courier New", Courier, monospace; font-size: small;
+        }
+        pre {
+                text-align: left; padding: 4px;
+                color: #000; background-color: #CCC;
+        }
+        pre dfn  { color: #900; }
+        pre em   { color: #66F; background-color: #FFC; font-weight: normal; }
+        pre .key { color: #33C; font-weight: bold; }
+        pre .id  { color: #900; }
+        pre .str { color: #000; background-color: #CFF; }
+        pre .val { color: #066; }
+        pre .rep { color: #909; }
+        pre .oth { color: #000; background-color: #FCF; }
+        pre .err { background-color: #FCC; }
+
+        /* RFC-2629 <texttable>s. */
+        table.all, table.full, table.headers, table.none {
+                font-size: small; text-align: center; border-width: 2px;
+                vertical-align: top; border-collapse: collapse;
+        }
+        table.all, table.full { border-style: solid; border-color: black; }
+        table.headers, table.none { border-style: none; }
+        th {
+                font-weight: bold; border-color: black;
+                border-width: 2px 2px 3px 2px;
+        }
+        table.all th, table.full th { border-style: solid; }
+        table.headers th { border-style: none none solid none; }
+        table.none th { border-style: none; }
+        table.all td {
+                border-style: solid; border-color: #333;
+                border-width: 1px 2px;
+        }
+        table.full td, table.headers td, table.none td { border-style: none; }
+
+        hr { height: 1px; }
+        hr.insert {
+                width: 80%; border-style: none; border-width: 0;
+                color: #CCC; background-color: #CCC;
+        }
+--></style>
+</head>
+<body>
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<table summary="layout" width="66%" border="0" cellpadding="0" cellspacing="0"><tr><td><table summary="layout" width="100%" border="0" cellpadding="2" cellspacing="1">
+<tr><td class="header">Internet Engineering Task Force</td><td class="header">G. Luff, Ed.</td></tr>
+<tr><td class="header">Internet-Draft</td><td class="header">&nbsp;</td></tr>
+<tr><td class="header">Intended status: Informational</td><td class="header">K. Zyp</td></tr>
+<tr><td class="header">Expires: August 4, 2013</td><td class="header">SitePen (USA)</td></tr>
+<tr><td class="header">&nbsp;</td><td class="header">G. Court</td></tr>
+<tr><td class="header">&nbsp;</td><td class="header">January 31, 2013</td></tr>
+</table></td></tr></table>
+<h1><br />JSON Hyper-Schema: Hypertext definitions for JSON Schema<br />json-schema-hypermedia</h1>
+
+<h3>Abstract</h3>
+
+<p>
+                JSON Schema is a JSON based format for defining the structure of JSON data.
+                This document specifies hyperlink- and hypermedia-related keywords of JSON Schema.
+            
+</p>
+<h3>Status of This Memo</h3>
+<p>
+This Internet-Draft is submitted  in full
+conformance with the provisions of BCP&nbsp;78 and BCP&nbsp;79.</p>
+<p>
+Internet-Drafts are working documents of the Internet Engineering
+Task Force (IETF).  Note that other groups may also distribute
+working documents as Internet-Drafts.  The list of current
+Internet-Drafts is at http://datatracker.ietf.org/drafts/current/.</p>
+<p>
+Internet-Drafts are draft documents valid for a maximum of six months
+and may be updated, replaced, or obsoleted by other documents at any time.
+It is inappropriate to use Internet-Drafts as reference material or to cite
+them other than as &ldquo;work in progress.&rdquo;</p>
+<p>
+This Internet-Draft will expire on August 4, 2013.</p>
+
+<h3>Copyright Notice</h3>
+<p>
+Copyright (c) 2013 IETF Trust and the persons identified as the
+document authors.  All rights reserved.</p>
+<p>
+This document is subject to BCP 78 and the IETF Trust's Legal
+Provisions Relating to IETF Documents
+(http://trustee.ietf.org/license-info) in effect on the date of
+publication of this document.  Please review these documents
+carefully, as they describe your rights and restrictions with respect
+to this document. Code Components extracted from this document must
+include Simplified BSD License text as described in Section 4.e of
+the Trust Legal Provisions and are provided without warranty as
+described in the Simplified BSD License.</p>
+<a name="toc"></a><br /><hr />
+<h3>Table of Contents</h3>
+<p class="toc">
+<a href="#anchor1">1.</a>&nbsp;
+Introduction<br />
+<a href="#anchor2">2.</a>&nbsp;
+Conventions and Terminology<br />
+<a href="#anchor3">3.</a>&nbsp;
+Overview<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor4">3.1.</a>&nbsp;
+Design Considerations<br />
+<a href="#anchor5">4.</a>&nbsp;
+Schema keywords<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor6">4.1.</a>&nbsp;
+links<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor7">4.1.1.</a>&nbsp;
+Multiple links per URI<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor8">4.2.</a>&nbsp;
+fragmentResolution<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor9">4.2.1.</a>&nbsp;
+json-pointer fragment resolution<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor10">4.3.</a>&nbsp;
+media<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor11">4.3.1.</a>&nbsp;
+Properties of &quot;media&quot;<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor14">4.3.2.</a>&nbsp;
+Example<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor15">4.4.</a>&nbsp;
+readOnly<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor16">4.5.</a>&nbsp;
+pathStart<br />
+<a href="#anchor17">5.</a>&nbsp;
+Link Description Object<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#href">5.1.</a>&nbsp;
+href<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor18">5.1.1.</a>&nbsp;
+URI Templating<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor27">5.2.</a>&nbsp;
+rel<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor28">5.2.1.</a>&nbsp;
+Fragment resolution with &quot;root&quot; links<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor29">5.2.2.</a>&nbsp;
+Security Considerations for &quot;self&quot; links<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor30">5.3.</a>&nbsp;
+title<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor31">5.4.</a>&nbsp;
+targetSchema<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor32">5.4.1.</a>&nbsp;
+Security Considerations for &quot;targetSchema&quot;<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor33">5.5.</a>&nbsp;
+mediaType<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor34">5.5.1.</a>&nbsp;
+Security concerns for &quot;mediaType&quot;<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor35">5.6.</a>&nbsp;
+Submission Link Properties<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor36">5.6.1.</a>&nbsp;
+method<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor37">5.6.2.</a>&nbsp;
+encType<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor38">5.6.3.</a>&nbsp;
+schema<br />
+<a href="#anchor39">6.</a>&nbsp;
+IANA Considerations<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor40">6.1.</a>&nbsp;
+Registry of Link Relations<br />
+<a href="#rfc.references1">7.</a>&nbsp;
+References<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#rfc.references1">7.1.</a>&nbsp;
+Normative References<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#rfc.references2">7.2.</a>&nbsp;
+Informative References<br />
+<a href="#anchor43">Appendix&nbsp;A.</a>&nbsp;
+Change Log<br />
+</p>
+<br clear="all" />
+
+<a name="anchor1"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.1"></a><h3>1.&nbsp;
+Introduction</h3>
+
+<p>
+                JSON Schema is a JSON based format for defining the structure of JSON data.
+                This document specifies hyperlink- and hypermedia-related keywords of JSON Schema.
+            
+</p>
+<p>
+                The term JSON Hyper-Schema is used to refer to a JSON Schema that uses these keywords.
+            
+</p>
+<p>
+                This specification will use the terminology defined by the JSON Schema core
+                specification. It is advised that readers have a copy of this specification.
+            
+</p>
+<a name="anchor2"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.2"></a><h3>2.&nbsp;
+Conventions and Terminology</h3>
+
+<p>
+                
+
+                The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+                "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
+                interpreted as described in <a class='info' href='#RFC2119'>RFC 2119<span> (</span><span class='info'>Bradner, S., &ldquo;Key words for use in RFCs to Indicate Requirement Levels,&rdquo; March&nbsp;1997.</span><span>)</span></a> [RFC2119].
+            
+</p>
+<p>
+                The terms "schema", "instance", "property" and "item" are to be interpreted as defined in the JSON Schema core definition [FIXME_LINK].
+            
+</p>
+<a name="anchor3"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3"></a><h3>3.&nbsp;
+Overview</h3>
+
+<p>
+                This document describes how JSON Schema can be used to define hyperlinks on instance data.  It also defines how to provide additional information required to interpret JSON data as rich multimedia documents.
+            
+</p>
+<p>
+                Just as with the core JSON schema keywords, all the keywords described in the "Schema Keywords" section are optional.
+            
+</p>
+<p>Here is an example JSON Schema defining hyperlinks, and providing a multimedia interpretation for the "imgData" property:
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+
+{
+    "title": "Written Article",
+    "type": "object",
+    "properties": {
+        "id": {
+            "title": "Article Identifier",
+            "type": "number"
+        },
+        "title": {
+            "title": "Article Title",
+            "type": "string"
+        },
+        "authorId": {
+            "type": "integer"
+        },
+        "imgData": {
+            "title": "Article Illustration (small)",
+            "type": "string",
+            "media": {
+                "binaryEncoding": "base64",
+                "type": "image/png"
+            }
+        }
+    },
+    "required" : ["id", "title", "authorId"],
+    "links": [
+        {
+            "rel": "full",
+            "href": "{id}"
+        },
+        {
+            "rel": "author",
+            "href": "/user?id={authorId}"
+        }
+    ]
+}
+
+</pre></div>
+<p>
+                    This example schema defines the properties of the instance.
+                    For the "imgData" property, it specifies that that it should be base64-decoded and the resulting binary data treated as a PNG image.
+                    It also defines link relations for the instance, with URIs incorporating values from the instance.
+                
+</p>
+<p>An example of a JSON instance described by the above schema might be:
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+
+{
+    "id": 15,
+    "title": "Example data",
+    "authorId": 105,
+    "imgData": "iVBORw...kJggg=="
+}
+
+</pre></div>
+<p>The base-64 data has been abbreviated for readability.
+</p>
+<a name="anchor4"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.1"></a><h3>3.1.&nbsp;
+Design Considerations</h3>
+
+<p>
+                    The purpose of this document is to define keywords for the JSON Schema that allow JSON data to be understood as hyper-text.
+                
+</p>
+<p>
+                    JSON data on its own requires special knowledge from the client about the format in order to be interpretable as hyper-text.
+                    This document proposes a way to describe the hyper-text and hyper-media interpretation of such JSON formats, without defining reserved keywords or otherwise restricting the structure of the JSON data.
+                
+</p>
+<a name="anchor5"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.4"></a><h3>4.&nbsp;
+Schema keywords</h3>
+
+<a name="anchor6"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.4.1"></a><h3>4.1.&nbsp;
+links</h3>
+
+<p>
+                    The "links" property of schemas is used to associate Link Description Objects with instances.  The value of this property MUST be an array, and the items in the array must be Link Description Objects, as defined below.
+                
+</p>
+<p>An example schema using the "links" keyword could be:
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+{
+    "title": "Schema defining links",
+    "links": [
+        {
+            "rel": "full",
+            "href": "{id}"
+        },
+        {
+            "rel": "parent",
+            "href": "{parent}"
+        }
+    ]
+}
+</pre></div>
+<a name="anchor7"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.4.1.1"></a><h3>4.1.1.&nbsp;
+Multiple links per URI</h3>
+
+<p>
+                        A single URI might have more than one role with relation to an instance.  This is not a problem - the same URI can be used in more than one Link Description Object.
+                    
+</p>
+<p>
+                            For example, this schema describes a format for blog posts, accessed via HTTP.
+                            The links describe how to access the comments for the post, how to search the comments, and how to submit new comments, all with the same URI:
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+{
+    "title": "News post",
+    ...
+    "links": [
+        {
+            "rel": "comments",
+            "href": "/{id}/comments"
+        },
+        {
+            "rel": "search",
+            "href": "/{id}/comments",
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "searchTerm": {
+                        "type": "string"
+                    },
+                    "itemsPerPage": {
+                        "type": "integer",
+                        "minimum": 10,
+                        "multipleOf": 10,
+                        "default": 20
+                    }
+                },
+                "required": ["searchTerm"]
+            }
+        },
+        {
+            "title": "Post a comment",
+            "rel": "create",
+            "href": "/{id}/comments",
+            "method": "POST",
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "message": {
+                        "type": "string"
+                    }
+                },
+                "required": ["message"]
+            }
+        }
+    ]
+}
+</pre></div>
+<p>
+                        If the client follows the first link, the URI might be expanded to "/15/comments".
+                        For the second link, the method is "GET" (the default for HTTP) so a client following this link would add the parameters to the URL to produce something like: "/15/comments?searchTerm=JSON&amp;itemsPerPage=50".
+                        The third link defines a possible interaction where a client would POST to a URI (such as "/15/comments"), where the post-data was a JSON representation of the new comment, for example:
+                    
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+{
+    "message": "This is an example comment"
+}
+</pre></div>
+<a name="anchor8"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.4.2"></a><h3>4.2.&nbsp;
+fragmentResolution</h3>
+
+<p>
+                    When addressing a JSON document, the fragment part of the URI may be used to refer to a particular instance within the document.
+                
+</p>
+<p>
+                    This keyword indicates the method to use for finding the appropriate instance within a document, given the fragment part.
+                    The default fragment resolution protocol is "json-pointer", which is defined below.
+                    Other fragment resolution protocols MAY be used, but are not defined in this document.
+                
+</p>
+<p>
+                    If the instance is described by a schema providing the a link with "root" relation, or such a link is provided in using the <a class='info' href='#RFC5988'>HTTP Link header<span> (</span><span class='info'>Nottingham, M., &ldquo;Web Linking,&rdquo; October&nbsp;2010.</span><span>)</span></a> [RFC5988], then the target of the "root" link should be considered the document root for the purposes of all fragment resolution methods that use the document structure (such as "json-pointer").
+                    The only exception to this is the resolution of "root" links themselves.
+                
+</p>
+<a name="anchor9"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.4.2.1"></a><h3>4.2.1.&nbsp;
+json-pointer fragment resolution</h3>
+
+<p>
+                        The "json-pointer" fragment resolution protocol uses a <a class='info' href='#json-pointer'>JSON Pointer<span> (</span><span class='info'>Bryan, P. and K. Zyp, &ldquo;JSON Pointer,&rdquo; October&nbsp;2011.</span><span>)</span></a> [json&#8209;pointer] to resolve fragment identifiers in URIs within instance representations.
+                    
+</p>
+<a name="anchor10"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.4.3"></a><h3>4.3.&nbsp;
+media</h3>
+
+<p>
+                    The "media" property indicates that this instance contains non-JSON data encoded in a JSON string.  It describes the type of content and how it is encoded.
+                
+</p>
+<p>
+                    The value of this property MUST be an object, and SHOULD be ignored for any instance that is not a string.
+                
+</p>
+<a name="anchor11"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.4.3.1"></a><h3>4.3.1.&nbsp;
+Properties of &quot;media&quot;</h3>
+
+<p>
+                        The value of the "media" keyword MAY contain any of the following properties:
+                    
+</p>
+<a name="anchor12"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.4.3.1.1"></a><h3>4.3.1.1.&nbsp;
+binaryEncoding</h3>
+
+<p>
+                            If the instance value is a string, this property defines that the string SHOULD be interpreted as binary data and decoded using the encoding named by this property.
+                            <a class='info' href='#RFC2045'>RFC 2045, Sec 6.1<span> (</span><span class='info'>Freed, N. and N. Borenstein, &ldquo;Multipurpose Internet Mail Extensions (MIME) Part One: Format of Internet Message Bodies,&rdquo; November&nbsp;1996.</span><span>)</span></a> [RFC2045] lists the possible values for this property.
+                        
+</p>
+<a name="anchor13"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.4.3.1.2"></a><h3>4.3.1.2.&nbsp;
+type</h3>
+
+<p>
+                            The value of this property must be a media type, as defined by <a class='info' href='#RFC2046'>RFC 2046<span> (</span><span class='info'>Freed, N. and N. Borenstein, &ldquo;Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types,&rdquo; November&nbsp;1996.</span><span>)</span></a> [RFC2046].
+                            This property defines the media type of instances which this schema defines.
+                        
+</p>
+<p>
+                            If the "binaryEncoding" property is not set, but the instance value is a string, then the value of this property SHOULD specify a text document type, and the character set SHOULD be the character set into which the JSON string value was decoded (for which the default is Unicode).
+                        
+</p>
+<a name="anchor14"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.4.3.2"></a><h3>4.3.2.&nbsp;
+Example</h3>
+
+<p>Here is an example schema, illustrating the use of "media":
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+
+{
+    "type": "string",
+    "media": {
+        "binaryEncoding": "base64",
+        "type": "image/png"
+    }
+}
+
+</pre></div>
+<p>Instances described by this schema should be strings, and their values should be interpretable as base64-encoded PNG images.
+</p>
+<p>Another example:
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+
+{
+    "type": "string",
+    "media": {
+        "mediaType": "text/html"
+    }
+}
+
+</pre></div>
+<p>Instances described by this schema should be strings containing HTML, using whatever character set the JSON string was decoded into (default is Unicode).
+</p>
+<a name="anchor15"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.4.4"></a><h3>4.4.&nbsp;
+readOnly</h3>
+
+<p>
+                    If it has a value of boolean true, this keyword indicates that the instance property SHOULD NOT be changed, and attempts by a user agent to modify the value of this property are expected to be rejected by a server.
+                
+</p>
+<p>
+                    The value of this keyword MUST be a boolean.
+                    The default value is false.
+                
+</p>
+<a name="anchor16"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.4.5"></a><h3>4.5.&nbsp;
+pathStart</h3>
+
+<p>
+                    This property is a URI that defines what the instance's URI MUST start with in order to validate.
+                    The value of the "pathStart" property MUST be resolved relative to the closest URI Resolution Scope (as defined in the core specification [FIXME link]), using the rules from <a class='info' href='#RFC3986'>RFC 3986, Sec 5<span> (</span><span class='info'>Berners-Lee, T., Fielding, R., and L. Masinter, &ldquo;Uniform Resource Identifier (URI): Generic Syntax,&rdquo; January&nbsp;2005.</span><span>)</span></a> [RFC3986].
+                
+</p>
+<p>
+                    When multiple schemas have been referenced for an instance, the user agent can determine if this schema is applicable for a particular instance by determining if the URI of the instance begins with the the value of the "pathStart" property.
+                    If the URI of the instance does not start with this URI, or if another schema specifies a starting URI that is longer and also matches the instance, this schema SHOULD NOT be considered to describe the instance.
+                    Any schema that does not have a pathStart property SHOULD be considered applicable to all the instances for which it is referenced.
+                
+</p>
+<a name="anchor17"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5"></a><h3>5.&nbsp;
+Link Description Object</h3>
+
+<p>
+                A Link Description Object (LDO) is used to describe a single link relation.
+                In the context of a schema, it defines the link relations of the instances of the schema, and can be parameterized by the instance values.
+                A Link Description Object (LDO) must be an object.
+            
+</p>
+<p>
+                The link description format can be used without JSON Schema, and use of this format can be declared by referencing the normative link description schema as the schema for the data structure that uses the links.
+                The URI of the normative link description schema is: <a href='http://json-schema.org/links'>http://json-schema.org/links</a> (latest version) or <a href='http://json-schema.org/draft-04/links'>http://json-schema.org/draft-04/links</a> (draft-04 version).
+            
+</p>
+<p>
+                "Form"-like functionality can be defined by use of the "schema" keyword, which supplies a schema describing the data to supply to the server.
+            
+</p>
+<a name="href"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.1"></a><h3>5.1.&nbsp;
+href</h3>
+
+<p>
+                    The value of the "href" link description property is a template used to determine the target URI of the related resource.
+                    The value of the instance property SHOULD be resolved as a URI-Reference per <a class='info' href='#RFC3986'>RFC 3986<span> (</span><span class='info'>Berners-Lee, T., Fielding, R., and L. Masinter, &ldquo;Uniform Resource Identifier (URI): Generic Syntax,&rdquo; January&nbsp;2005.</span><span>)</span></a> [RFC3986] and MAY be a relative reference to a URI.
+                    The base URI to be used for relative URI resolution SHOULD be the URI used to retrieve the instance object (not the schema).
+                
+</p>
+<p>
+                    The base URI to be used for relative URI resolution SHOULD is defined as follows:
+                    </p>
+<blockquote class="text">
+<p>if the data has a link defined, with a relation of "self", then the "href" value of that link is used, unless the relation of the link being resolved is also "self"
+</p>
+<p>otherwise, the URI should be resolved against the link with relation "self" belonging to the closest parent node in the JSON document, if it exists
+</p>
+<p>otherwise, the URI used to fetch the document should be used.
+</p>
+</blockquote><p>
+                
+</p>
+<p>This property is not optional.
+</p>
+<a name="anchor18"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.1.1"></a><h3>5.1.1.&nbsp;
+URI Templating</h3>
+
+<p>
+                        The value of "href" is to be used as a URI Template, as defined in <a class='info' href='#RFC6570'>RFC 6570<span> (</span><span class='info'>Gregorio, J., Fielding, R., Hadley, M., Nottingham, M., and D. Orchard, &ldquo;URI Template,&rdquo; March&nbsp;2012.</span><span>)</span></a> [RFC6570].  However, some special considerations apply:
+                    
+</p>
+<a name="anchor19"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.1.1.1"></a><h3>5.1.1.1.&nbsp;
+Pre-processing</h3>
+
+<p>
+                            The <a class='info' href='#RFC6570'>URI Template specification<span> (</span><span class='info'>Gregorio, J., Fielding, R., Hadley, M., Nottingham, M., and D. Orchard, &ldquo;URI Template,&rdquo; March&nbsp;2012.</span><span>)</span></a> [RFC6570] restricts the set of characters available for variable names.
+                            Property names in JSON, however, can be any UTF-8 string.
+                        
+</p>
+<p>
+                            To allow the use of any JSON property name in the template, before using the value of "href" as a URI Template, the following pre-processing rules MUST be applied, in order:
+                        
+</p>
+<a name="anchor20"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.1.1.1.1"></a><h3>5.1.1.1.1.&nbsp;
+Bracket escaping</h3>
+
+<p>
+                                The purpose of this step is to allow the use of brackets to percent-encode variable names inside curly brackets.
+                                Variable names to be escaped are enclosed within rounded brackets, with the close-rounded-bracket character ")" being escaped as a pair of close-rounded-brackets "))".
+                                Since the empty string is not a valid variable name in RFC 6570, an empty pair of brackets is replaced with "%65mpty".
+                            
+</p>
+<p>
+                                The rules are as follows:
+                            
+</p>
+<p>
+                                Find the largest possible sections of the text such that:
+                                </p>
+<blockquote class="text">
+<p>do not contain an odd number of close-rounded-bracket characters ")" in sequence in that section of the text
+</p>
+<p>are surrounded by a pair of rounded brackets: ( ), where
+</p>
+<p>the surrounding rounded brackets are themselves contained within a pair of curly brackets: { }
+</p>
+</blockquote><p>
+                            
+</p>
+<p>
+                                Each of these sections of the text (including the surrounding rounded brackets) MUST be replaced, according to the following rules:
+                                </p>
+<blockquote class="text">
+<p>If the brackets contained no text (the empty string), then they are replaced with "%65mpty" (which is "empty" with a percent-encoded "e")
+</p>
+<p>Otherwise, the enclosing brackets are removed, and the inner text used after the following modifications
+                                        </p>
+<blockquote class="text">
+<p>all pairs of close-brackets "))" are replaced with a single close bracket
+</p>
+<p>after that, the text is replaced with its percent-encoded equivalent, such that the result is a valid RFC 6570 variable name (note that this requires encoding characters such as "*" and "!")
+</p>
+</blockquote>
+                                    
+
+</blockquote><p>
+                            
+</p>
+<a name="anchor21"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.1.1.1.2"></a><h3>5.1.1.1.2.&nbsp;
+Replacing $</h3>
+
+<p>
+                                After the above substitutions, if the character "$" (dollar sign) appears within a pair of curly brackets, then it MUST be replaced with the text "%73elf" (which is "self" with a percent-encoded "s").
+                            
+</p>
+<p>
+                                The purpose of this stage is to allow the use of the instance value itself (instead of its object properties or array items) in the URI Template, by the special value "%73elf".
+                            
+</p>
+<a name="anchor22"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.1.1.1.3"></a><h3>5.1.1.1.3.&nbsp;
+Choice of special-case values</h3>
+
+<p>
+                                The special-case values of "%73elf" and "%65mpty" were chosen because they are unlikely to be accidentally generated by either a human or automated escaping.
+                            
+</p>
+<a name="anchor23"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.1.1.1.4"></a><h3>5.1.1.1.4.&nbsp;
+Examples</h3>
+
+<p>
+                                
+<p>For example, here are some possible values for "href", followed by the results after pre-processing:
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+
+Input                    Output
+-----------------------------------------
+"no change"              "no change"
+"(no change)"            "(no change)"
+"{(escape space)}"       "{escape%20space}"
+"{(escape+plus)}"        "{escape%2Bplus}"
+"{(escape*asterisk)}"    "{escape%2Aasterisk}"
+"{(escape(bracket)}"     "{escape%28bracket}"
+"{(escape))bracket)}"    "{escape%29bracket}"
+"{(a))b)}"             "{a%29b}
+"{(a (b)))}"             "{a%20%28b%29}
+"{()}"                   "{%65mpty}
+"{+$*}"                   "{+%73elf*}
+"{+($)*}"                 "{+%24*}
+
+</pre></div>
+<p>
+                                        Note that in the final example, because the "+" was outside the brackets, it remained unescaped, whereas in the fourth example the "+" was escaped.
+                                    
+</p>
+                            
+
+<a name="anchor24"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.1.1.2"></a><h3>5.1.1.2.&nbsp;
+Values for substitution</h3>
+
+<p>
+                            After pre-processing, the URI Template is filled out using data from the instance.
+                            To allow the use of any object property (including the empty string), array index, or the instance value itself, the following rules are defined:
+                        
+</p>
+<p>
+                            For a given variable name in the URI Template, the value to use is determined as follows:
+                            </p>
+<blockquote class="text">
+<p>If the variable name is "%73elf", then the instance value itself MUST be used.
+</p>
+<p>If the variable name is "%65mpty", then the instances's empty-string ("") property MUST be used (if it exists).
+</p>
+<p>If the instance is an array, and the variable name is a representation of a non-negative integer, then the value at the corresponding array index MUST be used (if it exists).
+</p>
+<p>Otherwise, the variable name should be percent-decoded, and the corresponding object property MUST be used (if it exists).
+</p>
+</blockquote><p>
+                        
+</p>
+<a name="anchor25"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.1.1.2.1"></a><h3>5.1.1.2.1.&nbsp;
+Converting to strings</h3>
+
+<p>
+                                When any value referenced by the URI template is null, a boolean or a number, then it should first be converted into a string as follows:
+                                </p>
+<blockquote class="text">
+<p>null values SHOULD be replaced by the text "null"
+</p>
+<p>boolean values SHOULD be replaced by their lower-case equivalents: "true" or "false"
+</p>
+<p>numbers SHOULD be replaced with their original JSON representation.
+</p>
+</blockquote><p>
+                            
+</p>
+<p>
+                                In some software environments the original JSON representation of a number will not be available (there is no way to tell the difference between 1.0 and 1), so any reasonable representation should be used.
+                                Schema and API authors should bear this in mind, and use other types (such as string or boolean) if the exact representation is important.
+                            
+</p>
+<a name="anchor26"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.1.1.3"></a><h3>5.1.1.3.&nbsp;
+Missing values</h3>
+
+<p>
+                            Sometimes, the appropriate values will not be available.
+                            For example, the template might specify the use of object properties, but the instance is an array or a string.
+                        
+</p>
+<p>
+                            If any of the values required for the template are not present in the JSON instance, then substitute values MAY be provided from another source (such as default values).
+                            Otherwise, the link definition SHOULD be considered not to apply to the instance.
+                        
+</p>
+<a name="anchor27"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.2"></a><h3>5.2.&nbsp;
+rel</h3>
+
+<p>
+                    The value of the "rel" property indicates the name of the relation to the target resource.
+                    This property is not optional.
+                
+</p>
+<p>
+                    The relation to the target SHOULD be interpreted as specifically from the instance object that the schema (or sub-schema) applies to, not just the top level resource that contains the object within its hierarchy.
+                    A link relation from the top level resource to a target MUST be indicated with the schema describing the top level JSON representation.
+                
+</p>
+<p>
+                    Relationship definitions SHOULD NOT be media type dependent, and users are encouraged to utilize existing accepted relation definitions, including those in existing relation registries (see <a class='info' href='#RFC4287'>RFC 4287<span> (</span><span class='info'>Nottingham, M., Ed. and R. Sayre, Ed., &ldquo;The Atom Syndication Format,&rdquo; December&nbsp;2005.</span><span>)</span></a> [RFC4287]).
+                    However, we define these relations here for clarity of normative interpretation within the context of JSON Schema defined relations:
+
+                    </p>
+<blockquote class="text"><dl>
+<dt>self</dt>
+<dd>
+                            If the relation value is "self", when this property is encountered in the instance object, the object represents a resource and the instance object is treated as a full representation of the target resource identified by the specified URI.
+                        
+</dd>
+<dt>full</dt>
+<dd>
+                            This indicates that the target of the link is the full representation for the instance object.
+                            The instance that contains this link may not be the full representation.
+                        
+</dd>
+<dt>describedBy</dt>
+<dd>
+                            This indicates the target of the link is a schema describing the instance object.
+                            This MAY be used to specifically denote the schemas of objects within a JSON object hierarchy, facilitating polymorphic type data structures.
+                        
+</dd>
+<dt>root</dt>
+<dd>
+                            This relation indicates that the target of the link SHOULD be treated as the root or the body of the representation for the purposes of user agent interaction or fragment resolution.
+                            All other data in the document can be regarded as meta-data for the document.
+                            The URI of this link MUST refer to a location within the instance document, otherwise the link MUST be ignored.
+                        
+</dd>
+</dl></blockquote><p>
+                
+</p>
+<p>
+                    The following relations are applicable for schemas (the schema as the "from" resource in the relation):
+
+                    </p>
+<blockquote class="text"><dl>
+<dt>instances</dt>
+<dd>
+                            This indicates the target resource that represents a collection of instances of a schema.
+                        
+</dd>
+<dt>create</dt>
+<dd>
+                            This indicates a target to use for creating new instances of a schema.
+                            This link definition SHOULD be a submission link with a non-safe method (like POST).
+                        
+</dd>
+</dl></blockquote><p>
+                    
+                    Links defined in the schema using these relation values SHOULD not require parameterization with data from the instance, as they describe a link for the schema, not the instances.
+                
+</p>
+<p>For example, if a schema is defined:
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+{
+    "links": [{
+        "rel": "self",
+        "href": "{id}"
+    }, {
+        "rel": "up",
+        "href": "{upId}"
+    }, {
+        "rel": "children",
+        "href": "?upId={id}"
+    }]
+}
+</pre></div>
+<p>And if a collection of instance resources were retrieved with JSON representation:
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+GET /Resource/
+
+[{
+    "id": "thing",
+    "upId": "parent"
+}, {
+    "id": "thing2",
+    "upId": "parent"
+}]
+</pre></div>
+<p>
+                        This would indicate that for the first item in the collection, its own (self) URI would resolve to "/Resource/thing" and the first item's "up" relation SHOULD be resolved to the resource at "/Resource/parent".
+                        The "children" collection would be located at "/Resource/?upId=thing".
+                    
+</p>
+<p>
+                    Note that these relationship values are case-insensitive, consistent with their use in HTML and the <a class='info' href='#RFC5988'>HTTP Link header<span> (</span><span class='info'>Nottingham, M., &ldquo;Web Linking,&rdquo; October&nbsp;2010.</span><span>)</span></a> [RFC5988].
+                
+</p>
+<a name="anchor28"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.2.1"></a><h3>5.2.1.&nbsp;
+Fragment resolution with &quot;root&quot; links</h3>
+
+<p>
+                        The presence of a link with relation "root" alters what the root of the document is considered to be.
+                        For fragment resolution methods (such as JSON Pointer fragments) that navigate through the document, the target of the "root" link should be the starting point for such methods.
+                    
+</p>
+<p>
+                        The only exception is "root" links themselves.
+                        When calculating the target of links with relation "root", existing "root" links MUST NOT be taken into consideration.
+                    
+</p>
+<p>
+                        
+<p>For example, say we have the following schema:
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+{
+    "links": [{
+        "rel": "root",
+        "href": "#/myRootData"
+    }]
+}
+</pre></div>
+                    
+
+<p>
+                        
+<p>And the following data, returned from the URI: "http://example.com/data/12345":
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+{
+    "myRootData": {
+        "title": "Document title"
+    },
+    "metaData": {
+        ...
+    }
+}
+</pre></div>
+                    
+
+<p>
+                        To correctly resolve the URL "http://example.com/data/12345", we must take the "root" link into account.  Here are some example URIs, along with the data they would resolve to:
+                        </p>
+<div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+
+URI                                         Data
+-----------------------------------------------------------------------
+http://example.com/data/12345               {"title": "Document title"}
+http://example.com/data/12345#/title        "Document title"
+
+</pre></div><p>
+
+                    
+</p>
+<a name="anchor29"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.2.2"></a><h3>5.2.2.&nbsp;
+Security Considerations for &quot;self&quot; links</h3>
+
+<p>
+                        When link relation of "self" is used to denote a full representation of an object, the user agent SHOULD NOT consider the representation to be the authoritative representation of the resource denoted by the target URI if the target URI is not equivalent to or a sub-path of the the URI used to request the resource representation which contains the target URI with the "self" link.
+        
+                        
+<p>For example, if a hyper schema was defined:
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+{
+    "links": [{
+        "rel": "self",
+        "href": "{id}"
+    }]
+}
+</pre></div>
+        
+                        
+<p>And a resource was requested from somesite.com:
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+
+GET /foo/
+
+</pre></div>
+        
+                        
+<p>With a response of:
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+Content-Type: application/json; profile=/schema-for-this-data
+
+[{
+    "id": "bar",
+    "name": "This representation can be safely treated \
+        as authoritative "
+}, {
+    "id": "/baz",
+    "name": "This representation should not be treated as \
+        authoritative the user agent should make request the resource\
+        from '/baz' to ensure it has the authoritative representation"
+}, {
+    "id": "http://othersite.com/something",
+    "name": "This representation\
+        should also not be treated as authoritative and the target\
+        resource representation should be retrieved for the\
+        authoritative representation"
+}]
+</pre></div>
+                    
+
+<a name="anchor30"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.3"></a><h3>5.3.&nbsp;
+title</h3>
+
+<p>
+                    This property defines a title for the link.
+                    The value must be a string.
+                
+</p>
+<p>
+                    User agents MAY use this title when presenting the link to the user.
+                
+</p>
+<a name="anchor31"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.4"></a><h3>5.4.&nbsp;
+targetSchema</h3>
+
+<p>
+                    This property value is advisory only, and is a schema that defines the expected structure of the JSON representation of the target of the link, if the target of the link is returned using JSON representation.
+                
+</p>
+<a name="anchor32"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.4.1"></a><h3>5.4.1.&nbsp;
+Security Considerations for &quot;targetSchema&quot;</h3>
+
+<p>
+                        This property has similar security concerns to that of "mediaType".
+                        Clients MUST NOT use the value of this property to aid in the interpretation of the data received in response to following the link, as this leaves "safe" data open to re-interpretation.
+                    
+</p>
+<p>
+                        
+<p>
+                                For example, suppose two programmers are having a discussion about web security using a text-only message board.
+                                Here is some data from that conversation, with a URI of: http://forum.example.com/topics/152/comments/13
+                            
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+{
+    "topicId": 152,
+    "commentId": 13,
+    "from": {
+        "name": "Jane",
+        "id": 5
+    },
+    "to": {
+        "name": "Jason",
+        "id": 8
+    },
+    "message": "It's easy, you just add some HTML like this: &lt;script&gt;doSomethingEvil()&lt;/script&gt;"
+}
+</pre></div>
+                    
+
+<p>
+                        A third party might then write provide the following Link Description Object at another location:
+                        </p>
+<div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+{
+    "rel": "evil-attack",
+    "href": "http://forum.example.com/topics/152/comments/13",
+    "targetSchema": {
+        "properties": {
+            "message": {
+                "description": "Re-interpret the message text as HTML",
+                "media": {
+                    "type": "text/html"
+                }
+            }
+        }
+    }
+}
+</pre></div><p>
+
+<p>
+                                If the client used this "targetSchema" value when interpreting the above data, then it might display the contents of "message" as HTML.
+                                At this point, the JavaScript embedded in the message might be executed (in the context of the "forum.example.com" domain).
+                            
+</p>
+                    
+
+<a name="anchor33"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.5"></a><h3>5.5.&nbsp;
+mediaType</h3>
+
+<p>
+                    The value of this property is advisory only, and represents the media type <a class='info' href='#RFC2046'>RFC 2046<span> (</span><span class='info'>Freed, N. and N. Borenstein, &ldquo;Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types,&rdquo; November&nbsp;1996.</span><span>)</span></a> [RFC2046], that is expected to be returned when fetching this resource.
+                    This property value MAY be a media range instead, using the same pattern defined in <a class='info' href='#RFC2616'>RFC 2161, section 14.1 - HTTP "Accept" header<span> (</span><span class='info'>Fielding, R., Gettys, J., Mogul, J., Frystyk, H., Masinter, L., Leach, P., and T. Berners-Lee, &ldquo;Hypertext Transfer Protocol -- HTTP/1.1,&rdquo; June&nbsp;1999.</span><span>)</span></a> [RFC2616].
+                
+</p>
+<p>
+                    This property is analogous to the "type" property of &lt;a&gt; elements in HTML (advisory content type), or the "type" parameter in the <a class='info' href='#RFC5988'>HTTP Link header<span> (</span><span class='info'>Nottingham, M., &ldquo;Web Linking,&rdquo; October&nbsp;2010.</span><span>)</span></a> [RFC5988].
+                    User agents MAY use this information to inform the interface they present to the user before the link is followed, but this information MUST NOT use this information in the interpretation of the resulting data.
+                    When deciding how to interpret data obtained through following this link, the behaviour of user agents MUST be identical regardless of the value of the this property.
+                
+</p>
+<p>
+                    If this property's value is specified, and the link's target is to be obtained using any protocol that supports the HTTP/1.1 "Accept" header <a class='info' href='#RFC2616'>RFC 2616, section 14.1<span> (</span><span class='info'>Fielding, R., Gettys, J., Mogul, J., Frystyk, H., Masinter, L., Leach, P., and T. Berners-Lee, &ldquo;Hypertext Transfer Protocol -- HTTP/1.1,&rdquo; June&nbsp;1999.</span><span>)</span></a> [RFC2616], then user agents MAY use the value of this property to aid in the assembly of that header when making the request to the server.
+                
+</p>
+<p>
+                    If this property's value is not specified, then the value should be taken to be "application/json".
+                
+</p>
+<p>For example, if a schema is defined:
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+
+{
+    "links": [{
+        "rel": "self",
+        "href": "/{id}/json"
+    }, {
+        "rel": "alternate",
+        "href": "/{id}/html",
+        "mediaType": "text/html"
+    }, {
+        "rel": "alternate",
+        "href": "/{id}/rss",
+        "mediaType": "application/rss+xml"
+    }, {
+        "rel": "icon",
+        "href": "{id}/icon",
+        "mediaType": "image/*"
+    }]
+}
+
+</pre></div>
+<p>
+                        A suitable instance described by this schema would have four links defined.
+                        The link with a "rel" value of "self" would have an expected MIME type of "application/json" (the default).
+                        The two links with a "rel" value of "alternate" specify the locations of HTML and RSS versions of the current item.
+                        The link with a "rel" value of "icon" links to an image, but does not specify the exact format.
+                    
+</p>
+<p>
+                    A visual user agent displaying the item from the above example might present a button representing an RSS feed, which when pressed passes the target URI (calculated "href" value) to an view more suited to displaying it, such as a news feed aggregator tab.
+                
+</p>
+<p>
+                    Note that presenting the link in the above manner, or passing the URI to a news feed aggregator view does not constitute interpretation of the data, but an interpretation of the link.
+                    The interpretation of the data itself is performed by the news feed aggregator, which SHOULD reject any data that would not have also been interpreted as a news feed, had it been displayed in the main view.
+                
+</p>
+<a name="anchor34"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.5.1"></a><h3>5.5.1.&nbsp;
+Security concerns for &quot;mediaType&quot;</h3>
+
+<p>
+                        The "mediaType" property in link definitions defines the expected format of the link's target.
+                        However, this is advisory only, and MUST NOT be considered authoritative.
+                    
+</p>
+<p>
+                        When choosing how to interpret data, the type information provided by the server (or inferred from the filename, or any other usual method) MUST be the only consideration, and the "mediaType" property of the link MUST NOT be used.
+                        User agents MAY use this information to determine how they represent the link or where to display it (for example hover-text, opening in a new tab).
+                        If user agents decide to pass the link to an external program, they SHOULD first verify that the data is of a type that would normally be passed to that external program.
+                    
+</p>
+<p>
+                        This is to guard against re-interpretation of "safe" data, similar to the precautions for "targetSchema".
+                    
+</p>
+<a name="anchor35"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.6"></a><h3>5.6.&nbsp;
+Submission Link Properties</h3>
+
+<p>
+                    The following properties also apply to Link Description Objects, and provide functionality analogous to HTML forms, in providing a means for submitting extra (often user supplied) information to send to a server.
+                
+</p>
+<a name="anchor36"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.6.1"></a><h3>5.6.1.&nbsp;
+method</h3>
+
+<p>
+                        This property defines which method can be used to access the target resource.
+                        In an HTTP environment, this might be "GET" or "POST" (or other HTTP methods).
+                    
+</p>
+<p>
+                        Some link relation values imply a set of appropriate HTTP methods to be used for the link.
+                        For example, a client might assume that a link with a relation of "edit" can be used in conjuction with the "PUT" HTTP method.
+                        If the client does not know which methods might be appropriate, then this SHOULD default to "GET".
+                    
+</p>
+<a name="anchor37"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.6.2"></a><h3>5.6.2.&nbsp;
+encType</h3>
+
+<p>
+                        If present, this property indicates a query media type format that the server supports for querying or posting to the collection of instances at the target resource.
+                        The query can be suffixed to the target URI to query the collection with property-based constraints on the resources that SHOULD be returned from the server or used to post data to the resource (depending on the method).
+
+                        
+<p>For example, with the following schema:
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+{
+    "links": [{
+        "encType": "application/x-www-form-urlencoded",
+        "method": "GET",
+        "href": "/Product/",
+        "properties": {
+            "name": {
+                "description": "name of the product"
+            }
+        }
+    }]
+}
+</pre></div>
+<p>This indicates that the client can query the server for instances that have a specific name.
+</p>
+
+                        
+<p>For example:
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+
+/Product/?name=Slinky
+
+</pre></div>
+
+                        If no encType or method is specified, only the single URI specified by the href property is defined.
+                        If the method is POST, "application/json" is the default media type.
+                    
+
+<a name="anchor38"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.6.3"></a><h3>5.6.3.&nbsp;
+schema</h3>
+
+<p>
+                        This property contains a schema which defines the acceptable structure of the submitted request.
+                        For a GET request, this schema would define the properties for the query string and for a POST request, this would define the body.
+                    
+</p>
+<p>
+                        Note that this is separate from the URI templating of "href" (which uses data from the instance, not submitted by the user).
+                        It is also separate from the "targetSchema" property, which provides a schema for the data that the client should expect to be returned when they follow the link.
+                    
+</p>
+<a name="anchor39"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.6"></a><h3>6.&nbsp;
+IANA Considerations</h3>
+
+<a name="anchor40"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.6.1"></a><h3>6.1.&nbsp;
+Registry of Link Relations</h3>
+
+<p>
+                    This registry is maintained by IANA per <a class='info' href='#RFC4287'>RFC 4287<span> (</span><span class='info'>Nottingham, M., Ed. and R. Sayre, Ed., &ldquo;The Atom Syndication Format,&rdquo; December&nbsp;2005.</span><span>)</span></a> [RFC4287] and this specification adds four values: "full", "create", "instances", "root".
+                    New assignments are subject to IESG Approval, as outlined in <a class='info' href='#RFC5226'>RFC 5226<span> (</span><span class='info'>Narten, T. and H. Alvestrand, &ldquo;Guidelines for Writing an IANA Considerations Section in RFCs,&rdquo; May&nbsp;2008.</span><span>)</span></a> [RFC5226].
+                    Requests should be made by email to IANA, which will then forward the request to the IESG, requesting approval.
+                
+</p>
+<a name="rfc.references"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.7"></a><h3>7.&nbsp;
+References</h3>
+
+<a name="rfc.references1"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<h3>7.1.&nbsp;Normative References</h3>
+<table width="99%" border="0">
+<tr><td class="author-text" valign="top"><a name="RFC2045">[RFC2045]</a></td>
+<td class="author-text"><a href="mailto:ned@innosoft.com">Freed, N.</a> and <a href="mailto:nsb@nsb.fv.com">N. Borenstein</a>, &ldquo;<a href="http://tools.ietf.org/html/rfc2045">Multipurpose Internet Mail Extensions (MIME) Part One: Format of Internet Message Bodies</a>,&rdquo; RFC&nbsp;2045, November&nbsp;1996 (<a href="http://www.rfc-editor.org/rfc/rfc2045.txt">TXT</a>).</td></tr>
+<tr><td class="author-text" valign="top"><a name="RFC2119">[RFC2119]</a></td>
+<td class="author-text"><a href="mailto:sob@harvard.edu">Bradner, S.</a>, &ldquo;<a href="http://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>,&rdquo; BCP&nbsp;14, RFC&nbsp;2119, March&nbsp;1997 (<a href="http://www.rfc-editor.org/rfc/rfc2119.txt">TXT</a>, <a href="http://xml.resource.org/public/rfc/html/rfc2119.html">HTML</a>, <a href="http://xml.resource.org/public/rfc/xml/rfc2119.xml">XML</a>).</td></tr>
+<tr><td class="author-text" valign="top"><a name="RFC3986">[RFC3986]</a></td>
+<td class="author-text"><a href="mailto:timbl@w3.org">Berners-Lee, T.</a>, <a href="mailto:fielding@gbiv.com">Fielding, R.</a>, and <a href="mailto:LMM@acm.org">L. Masinter</a>, &ldquo;<a href="http://tools.ietf.org/html/rfc3986">Uniform Resource Identifier (URI): Generic Syntax</a>,&rdquo; STD&nbsp;66, RFC&nbsp;3986, January&nbsp;2005 (<a href="http://www.rfc-editor.org/rfc/rfc3986.txt">TXT</a>, <a href="http://xml.resource.org/public/rfc/html/rfc3986.html">HTML</a>, <a href="http://xml.resource.org/public/rfc/xml/rfc3986.xml">XML</a>).</td></tr>
+<tr><td class="author-text" valign="top"><a name="RFC4287">[RFC4287]</a></td>
+<td class="author-text"><a href="mailto:mnot@pobox.com">Nottingham, M., Ed.</a> and <a href="mailto:rfsayre@boswijck.com">R. Sayre, Ed.</a>, &ldquo;<a href="http://tools.ietf.org/html/rfc4287">The Atom Syndication Format</a>,&rdquo; RFC&nbsp;4287, December&nbsp;2005 (<a href="http://www.rfc-editor.org/rfc/rfc4287.txt">TXT</a>, <a href="http://xml.resource.org/public/rfc/html/rfc4287.html">HTML</a>, <a href="http://xml.resource.org/public/rfc/xml/rfc4287.xml">XML</a>).</td></tr>
+<tr><td class="author-text" valign="top"><a name="RFC6570">[RFC6570]</a></td>
+<td class="author-text">Gregorio, J., Fielding, R., Hadley, M., Nottingham, M., and D. Orchard, &ldquo;<a href="http://tools.ietf.org/html/rfc6570">URI Template</a>,&rdquo; RFC&nbsp;6570, March&nbsp;2012 (<a href="http://www.rfc-editor.org/rfc/rfc6570.txt">TXT</a>).</td></tr>
+<tr><td class="author-text" valign="top"><a name="json-pointer">[json-pointer]</a></td>
+<td class="author-text">Bryan, P. and K. Zyp, &ldquo;<a href="http://tools.ietf.org/html/draft-pbryan-zyp-json-pointer-02">JSON Pointer</a>,&rdquo; October&nbsp;2011.</td></tr>
+</table>
+
+<a name="rfc.references2"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<h3>7.2.&nbsp;Informative References</h3>
+<table width="99%" border="0">
+<tr><td class="author-text" valign="top"><a name="RFC2616">[RFC2616]</a></td>
+<td class="author-text"><a href="mailto:fielding@ics.uci.edu">Fielding, R.</a>, <a href="mailto:jg@w3.org">Gettys, J.</a>, <a href="mailto:mogul@wrl.dec.com">Mogul, J.</a>, <a href="mailto:frystyk@w3.org">Frystyk, H.</a>, <a href="mailto:masinter@parc.xerox.com">Masinter, L.</a>, <a href="mailto:paulle@microsoft.com">Leach, P.</a>, and <a href="mailto:timbl@w3.org">T. Berners-Lee</a>, &ldquo;<a href="http://tools.ietf.org/html/rfc2616">Hypertext Transfer Protocol -- HTTP/1.1</a>,&rdquo; RFC&nbsp;2616, June&nbsp;1999 (<a href="http://www.rfc-editor.org/rfc/rfc2616.txt">TXT</a>, <a href="http://www.rfc-editor.org/rfc/rfc2616.ps">PS</a>, <a href="http://www.rfc-editor.org/rfc/rfc2616.pdf">PDF</a>, <a href="http://xml.resource.org/public/rfc/html/rfc2616.html">HTML</a>, <a href="http://xml.resource.org/public/rfc/xml/rfc2616.xml">XML</a>).</td></tr>
+<tr><td class="author-text" valign="top"><a name="RFC4627">[RFC4627]</a></td>
+<td class="author-text">Crockford, D., &ldquo;<a href="http://tools.ietf.org/html/rfc4627">The application/json Media Type for JavaScript Object Notation (JSON)</a>,&rdquo; RFC&nbsp;4627, July&nbsp;2006 (<a href="http://www.rfc-editor.org/rfc/rfc4627.txt">TXT</a>).</td></tr>
+<tr><td class="author-text" valign="top"><a name="RFC5226">[RFC5226]</a></td>
+<td class="author-text">Narten, T. and H. Alvestrand, &ldquo;<a href="http://tools.ietf.org/html/rfc5226">Guidelines for Writing an IANA Considerations Section in RFCs</a>,&rdquo; BCP&nbsp;26, RFC&nbsp;5226, May&nbsp;2008 (<a href="http://www.rfc-editor.org/rfc/rfc5226.txt">TXT</a>).</td></tr>
+<tr><td class="author-text" valign="top"><a name="RFC2046">[RFC2046]</a></td>
+<td class="author-text"><a href="mailto:ned@innosoft.com">Freed, N.</a> and <a href="mailto:nsb@nsb.fv.com">N. Borenstein</a>, &ldquo;<a href="http://tools.ietf.org/html/rfc2046">Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types</a>,&rdquo; RFC&nbsp;2046, November&nbsp;1996 (<a href="http://www.rfc-editor.org/rfc/rfc2046.txt">TXT</a>).</td></tr>
+<tr><td class="author-text" valign="top"><a name="RFC5988">[RFC5988]</a></td>
+<td class="author-text">Nottingham, M., &ldquo;<a href="http://tools.ietf.org/html/rfc5988">Web Linking</a>,&rdquo; RFC&nbsp;5988, October&nbsp;2010 (<a href="http://www.rfc-editor.org/rfc/rfc5988.txt">TXT</a>).</td></tr>
+<tr><td class="author-text" valign="top"><a name="W3C.REC-html401-19991224">[W3C.REC-html401-19991224]</a></td>
+<td class="author-text">Hors, A., Raggett, D., and I. Jacobs, &ldquo;<a href="http://www.w3.org/TR/1999/REC-html401-19991224">HTML 4.01 Specification</a>,&rdquo; World Wide Web Consortium Recommendation&nbsp;REC-html401-19991224, December&nbsp;1999 (<a href="http://www.w3.org/TR/1999/REC-html401-19991224">HTML</a>).</td></tr>
+</table>
+
+<a name="anchor43"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.A"></a><h3>Appendix A.&nbsp;
+Change Log</h3>
+
+<p>
+                </p>
+<blockquote class="text"><dl>
+<dt>draft-04</dt>
+<dd>
+                        
+<ul class="text">
+<li>Resolution of link URIs ("href") is now affected by rel="self" links on the instance
+</li>
+<li>Define "title" for LDOs
+</li>
+<li>Use URI Templates for the "href" property
+</li>
+<li>Split hyper-schema definition out from main schema.
+</li>
+<li>Removed "readonly"
+</li>
+<li>Capitalised the T in "encType"
+</li>
+<li>Moved "mediaType" and "contentEncoding" to the new "media" property (renamed "type" and "binaryEncoding")
+</li>
+<li>Added "mediaType" property to LDOs
+</li>
+<li>Replaced "slash-delimited" fragment resolution with
+                            "json-pointer".
+</li>
+<li>Added "template" LDO attribute.
+</li>
+<li>Improved wording of sections.
+</li>
+</ul>
+                    
+</dd>
+<dt>draft-03</dt>
+<dd>
+                        
+<ul class="text">
+<li>Added example and verbiage to "extends" attribute.
+</li>
+<li>Defined slash-delimited to use a leading slash.
+</li>
+<li>Made "root" a relation instead of an attribute.
+</li>
+<li>Removed address values, and MIME media type from format to reduce
+                            confusion (mediaType already exists, so it can be used for MIME
+                            types).
+</li>
+<li>Added more explanation of nullability.
+</li>
+<li>Removed "alternate" attribute.
+</li>
+<li>Upper cased many normative usages of must, may, and should.
+</li>
+<li>Replaced the link submission "properties" attribute to "schema"
+                            attribute.
+</li>
+<li>Replaced "optional" attribute with "required" attribute.
+</li>
+<li>Replaced "maximumCanEqual" attribute with "exclusiveMaximum"
+                            attribute.
+</li>
+<li>Replaced "minimumCanEqual" attribute with "exclusiveMinimum"
+                            attribute.
+</li>
+<li>Replaced "requires" attribute with "dependencies" attribute.
+</li>
+<li>Moved "contentEncoding" attribute to hyper schema.
+</li>
+<li>Added "additionalItems" attribute.
+</li>
+<li>Added "id" attribute.
+</li>
+<li>Switched self-referencing variable substitution from "-this" to "@"
+                            to align with reserved characters in URI template.
+</li>
+<li>Added "patternProperties" attribute.
+</li>
+<li>Schema URIs are now namespace versioned.
+</li>
+<li>Added "$ref" and "$schema" attributes.
+</li>
+</ul>
+                    
+</dd>
+<dt>draft-02</dt>
+<dd>
+                        
+<ul class="text">
+<li>Replaced "maxDecimal" attribute with "divisibleBy" attribute.
+</li>
+<li>Added slash-delimited fragment resolution protocol and made it the
+                            default.
+</li>
+<li>Added language about using links outside of schemas by referencing
+                            its normative URI.
+</li>
+<li>Added "uniqueItems" attribute.
+</li>
+<li>Added "targetSchema" attribute to link description object.
+</li>
+</ul>
+                    
+</dd>
+<dt>draft-01</dt>
+<dd>
+                        
+<ul class="text">
+<li>Fixed category and updates from template.
+</li>
+</ul>
+                    
+</dd>
+<dt>draft-00</dt>
+<dd>
+                        
+<ul class="text">
+<li>Initial draft.
+</li>
+</ul>
+                    
+</dd>
+</dl></blockquote><p>
+            
+</p>
+<a name="rfc.authors"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<h3>Authors' Addresses</h3>
+<table width="99%" border="0" cellpadding="0" cellspacing="0">
+<tr><td class="author-text">&nbsp;</td>
+<td class="author-text">Geraint Luff (editor)</td></tr>
+<tr><td class="author-text">&nbsp;</td>
+<td class="author-text">Cambridge</td></tr>
+<tr><td class="author-text">&nbsp;</td>
+<td class="author-text">UK</td></tr>
+<tr><td class="author" align="right">EMail:&nbsp;</td>
+<td class="author-text"><a href="mailto:luffgd@gmail.com">luffgd@gmail.com</a></td></tr>
+<tr cellpadding="3"><td>&nbsp;</td><td>&nbsp;</td></tr>
+<tr><td class="author-text">&nbsp;</td>
+<td class="author-text">Kris Zyp</td></tr>
+<tr><td class="author-text">&nbsp;</td>
+<td class="author-text">SitePen (USA)</td></tr>
+<tr><td class="author-text">&nbsp;</td>
+<td class="author-text">530 Lytton Avenue</td></tr>
+<tr><td class="author-text">&nbsp;</td>
+<td class="author-text">Palo Alto, CA 94301</td></tr>
+<tr><td class="author-text">&nbsp;</td>
+<td class="author-text">USA</td></tr>
+<tr><td class="author" align="right">Phone:&nbsp;</td>
+<td class="author-text">+1 650 968 8787</td></tr>
+<tr><td class="author" align="right">EMail:&nbsp;</td>
+<td class="author-text"><a href="mailto:kris@sitepen.com">kris@sitepen.com</a></td></tr>
+<tr cellpadding="3"><td>&nbsp;</td><td>&nbsp;</td></tr>
+<tr><td class="author-text">&nbsp;</td>
+<td class="author-text">Gary Court</td></tr>
+<tr><td class="author-text">&nbsp;</td>
+<td class="author-text">Calgary, AB</td></tr>
+<tr><td class="author-text">&nbsp;</td>
+<td class="author-text">Canada</td></tr>
+<tr><td class="author" align="right">EMail:&nbsp;</td>
+<td class="author-text"><a href="mailto:gary.court@gmail.com">gary.court@gmail.com</a></td></tr>
+</table>
+</body></html>

--- a/draft-04/json-schema-validation.html
+++ b/draft-04/json-schema-validation.html
@@ -1,0 +1,2117 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html lang="en"><head><title>JSON Schema: interactive and non interactive validation</title>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<meta name="description" content="JSON Schema: interactive and non interactive validation">
+<meta name="keywords" content="JSON, Schema, validation">
+<meta name="generator" content="xml2rfc v1.36 (http://xml.resource.org/)">
+<style type='text/css'><!--
+        body {
+                font-family: verdana, charcoal, helvetica, arial, sans-serif;
+                font-size: small; color: #000; background-color: #FFF;
+                margin: 2em;
+        }
+        h1, h2, h3, h4, h5, h6 {
+                font-family: helvetica, monaco, "MS Sans Serif", arial, sans-serif;
+                font-weight: bold; font-style: normal;
+        }
+        h1 { color: #900; background-color: transparent; text-align: right; }
+        h3 { color: #333; background-color: transparent; }
+
+        td.RFCbug {
+                font-size: x-small; text-decoration: none;
+                width: 30px; height: 30px; padding-top: 2px;
+                text-align: justify; vertical-align: middle;
+                background-color: #000;
+        }
+        td.RFCbug span.RFC {
+                font-family: monaco, charcoal, geneva, "MS Sans Serif", helvetica, verdana, sans-serif;
+                font-weight: bold; color: #666;
+        }
+        td.RFCbug span.hotText {
+                font-family: charcoal, monaco, geneva, "MS Sans Serif", helvetica, verdana, sans-serif;
+                font-weight: normal; text-align: center; color: #FFF;
+        }
+
+        table.TOCbug { width: 30px; height: 15px; }
+        td.TOCbug {
+                text-align: center; width: 30px; height: 15px;
+                color: #FFF; background-color: #900;
+        }
+        td.TOCbug a {
+                font-family: monaco, charcoal, geneva, "MS Sans Serif", helvetica, sans-serif;
+                font-weight: bold; font-size: x-small; text-decoration: none;
+                color: #FFF; background-color: transparent;
+        }
+
+        td.header {
+                font-family: arial, helvetica, sans-serif; font-size: x-small;
+                vertical-align: top; width: 33%;
+                color: #FFF; background-color: #666;
+        }
+        td.author { font-weight: bold; font-size: x-small; margin-left: 4em; }
+        td.author-text { font-size: x-small; }
+
+        /* info code from SantaKlauss at http://www.madaboutstyle.com/tooltip2.html */
+        a.info {
+                /* This is the key. */
+                position: relative;
+                z-index: 24;
+                text-decoration: none;
+        }
+        a.info:hover {
+                z-index: 25;
+                color: #FFF; background-color: #900;
+        }
+        a.info span { display: none; }
+        a.info:hover span.info {
+                /* The span will display just on :hover state. */
+                display: block;
+                position: absolute;
+                font-size: smaller;
+                top: 2em; left: -5em; width: 15em;
+                padding: 2px; border: 1px solid #333;
+                color: #900; background-color: #EEE;
+                text-align: left;
+        }
+
+        a { font-weight: bold; }
+        a:link    { color: #900; background-color: transparent; }
+        a:visited { color: #633; background-color: transparent; }
+        a:active  { color: #633; background-color: transparent; }
+
+        p { margin-left: 2em; margin-right: 2em; }
+        p.copyright { font-size: x-small; }
+        p.toc { font-size: small; font-weight: bold; margin-left: 3em; }
+        table.toc { margin: 0 0 0 3em; padding: 0; border: 0; vertical-align: text-top; }
+        td.toc { font-size: small; font-weight: bold; vertical-align: text-top; }
+
+        ol.text { margin-left: 2em; margin-right: 2em; }
+        ul.text { margin-left: 2em; margin-right: 2em; }
+        li      { margin-left: 3em; }
+
+        /* RFC-2629 <spanx>s and <artwork>s. */
+        em     { font-style: italic; }
+        strong { font-weight: bold; }
+        dfn    { font-weight: bold; font-style: normal; }
+        cite   { font-weight: normal; font-style: normal; }
+        tt     { color: #036; }
+        tt, pre, pre dfn, pre em, pre cite, pre span {
+                font-family: "Courier New", Courier, monospace; font-size: small;
+        }
+        pre {
+                text-align: left; padding: 4px;
+                color: #000; background-color: #CCC;
+        }
+        pre dfn  { color: #900; }
+        pre em   { color: #66F; background-color: #FFC; font-weight: normal; }
+        pre .key { color: #33C; font-weight: bold; }
+        pre .id  { color: #900; }
+        pre .str { color: #000; background-color: #CFF; }
+        pre .val { color: #066; }
+        pre .rep { color: #909; }
+        pre .oth { color: #000; background-color: #FCF; }
+        pre .err { background-color: #FCC; }
+
+        /* RFC-2629 <texttable>s. */
+        table.all, table.full, table.headers, table.none {
+                font-size: small; text-align: center; border-width: 2px;
+                vertical-align: top; border-collapse: collapse;
+        }
+        table.all, table.full { border-style: solid; border-color: black; }
+        table.headers, table.none { border-style: none; }
+        th {
+                font-weight: bold; border-color: black;
+                border-width: 2px 2px 3px 2px;
+        }
+        table.all th, table.full th { border-style: solid; }
+        table.headers th { border-style: none none solid none; }
+        table.none th { border-style: none; }
+        table.all td {
+                border-style: solid; border-color: #333;
+                border-width: 1px 2px;
+        }
+        table.full td, table.headers td, table.none td { border-style: none; }
+
+        hr { height: 1px; }
+        hr.insert {
+                width: 80%; border-style: none; border-width: 0;
+                color: #CCC; background-color: #CCC;
+        }
+--></style>
+</head>
+<body>
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<table summary="layout" width="66%" border="0" cellpadding="0" cellspacing="0"><tr><td><table summary="layout" width="100%" border="0" cellpadding="2" cellspacing="1">
+<tr><td class="header">Internet Engineering Task Force</td><td class="header">fge. Galiegue</td></tr>
+<tr><td class="header">Internet-Draft</td><td class="header">&nbsp;</td></tr>
+<tr><td class="header">Intended status: Informational</td><td class="header">K. Zyp, Ed.</td></tr>
+<tr><td class="header">Expires: August 3, 2013</td><td class="header">SitePen (USA)</td></tr>
+<tr><td class="header">&nbsp;</td><td class="header">G. Court</td></tr>
+<tr><td class="header">&nbsp;</td><td class="header">January 30, 2013</td></tr>
+</table></td></tr></table>
+<h1><br />JSON Schema: interactive and non interactive validation<br />json-schema-validation</h1>
+
+<h3>Abstract</h3>
+
+<p>
+                JSON Schema (application/schema+json) has several purposes, one of which is instance
+                validation. The validation process may be interactive or non interactive. For
+                instance, applications may use JSON Schema to build a user interface enabling
+                interactive content generation in addition to user input checking, or validate data
+                retrieved from various sources. This specification describes schema keywords
+                dedicated to validation purposes.
+            
+</p>
+<h3>Status of This Memo</h3>
+<p>
+This Internet-Draft is submitted  in full
+conformance with the provisions of BCP&nbsp;78 and BCP&nbsp;79.</p>
+<p>
+Internet-Drafts are working documents of the Internet Engineering
+Task Force (IETF).  Note that other groups may also distribute
+working documents as Internet-Drafts.  The list of current
+Internet-Drafts is at http://datatracker.ietf.org/drafts/current/.</p>
+<p>
+Internet-Drafts are draft documents valid for a maximum of six months
+and may be updated, replaced, or obsoleted by other documents at any time.
+It is inappropriate to use Internet-Drafts as reference material or to cite
+them other than as &ldquo;work in progress.&rdquo;</p>
+<p>
+This Internet-Draft will expire on August 3, 2013.</p>
+
+<h3>Copyright Notice</h3>
+<p>
+Copyright (c) 2013 IETF Trust and the persons identified as the
+document authors.  All rights reserved.</p>
+<p>
+This document is subject to BCP 78 and the IETF Trust's Legal
+Provisions Relating to IETF Documents
+(http://trustee.ietf.org/license-info) in effect on the date of
+publication of this document.  Please review these documents
+carefully, as they describe your rights and restrictions with respect
+to this document. Code Components extracted from this document must
+include Simplified BSD License text as described in Section 4.e of
+the Trust Legal Provisions and are provided without warranty as
+described in the Simplified BSD License.</p>
+<a name="toc"></a><br /><hr />
+<h3>Table of Contents</h3>
+<p class="toc">
+<a href="#anchor1">1.</a>&nbsp;
+Introduction<br />
+<a href="#anchor2">2.</a>&nbsp;
+Conventions and Terminology<br />
+<a href="#anchor3">3.</a>&nbsp;
+Interoperability considerations<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor4">3.1.</a>&nbsp;
+Validation of string instances<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor5">3.2.</a>&nbsp;
+Validation of numeric instances<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor6">3.3.</a>&nbsp;
+Regular expressions<br />
+<a href="#anchor7">4.</a>&nbsp;
+General validation considerations<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor8">4.1.</a>&nbsp;
+Keywords and instance primitive types<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor9">4.2.</a>&nbsp;
+Inter-dependent keywords<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor10">4.3.</a>&nbsp;
+Default values for missing keywords<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor11">4.4.</a>&nbsp;
+Validation of container instances<br />
+<a href="#anchor12">5.</a>&nbsp;
+Validation keywords sorted by instance types<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor13">5.1.</a>&nbsp;
+Validation keywords for numeric instances (number and integer)<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor14">5.1.1.</a>&nbsp;
+multipleOf<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor17">5.1.2.</a>&nbsp;
+maximum and exclusiveMaximum<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor21">5.1.3.</a>&nbsp;
+minimum and exclusiveMinimum<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor25">5.2.</a>&nbsp;
+Validation keywords for strings<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor26">5.2.1.</a>&nbsp;
+maxLength<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor29">5.2.2.</a>&nbsp;
+minLength<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor33">5.2.3.</a>&nbsp;
+pattern<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor36">5.3.</a>&nbsp;
+Validation keywords for arrays<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor37">5.3.1.</a>&nbsp;
+additionalItems and items<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor42">5.3.2.</a>&nbsp;
+maxItems<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor45">5.3.3.</a>&nbsp;
+minItems<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor49">5.3.4.</a>&nbsp;
+uniqueItems<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor53">5.4.</a>&nbsp;
+Validation keywords for objects<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor54">5.4.1.</a>&nbsp;
+maxProperties<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor57">5.4.2.</a>&nbsp;
+minProperties<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor61">5.4.3.</a>&nbsp;
+required<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor64">5.4.4.</a>&nbsp;
+additionalProperties, properties and patternProperties<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor70">5.4.5.</a>&nbsp;
+dependencies<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor75">5.5.</a>&nbsp;
+Validation keywords for any instance type<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor76">5.5.1.</a>&nbsp;
+enum<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor79">5.5.2.</a>&nbsp;
+type<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor82">5.5.3.</a>&nbsp;
+allOf<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor85">5.5.4.</a>&nbsp;
+anyOf<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor88">5.5.5.</a>&nbsp;
+oneOf<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor91">5.5.6.</a>&nbsp;
+not<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor94">5.5.7.</a>&nbsp;
+definitions<br />
+<a href="#anchor97">6.</a>&nbsp;
+Metadata keywords<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor98">6.1.</a>&nbsp;
+"title" and "description"<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor99">6.1.1.</a>&nbsp;
+Valid values<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor100">6.1.2.</a>&nbsp;
+Purpose<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor101">6.2.</a>&nbsp;
+"default"<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor102">6.2.1.</a>&nbsp;
+Valid values<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor103">6.2.2.</a>&nbsp;
+Purpose<br />
+<a href="#anchor104">7.</a>&nbsp;
+Semantic validation with "format"<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor105">7.1.</a>&nbsp;
+Foreword<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor106">7.2.</a>&nbsp;
+Implementation requirements<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor107">7.3.</a>&nbsp;
+Defined attributes<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor108">7.3.1.</a>&nbsp;
+date-time<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor111">7.3.2.</a>&nbsp;
+email<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor114">7.3.3.</a>&nbsp;
+hostname<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor117">7.3.4.</a>&nbsp;
+ipv4<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor120">7.3.5.</a>&nbsp;
+ipv6<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor123">7.3.6.</a>&nbsp;
+uri<br />
+<a href="#anchor126">8.</a>&nbsp;
+Reference algorithms for calculating children schemas<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor127">8.1.</a>&nbsp;
+Foreword<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor128">8.2.</a>&nbsp;
+Array elements<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor129">8.2.1.</a>&nbsp;
+Defining characteristic<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor130">8.2.2.</a>&nbsp;
+Implied keywords and default values.<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor131">8.2.3.</a>&nbsp;
+Calculation<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor134">8.3.</a>&nbsp;
+Object members<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor135">8.3.1.</a>&nbsp;
+Defining characteristic<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor136">8.3.2.</a>&nbsp;
+Implied keywords<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#anchor137">8.3.3.</a>&nbsp;
+Calculation<br />
+<a href="#anchor142">9.</a>&nbsp;
+IANA Considerations<br />
+<a href="#rfc.references1">10.</a>&nbsp;
+References<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#rfc.references1">10.1.</a>&nbsp;
+Normative References<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#rfc.references2">10.2.</a>&nbsp;
+Informative References<br />
+<a href="#anchor145">Appendix&nbsp;A.</a>&nbsp;
+ChangeLog<br />
+</p>
+<br clear="all" />
+
+<a name="anchor1"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.1"></a><h3>1.&nbsp;
+Introduction</h3>
+
+<p>
+                JSON Schema can be used to require that a given JSON document (an instance)
+                satisfies a certain number of criteria. These criteria are materialized by a set of
+                keywords which are described in this specification. In addition, a set of keywords
+                is defined to assist in interactive instance generation. Those are also described in
+                this specification.
+            
+</p>
+<p>
+                This specification will use the terminology defined by the JSON Schema core
+                specification. It is advised that readers have a copy of this specification.
+            
+</p>
+<a name="anchor2"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.2"></a><h3>2.&nbsp;
+Conventions and Terminology</h3>
+
+<p>
+                
+
+                The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+                "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
+                interpreted as described in <a class='info' href='#RFC2119'>RFC 2119<span> (</span><span class='info'>Bradner, S., &ldquo;Key words for use in RFCs to Indicate Requirement Levels,&rdquo; March&nbsp;1997.</span><span>)</span></a> [RFC2119].
+            
+</p>
+<p>
+                This specification uses the term "container instance" to refer to both array and
+                object instances. It uses the term "children instances" to refer to array elements
+                or object member values.
+            
+</p>
+<p>
+                This specification uses the term "property set" to refer to the set of an object's
+                member names; for instance, the property set of JSON Object { "a": 1, "b": 2 } is [
+                "a", "b" ].
+            
+</p>
+<p>
+                Elements in an array value are said to be unique if no two elements of this array
+                are equal, as defined by the core specification.
+            
+</p>
+<a name="anchor3"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3"></a><h3>3.&nbsp;
+Interoperability considerations</h3>
+
+<a name="anchor4"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.1"></a><h3>3.1.&nbsp;
+Validation of string instances</h3>
+
+<p>
+                    It should be noted that the nul character (\x00) is valid in a JSON string. An
+                    instance to validate may contain a string value with this character, regardless
+                    of the ability of the underlying programming language to deal with such data.
+                
+</p>
+<a name="anchor5"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.2"></a><h3>3.2.&nbsp;
+Validation of numeric instances</h3>
+
+<p>
+                    The JSON specification does not define any bounds to the scale or precision of
+                    numeric values. JSON Schema does not define any such bounds either. This means
+                    that numeric instances processed by JSON Schema can be arbitrarily large and/or
+                    have an arbitrarily large decimal part, regardless of the ability of the
+                    underlying programming language to deal with such data.
+                
+</p>
+<a name="anchor6"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.3"></a><h3>3.3.&nbsp;
+Regular expressions</h3>
+
+<p>
+                    Two validation keywords, "pattern" and "patternProperties", use regular
+                    expressions to express constraints. These regular expressions SHOULD
+                    be valid according to the <a class='info' href='#ecma262'>ECMA 262<span> (</span><span class='info'>, &ldquo;ECMA 262 specification,&rdquo; .</span><span>)</span></a> [ecma262] regular
+                    expression dialect.
+                
+</p>
+<p>
+                    Furthermore, given the high disparity in regular expression constructs support,
+                    schema authors SHOULD limit themselves to the following regular expression
+                    tokens:
+
+                    </p>
+<blockquote class="text">
+<p>individual Unicode characters, as defined by the <a class='info' href='#RFC4627'>JSON specification<span> (</span><span class='info'>Crockford, D., &ldquo;The application/json Media Type for JavaScript Object Notation (JSON),&rdquo; July&nbsp;2006.</span><span>)</span></a> [RFC4627];
+</p>
+<p>simple character classes ([abc]), range character classes ([a-z]);
+</p>
+<p>complemented character classes ([^abc], [^a-z]);
+</p>
+<p>simple quantifiers: "+" (one or more), "*" (zero or more), "?" (zero or
+                        one), and their lazy versions ("+?", "*?", "??");
+</p>
+<p>range quantifiers: "{x}" (exactly x occurrences), "{x,y}" (at least x, at
+                        most y, occurrences), {x,} (x occurrences or more), and their lazy
+                        versions;
+</p>
+<p>the beginning-of-input ("^") and end-of-input ("$") anchors;
+</p>
+<p>simple grouping ("(...)") and alternation ("|").
+</p>
+</blockquote><p>
+                
+</p>
+<p>
+                    Finally, implementations MUST NOT consider that regular expressions are
+                    anchored, neither at the beginning nor at the end. This means, for instance,
+                    that "es" matches "expression".
+                
+</p>
+<a name="anchor7"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.4"></a><h3>4.&nbsp;
+General validation considerations</h3>
+
+<a name="anchor8"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.4.1"></a><h3>4.1.&nbsp;
+Keywords and instance primitive types</h3>
+
+<p>
+                    Some validation keywords only apply to one or more primitive types. When the
+                    primitive type of the instance cannot be validated by a given keyword,
+                    validation for this keyword and instance SHOULD succeed.
+                
+</p>
+<p>
+                    This specification groups keywords in different sections, according to the
+                    primitive type, or types, these keywords validate. Note that some keywords
+                    validate all instance types.
+                
+</p>
+<a name="anchor9"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.4.2"></a><h3>4.2.&nbsp;
+Inter-dependent keywords</h3>
+
+<p>
+                    In order to validate an instance, some keywords are influenced by the presence
+                    (or absence) of other keywords. In this case, all these keywords will be grouped
+                    in the same section.
+                
+</p>
+<a name="anchor10"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.4.3"></a><h3>4.3.&nbsp;
+Default values for missing keywords</h3>
+
+<p>
+                    Some keywords, if absent, MAY be regarded by implementations as having
+                    a default value. In this case, the default value will be mentioned.
+                
+</p>
+<a name="anchor11"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.4.4"></a><h3>4.4.&nbsp;
+Validation of container instances</h3>
+
+<p>
+                    Keywords with the possibility to validate container instances (arrays or
+                    objects) only validate the instances themselves and not their children (array
+                    items or object properties). Some of these keywords do, however, contain
+                    information which is necessary for calculating which schema(s) a child must be
+                    valid against. The algorithms to calculate a child instance's relevant schema(s)
+                    are explained in a separate section.
+                
+</p>
+<p>
+                    It should be noted that while an array element will only have to validate
+                    against one schema, object member values may have to validate against more than
+                    one schema.
+                
+</p>
+<a name="anchor12"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5"></a><h3>5.&nbsp;
+Validation keywords sorted by instance types</h3>
+
+<a name="anchor13"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.1"></a><h3>5.1.&nbsp;
+Validation keywords for numeric instances (number and integer)</h3>
+
+<a name="anchor14"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.1.1"></a><h3>5.1.1.&nbsp;
+multipleOf</h3>
+
+<a name="anchor15"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.1.1.1"></a><h3>5.1.1.1.&nbsp;
+Valid values</h3>
+
+<p>
+                            The value of "multipleOf" MUST be a JSON number. This number MUST be
+                            strictly greater than 0.
+                        
+</p>
+<a name="anchor16"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.1.1.2"></a><h3>5.1.1.2.&nbsp;
+Conditions for successful validation</h3>
+
+<p>
+                            A numeric instance is valid against "multipleOf" if the
+                            result of the division of the instance by this keyword's value is
+                            an integer.
+                        
+</p>
+<a name="anchor17"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.1.2"></a><h3>5.1.2.&nbsp;
+maximum and exclusiveMaximum</h3>
+
+<a name="anchor18"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.1.2.1"></a><h3>5.1.2.1.&nbsp;
+Valid values</h3>
+
+<p>
+                            The value of "maximum" MUST be a JSON number. The value of
+                            "exclusiveMaximum" MUST be a boolean.
+                        
+</p>
+<p>
+                            If "exclusiveMaximum" is present, "maximum" MUST also be present.
+                        
+</p>
+<a name="anchor19"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.1.2.2"></a><h3>5.1.2.2.&nbsp;
+Conditions for successful validation</h3>
+
+<p>
+                            Successful validation depends on the presence and value of
+                            "exclusiveMaximum":
+
+                            </p>
+<blockquote class="text">
+<p>if "exclusiveMaximum" is not present, or has boolean value false,
+                                then the instance is valid if it is lower than, or equal to, the
+                                value of "maximum";
+</p>
+<p>if "exclusiveMaximum" has boolean value true, the instance is
+                                valid if it is strictly lower than the value of "maximum".
+</p>
+</blockquote><p>
+                        
+</p>
+<a name="anchor20"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.1.2.3"></a><h3>5.1.2.3.&nbsp;
+Default value</h3>
+
+<p>
+                            "exclusiveMaximum", if absent, may be considered as being present with
+                            boolean value false.
+                        
+</p>
+<a name="anchor21"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.1.3"></a><h3>5.1.3.&nbsp;
+minimum and exclusiveMinimum</h3>
+
+<a name="anchor22"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.1.3.1"></a><h3>5.1.3.1.&nbsp;
+Valid values</h3>
+
+<p>
+                            The value of "minimum" MUST be a JSON number. The value of
+                            "exclusiveMinimum" MUST be a boolean.
+                        
+</p>
+<p>
+                            If "exclusiveMinimum" is present, "minimum" MUST also be present.
+                        
+</p>
+<a name="anchor23"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.1.3.2"></a><h3>5.1.3.2.&nbsp;
+Conditions for successful validation</h3>
+
+<p>
+                            Successful validation depends on the presence and value of
+                            "exclusiveMinimum":
+
+                            </p>
+<blockquote class="text">
+<p>if "exclusiveMinimum" is not present, or has boolean value false,
+                                then the instance is valid if it is greater than, or equal to, the
+                                value of "minimum";
+</p>
+<p>if "exclusiveMinimum" is present and has boolean value true, the
+                                instance is valid if it is strictly greater than the value of
+                                "minimum".
+</p>
+</blockquote><p>
+                        
+</p>
+<a name="anchor24"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.1.3.3"></a><h3>5.1.3.3.&nbsp;
+Default value</h3>
+
+<p>
+                            "exclusiveMinimum", if absent, may be considered as being present with
+                            boolean value false.
+                        
+</p>
+<a name="anchor25"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.2"></a><h3>5.2.&nbsp;
+Validation keywords for strings</h3>
+
+<a name="anchor26"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.2.1"></a><h3>5.2.1.&nbsp;
+maxLength</h3>
+
+<a name="anchor27"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.2.1.1"></a><h3>5.2.1.1.&nbsp;
+Valid values</h3>
+
+<p>
+                            The value of this keyword MUST be an integer. This integer MUST be
+                            greater than, or equal to, 0.
+                        
+</p>
+<a name="anchor28"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.2.1.2"></a><h3>5.2.1.2.&nbsp;
+Conditions for successful validation</h3>
+
+<p>
+                            A string instance is valid against this keyword if its
+                            length is less than, or equal to, the value of this keyword.
+                        
+</p>
+<p>
+                            The length of a string instance is defined as the number of its
+                            characters as defined by <a class='info' href='#RFC4627'>RFC 4627<span> (</span><span class='info'>Crockford, D., &ldquo;The application/json Media Type for JavaScript Object Notation (JSON),&rdquo; July&nbsp;2006.</span><span>)</span></a> [RFC4627].
+                        
+</p>
+<a name="anchor29"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.2.2"></a><h3>5.2.2.&nbsp;
+minLength</h3>
+
+<a name="anchor30"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.2.2.1"></a><h3>5.2.2.1.&nbsp;
+Valid values</h3>
+
+<p>
+                            The value of this keyword MUST be an integer. This integer MUST be
+                            greater than, or equal to, 0.
+                        
+</p>
+<a name="anchor31"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.2.2.2"></a><h3>5.2.2.2.&nbsp;
+Conditions for successful validation</h3>
+
+<p>
+                            A string instance is valid against this keyword if its
+                            length is greater than, or equal to, the value of this keyword.
+                        
+</p>
+<p>
+                            The length of a string instance is defined as the number of its
+                            characters as defined by <a class='info' href='#RFC4627'>RFC 4627<span> (</span><span class='info'>Crockford, D., &ldquo;The application/json Media Type for JavaScript Object Notation (JSON),&rdquo; July&nbsp;2006.</span><span>)</span></a> [RFC4627].
+                        
+</p>
+<a name="anchor32"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.2.2.3"></a><h3>5.2.2.3.&nbsp;
+Default value</h3>
+
+<p>
+                            "minLength", if absent, may be considered as being present with integer
+                            value 0.
+                        
+</p>
+<a name="anchor33"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.2.3"></a><h3>5.2.3.&nbsp;
+pattern</h3>
+
+<a name="anchor34"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.2.3.1"></a><h3>5.2.3.1.&nbsp;
+Valid values</h3>
+
+<p>
+                            The value of this keyword MUST be a string. This string SHOULD be a
+                            valid regular expression, according to the ECMA 262 regular expression
+                            dialect.
+                        
+</p>
+<a name="anchor35"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.2.3.2"></a><h3>5.2.3.2.&nbsp;
+Conditions for successful validation</h3>
+
+<p>
+                            A string instance is considered valid if the regular
+                            expression matches the instance successfully. Recall: regular
+                            expressions are not implicitly anchored.
+                        
+</p>
+<a name="anchor36"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.3"></a><h3>5.3.&nbsp;
+Validation keywords for arrays</h3>
+
+<a name="anchor37"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.3.1"></a><h3>5.3.1.&nbsp;
+additionalItems and items</h3>
+
+<a name="anchor38"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.3.1.1"></a><h3>5.3.1.1.&nbsp;
+Valid values</h3>
+
+<p>
+                            The value of "additionalItems" MUST be either a boolean or an object. If
+                            it is an object, this object MUST be a valid JSON Schema.
+                        
+</p>
+<p>
+                            The value of "items" MUST be either an object or an array. If it is an
+                            object, this object MUST be a valid JSON Schema. If it is an array,
+                            items of this array MUST be objects, and each of these objects MUST be a
+                            valid JSON Schema.
+                        
+</p>
+<a name="anchor39"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.3.1.2"></a><h3>5.3.1.2.&nbsp;
+Conditions for successful validation</h3>
+
+<p>
+                            Successful validation of an array instance with regards to these two
+                            keywords is determined as follows:
+
+                            </p>
+<blockquote class="text">
+<p>if "items" is not present, or its value is an object, validation
+                                of the instance always succeeds, regardless of the value of
+                                "additionalItems";
+</p>
+<p>if the value of "additionalItems" is boolean value true or an
+                                object, validation of the instance always succeeds;
+</p>
+<p>if the value of "additionalItems" is boolean value false and the
+                                value of "items" is an array, the instance is valid if
+                                its size is less than, or equal to, the size of "items".
+</p>
+</blockquote><p>
+                        
+</p>
+<a name="anchor40"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.3.1.3"></a><h3>5.3.1.3.&nbsp;
+Example</h3>
+
+<p>
+                            The following example covers the case where "additionalItems" has
+                            boolean value false and "items" is an array, since this is the only
+                            situation under which an instance may fail to validate successfully.
+                        
+</p>
+<p>This is an example schema:
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+
+{
+    "items": [ {}, {}, {} ],
+    "additionalItems": false
+}
+
+</pre></div>
+<p>
+                            With this schema, the following instances are valid:
+
+                            </p>
+<blockquote class="text">
+<p>[] (an empty array),
+</p>
+<p>[ [ 1, 2, 3, 4 ], [ 5, 6, 7, 8 ] ],
+</p>
+<p>[ 1, 2, 3 ];
+</p>
+</blockquote><p>
+                        
+</p>
+<p>
+                            the following instances are invalid:
+
+                            </p>
+<blockquote class="text">
+<p>[ 1, 2, 3, 4 ],
+</p>
+<p>[ null, { "a": "b" }, true, 31.000002020013 ]
+</p>
+</blockquote><p>
+                        
+</p>
+<a name="anchor41"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.3.1.4"></a><h3>5.3.1.4.&nbsp;
+Default values</h3>
+
+<p>
+                            If either keyword is absent, it may be considered present with an empty
+                            schema.
+                        
+</p>
+<a name="anchor42"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.3.2"></a><h3>5.3.2.&nbsp;
+maxItems</h3>
+
+<a name="anchor43"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.3.2.1"></a><h3>5.3.2.1.&nbsp;
+Valid values</h3>
+
+<p>
+                            The value of this keyword MUST be an integer. This integer MUST be
+                            greater than, or equal to, 0.
+                        
+</p>
+<a name="anchor44"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.3.2.2"></a><h3>5.3.2.2.&nbsp;
+Conditions for successful validation</h3>
+
+<p>
+                            An array instance is valid against "maxItems" if its size is
+                            less than, or equal to, the value of this keyword.
+                        
+</p>
+<a name="anchor45"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.3.3"></a><h3>5.3.3.&nbsp;
+minItems</h3>
+
+<a name="anchor46"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.3.3.1"></a><h3>5.3.3.1.&nbsp;
+Valid values</h3>
+
+<p>
+                            The value of this keyword MUST be an integer. This integer MUST be
+                            greater than, or equal to, 0.
+                        
+</p>
+<a name="anchor47"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.3.3.2"></a><h3>5.3.3.2.&nbsp;
+Conditions for successful validation</h3>
+
+<p>
+                            An array instance is valid against "minItems" if its size is
+                            greater than, or equal to, the value of this keyword.
+                        
+</p>
+<a name="anchor48"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.3.3.3"></a><h3>5.3.3.3.&nbsp;
+Default value</h3>
+
+<p>
+                            If this keyword is not present, it may be considered present with a
+                            value of 0.
+                        
+</p>
+<a name="anchor49"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.3.4"></a><h3>5.3.4.&nbsp;
+uniqueItems</h3>
+
+<a name="anchor50"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.3.4.1"></a><h3>5.3.4.1.&nbsp;
+Valid values</h3>
+
+<p>
+                            The value of this keyword MUST be a boolean.
+                        
+</p>
+<a name="anchor51"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.3.4.2"></a><h3>5.3.4.2.&nbsp;
+Conditions for successful validation</h3>
+
+<p>
+                            If this keyword has boolean value false, the instance validates
+                            successfully. If it has boolean value true, the instance validates
+                            successfully if all of its elements are unique.
+                        
+</p>
+<a name="anchor52"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.3.4.3"></a><h3>5.3.4.3.&nbsp;
+Default value</h3>
+
+<p>
+                            If not present, this keyword may be considered present with boolean
+                            value false.
+                        
+</p>
+<a name="anchor53"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.4"></a><h3>5.4.&nbsp;
+Validation keywords for objects</h3>
+
+<a name="anchor54"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.4.1"></a><h3>5.4.1.&nbsp;
+maxProperties</h3>
+
+<a name="anchor55"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.4.1.1"></a><h3>5.4.1.1.&nbsp;
+Valid values</h3>
+
+<p>
+                            The value of this keyword MUST be an integer. This integer MUST be
+                            greater than, or equal to, 0.
+                        
+</p>
+<a name="anchor56"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.4.1.2"></a><h3>5.4.1.2.&nbsp;
+Conditions for successful validation</h3>
+
+<p>
+                            An object instance is valid against "maxProperties" if its
+                            number of properties is less than, or equal to, the value of this
+                            keyword.
+                        
+</p>
+<a name="anchor57"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.4.2"></a><h3>5.4.2.&nbsp;
+minProperties</h3>
+
+<a name="anchor58"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.4.2.1"></a><h3>5.4.2.1.&nbsp;
+Valid values</h3>
+
+<p>
+                            The value of this keyword MUST be an integer. This integer MUST be
+                            greater than, or equal to, 0.
+                        
+</p>
+<a name="anchor59"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.4.2.2"></a><h3>5.4.2.2.&nbsp;
+Conditions for successful validation</h3>
+
+<p>
+                            An object instance is valid against "minProperties" if its
+                            number of properties is greater than, or equal to, the value of this
+                            keyword.
+                        
+</p>
+<a name="anchor60"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.4.2.3"></a><h3>5.4.2.3.&nbsp;
+Default value</h3>
+
+<p>
+                            If this keyword is not present, it may be considered present with a
+                            value of 0.
+                        
+</p>
+<a name="anchor61"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.4.3"></a><h3>5.4.3.&nbsp;
+required</h3>
+
+<a name="anchor62"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.4.3.1"></a><h3>5.4.3.1.&nbsp;
+Valid values</h3>
+
+<p>
+                            The value of this keyword MUST be an array. This array MUST have at
+                            least one element. Elements of this array MUST be strings, and MUST be
+                            unique.
+                        
+</p>
+<a name="anchor63"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.4.3.2"></a><h3>5.4.3.2.&nbsp;
+Conditions for successful validation</h3>
+
+<p>
+                            An object instance is valid against this keyword if its
+                            property set contains all elements in this keyword's array value.
+                        
+</p>
+<a name="anchor64"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.4.4"></a><h3>5.4.4.&nbsp;
+additionalProperties, properties and patternProperties</h3>
+
+<a name="anchor65"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.4.4.1"></a><h3>5.4.4.1.&nbsp;
+Valid values</h3>
+
+<p>
+                            The value of "additionalProperties" MUST be a boolean or an object. If
+                            it is an object, it MUST also be a valid JSON Schema.
+                        
+</p>
+<p>
+                            The value of "properties" MUST be an object. Each value of this object
+                            MUST be an object, and each object MUST be a valid JSON Schema.
+                        
+</p>
+<p>
+                            The value of "patternProperties" MUST be an object. Each property name
+                            of this object SHOULD be a valid regular expression, according to the
+                            ECMA 262 regular expression dialect. Each property value of this object
+                            MUST be an object, and each object MUST be a valid JSON Schema.
+                        
+</p>
+<a name="anchor66"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.4.4.2"></a><h3>5.4.4.2.&nbsp;
+Conditions for successful validation</h3>
+
+<p>
+                            Successful validation of an object instance against these three keywords
+                            depends on the value of "additionalProperties":
+
+                            </p>
+<blockquote class="text">
+<p>if its value is boolean true or a schema, validation
+                                succeeds;
+</p>
+<p>if its value is boolean false, the algorithm to determine
+                                validation success is described below.
+</p>
+</blockquote><p>
+                        
+</p>
+<a name="anchor67"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.4.4.3"></a><h3>5.4.4.3.&nbsp;
+Default values</h3>
+
+<p>
+                            If either "properties" or "patternProperties" are absent, they can be
+                            considered present with an empty object as a value.
+                        
+</p>
+<p>
+                            If "additionalProperties" is absent, it may be considered present with
+                            an empty schema as a value.
+                        
+</p>
+<a name="anchor68"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.4.4.4"></a><h3>5.4.4.4.&nbsp;
+If "additionalProperties" has boolean value false</h3>
+
+<p>
+                            In this case, validation of the instance depends on the property set of
+                            "properties" and "patternProperties". In this section, the property
+                            names of "patternProperties" will be called regexes for convenience.
+                        
+</p>
+<p>
+                            The first step is to collect the following sets:
+
+                            </p>
+<blockquote class="text"><dl>
+<dt>s</dt>
+<dd>The property set of the instance to validate.
+</dd>
+<dt>p</dt>
+<dd>The property set from "properties".
+</dd>
+<dt>pp</dt>
+<dd>The property set from "patternProperties".
+</dd>
+</dl></blockquote><p>
+                        
+</p>
+<p>
+                            Having collected these three sets, the process is as follows:
+
+                            </p>
+<blockquote class="text">
+<p>remove from "s" all elements of "p", if any;
+</p>
+<p>for each regex in "pp", remove all elements of "s" which this
+                                regex matches.
+</p>
+</blockquote><p>
+                        
+</p>
+<p>
+                            Validation of the instance succeeds if, after these two
+                            steps, set "s" is empty.
+                        
+</p>
+<a name="anchor69"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.4.4.5"></a><h3>5.4.4.5.&nbsp;
+Example</h3>
+
+<p>
+                            This schema will be used as an example:
+                        
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+
+{
+    "properties": {
+        "p1": {}
+    },
+    "patternProperties": {
+        "p": {},
+        "[0-9]": {}
+    }
+}
+
+</pre></div>
+<p>
+                            This is the instance to validate:
+                        
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+
+{
+    "p1": true,
+    "p2": null,
+    "a32&amp;o": "foobar",
+    "": [],
+    "fiddle": 42,
+    "apple": "pie"
+}
+
+</pre></div>
+<p>
+                            The three property sets are:
+
+                            </p>
+<blockquote class="text"><dl>
+<dt>s</dt>
+<dd>[ "p1", "p2", "a32&amp;o", "", "fiddle", "apple"
+                                ]
+</dd>
+<dt>p</dt>
+<dd>[ "p1" ]
+</dd>
+<dt>pp</dt>
+<dd>[ "p", "[0-9]" ]
+</dd>
+</dl></blockquote><p>
+                        
+</p>
+<p>
+                            Applying the two steps of the algorithm:
+
+                            </p>
+<blockquote class="text">
+<p>after the first step, "p1" is removed from "s";
+</p>
+<p>after the second step, "p2" (matched by "p"), "a32&amp;o"
+                                (matched by "[0-9]") and "apple" (matched by "p") are removed from
+                                "s".
+</p>
+</blockquote><p>
+                        
+</p>
+<p>
+                            The set "s" still contains two elements, "" and "fiddle". Validation
+                            therefore fails.
+                        
+</p>
+<a name="anchor70"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.4.5"></a><h3>5.4.5.&nbsp;
+dependencies</h3>
+
+<a name="anchor71"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.4.5.1"></a><h3>5.4.5.1.&nbsp;
+Valid values</h3>
+
+<p>
+                            This keyword's value MUST be an object. Each value of this object MUST
+                            be either an object or an array.
+                        
+</p>
+<p>
+                            If the value is an object, it MUST be a valid JSON Schema. This is
+                            called a schema dependency.
+                        
+</p>
+<p>
+                            If the value is an array, it MUST have at least one element. Each
+                            element MUST be a string, and elements in the array MUST be unique. This
+                            is called a property dependency.
+                        
+</p>
+<a name="anchor72"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.4.5.2"></a><h3>5.4.5.2.&nbsp;
+Conditions for successful validation</h3>
+
+<a name="anchor73"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.4.5.2.1"></a><h3>5.4.5.2.1.&nbsp;
+Schema dependencies</h3>
+
+<p>
+                                For all (name, schema) pair of schema dependencies, if the instance
+                                has a property by this name, then it must also validate successfully
+                                against the schema.
+                            
+</p>
+<p>
+                                Note that this is the instance itself which must validate
+                                successfully, not the value associated with the property name.
+                            
+</p>
+<a name="anchor74"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.4.5.2.2"></a><h3>5.4.5.2.2.&nbsp;
+Property dependencies</h3>
+
+<p>
+                                For each (name, propertyset) pair of property dependencies, if the
+                                instance has a property by this name, then it must also have
+                                properties with the same names as propertyset.
+                            
+</p>
+<a name="anchor75"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.5"></a><h3>5.5.&nbsp;
+Validation keywords for any instance type</h3>
+
+<a name="anchor76"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.5.1"></a><h3>5.5.1.&nbsp;
+enum</h3>
+
+<a name="anchor77"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.5.1.1"></a><h3>5.5.1.1.&nbsp;
+Valid values</h3>
+
+<p>
+                            The value of this keyword MUST be an array. This array MUST have at
+                            least one element. Elements in the array MUST be unique.
+                        
+</p>
+<p>
+                            Elements in the array MAY be of any type, including null.
+                        
+</p>
+<a name="anchor78"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.5.1.2"></a><h3>5.5.1.2.&nbsp;
+Conditions for successful validation</h3>
+
+<p>
+                            An instance validates successfully against this keyword if its value is
+                            equal to one of the elements in this keyword's array value.
+                        
+</p>
+<a name="anchor79"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.5.2"></a><h3>5.5.2.&nbsp;
+type</h3>
+
+<a name="anchor80"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.5.2.1"></a><h3>5.5.2.1.&nbsp;
+Valid values</h3>
+
+<p>
+                            The value of this keyword MUST be either a string or an array. If it is
+                            an array, elements of the array MUST be strings and MUST be unique.
+                        
+</p>
+<p>
+                            String values MUST be one of the seven primitive types defined by
+                            the core specification.
+                        
+</p>
+<a name="anchor81"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.5.2.2"></a><h3>5.5.2.2.&nbsp;
+Conditions for successful validation</h3>
+
+<p>
+                            An instance matches successfully if its primitive type is one of the
+                            types defined by keyword. Recall: "number" includes "integer".
+                        
+</p>
+<a name="anchor82"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.5.3"></a><h3>5.5.3.&nbsp;
+allOf</h3>
+
+<a name="anchor83"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.5.3.1"></a><h3>5.5.3.1.&nbsp;
+Valid values</h3>
+
+<p>
+                            This keyword's value MUST be an array. This array MUST have at least one
+                            element.
+                        
+</p>
+<p>
+                            Elements of the array MUST be objects. Each object MUST be a valid JSON
+                            Schema.
+                        
+</p>
+<a name="anchor84"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.5.3.2"></a><h3>5.5.3.2.&nbsp;
+Conditions for successful validation</h3>
+
+<p>
+                            An instance validates successfully against this keyword if it validates
+                            successfully against all schemas defined by this keyword's value.
+                        
+</p>
+<a name="anchor85"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.5.4"></a><h3>5.5.4.&nbsp;
+anyOf</h3>
+
+<a name="anchor86"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.5.4.1"></a><h3>5.5.4.1.&nbsp;
+Valid values</h3>
+
+<p>
+                            This keyword's value MUST be an array. This array MUST have at least one
+                            element.
+                        
+</p>
+<p>
+                            Elements of the array MUST be objects. Each object MUST be a valid JSON
+                            Schema.
+                        
+</p>
+<a name="anchor87"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.5.4.2"></a><h3>5.5.4.2.&nbsp;
+Conditions for successful validation</h3>
+
+<p>
+                            An instance validates successfully against this keyword if it validates
+                            successfully against at least one schema defined by this keyword's value.
+                        
+</p>
+<a name="anchor88"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.5.5"></a><h3>5.5.5.&nbsp;
+oneOf</h3>
+
+<a name="anchor89"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.5.5.1"></a><h3>5.5.5.1.&nbsp;
+Valid values</h3>
+
+<p>
+                            This keyword's value MUST be an array. This array MUST have at least one
+                            element.
+                        
+</p>
+<p>
+                            Elements of the array MUST be objects. Each object MUST be a valid JSON
+                            Schema.
+                        
+</p>
+<a name="anchor90"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.5.5.2"></a><h3>5.5.5.2.&nbsp;
+Conditions for successful validation</h3>
+
+<p>
+                            An instance validates successfully against this keyword if it validates
+                            successfully against exactly one schema defined by this keyword's value.
+                        
+</p>
+<a name="anchor91"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.5.6"></a><h3>5.5.6.&nbsp;
+not</h3>
+
+<a name="anchor92"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.5.6.1"></a><h3>5.5.6.1.&nbsp;
+Valid values</h3>
+
+<p>
+                            This keyword's value MUST be an object. This object MUST be a valid JSON
+                            Schema.
+                        
+</p>
+<a name="anchor93"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.5.6.2"></a><h3>5.5.6.2.&nbsp;
+Conditions for successful validation</h3>
+
+<p>
+                            An instance is valid against this keyword if it fails to validate
+                            successfully against the schema defined by this keyword.
+                        
+</p>
+<a name="anchor94"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.5.7"></a><h3>5.5.7.&nbsp;
+definitions</h3>
+
+<a name="anchor95"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.5.7.1"></a><h3>5.5.7.1.&nbsp;
+Valid values</h3>
+
+<p>
+                            This keyword's value MUST be an object. Each member value of this object
+                            MUST be a valid JSON Schema.
+                        
+</p>
+<a name="anchor96"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.5.7.2"></a><h3>5.5.7.2.&nbsp;
+Conditions for successful validation</h3>
+
+<p>
+                            This keyword plays no role in validation per se. Its role is to provide
+                            a standardized location for schema authors to inline JSON Schemas into a
+                            more general schema.
+                        
+</p>
+<p>
+                            As an example, here is a schema describing an array of positive
+                            integers, where the positive integer constraint is a subschema in
+                            "definitions":
+
+                            </p>
+<div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+
+{
+    "type": "array",
+    "items": { "$ref": "#/definitions/positiveInteger" },
+    "definitions": {
+        "positiveInteger": {
+            "type": "integer",
+            "minimum": 0,
+            "exclusiveMinimum": true
+        }
+    }
+}
+
+</pre></div><p>
+
+                        
+</p>
+<a name="anchor97"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.6"></a><h3>6.&nbsp;
+Metadata keywords</h3>
+
+<a name="anchor98"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.6.1"></a><h3>6.1.&nbsp;
+"title" and "description"</h3>
+
+<a name="anchor99"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.6.1.1"></a><h3>6.1.1.&nbsp;
+Valid values</h3>
+
+<p>
+                        The value of both of these keywords MUST be a string.
+                    
+</p>
+<a name="anchor100"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.6.1.2"></a><h3>6.1.2.&nbsp;
+Purpose</h3>
+
+<p>
+                        Both of these keywords can be used to decorate a user interface with
+                        information about the data produced by this user interface. A title will
+                        preferrably be short, whereas a description will provide explanation about
+                        the purpose of the instance described by this schema.
+                    
+</p>
+<p>
+                        Both of these keywords MAY be used in root schemas, and in any subschemas.
+                    
+</p>
+<a name="anchor101"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.6.2"></a><h3>6.2.&nbsp;
+"default"</h3>
+
+<a name="anchor102"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.6.2.1"></a><h3>6.2.1.&nbsp;
+Valid values</h3>
+
+<p>
+                        There are no restrictions placed on the value of this keyword.
+                    
+</p>
+<a name="anchor103"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.6.2.2"></a><h3>6.2.2.&nbsp;
+Purpose</h3>
+
+<p>
+                        This keyword can be used to supply a default JSON value associated with a
+                        particular schema. It is RECOMMENDED that a default value be valid against
+                        the associated schema.
+                    
+</p>
+<p>
+                        This keyword MAY be used in root schemas, and in any subschemas.
+                    
+</p>
+<a name="anchor104"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.7"></a><h3>7.&nbsp;
+Semantic validation with "format"</h3>
+
+<a name="anchor105"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.7.1"></a><h3>7.1.&nbsp;
+Foreword</h3>
+
+<p>
+                    Structural validation alone may be insufficient to validate that an instance
+                    meets all the requirements of an application. The "format" keyword is defined to
+                    allow interoperable semantic validation for a fixed subset of values which are
+                    accurately described by authoritative resources, be they RFCs or other external
+                    specifications.
+                
+</p>
+<p>
+                    The value of this keyword is called a format attribute. It MUST be a string. A
+                    format attribute can generally only validate a given set of instance types. If
+                    the type of the instance to validate is not in this set, validation for this
+                    format attribute and instance SHOULD succeed.
+                
+</p>
+<a name="anchor106"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.7.2"></a><h3>7.2.&nbsp;
+Implementation requirements</h3>
+
+<p>
+                    Implementations MAY support the "format" keyword. Should they choose to do so:
+                    
+                    </p>
+<blockquote class="text">
+<p>they SHOULD implement validation for attributes defined below;
+</p>
+<p>they SHOULD offer an option to disable validation for this keyword.
+</p>
+</blockquote><p>
+                    
+                
+</p>
+<p>
+                    Implementations MAY add custom format attributes. Save for agreement between
+                    parties, schema authors SHALL NOT expect a peer implementation to support this
+                    keyword and/or custom format attributes.
+                
+</p>
+<a name="anchor107"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.7.3"></a><h3>7.3.&nbsp;
+Defined attributes</h3>
+
+<a name="anchor108"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.7.3.1"></a><h3>7.3.1.&nbsp;
+date-time</h3>
+
+<a name="anchor109"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.7.3.1.1"></a><h3>7.3.1.1.&nbsp;
+Applicability</h3>
+
+<p>
+                            This attribute applies to string instances.
+                        
+</p>
+<a name="anchor110"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.7.3.1.2"></a><h3>7.3.1.2.&nbsp;
+Validation</h3>
+
+<p>
+                            A string instance is valid against this attribute if it is a valid date
+                            representation as defined by <a class='info' href='#RFC3339'>RFC 3339, section
+                            5.6<span> (</span><span class='info'>Klyne, G., Ed. and C. Newman, &ldquo;Date and Time on the Internet: Timestamps,&rdquo; July&nbsp;2002.</span><span>)</span></a> [RFC3339].
+                        
+</p>
+<a name="anchor111"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.7.3.2"></a><h3>7.3.2.&nbsp;
+email</h3>
+
+<a name="anchor112"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.7.3.2.1"></a><h3>7.3.2.1.&nbsp;
+Applicability</h3>
+
+<p>
+                            This attribute applies to string instances.
+                        
+</p>
+<a name="anchor113"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.7.3.2.2"></a><h3>7.3.2.2.&nbsp;
+Validation</h3>
+
+<p>
+                            A string instance is valid against this attribute if it is a valid
+                            Internet email address as defined by <a class='info' href='#RFC5322'>RFC 5322,
+                            section 3.4.1<span> (</span><span class='info'>Resnick, P., Ed., &ldquo;Internet Message Format,&rdquo; October&nbsp;2008.</span><span>)</span></a> [RFC5322].
+                        
+</p>
+<a name="anchor114"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.7.3.3"></a><h3>7.3.3.&nbsp;
+hostname</h3>
+
+<a name="anchor115"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.7.3.3.1"></a><h3>7.3.3.1.&nbsp;
+Applicability</h3>
+
+<p>
+                            This attribute applies to string instances.
+                        
+</p>
+<a name="anchor116"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.7.3.3.2"></a><h3>7.3.3.2.&nbsp;
+Validation</h3>
+
+<p>
+                            A string instance is valid against this attribute if it is a valid
+                            representation for an Internet host name, as defined by <a class='info' href='#RFC1034'>RFC 1034, section 3.1<span> (</span><span class='info'>Mockapetris, P., &ldquo;Domain names - concepts and facilities,&rdquo; November&nbsp;1987.</span><span>)</span></a> [RFC1034].
+                        
+</p>
+<a name="anchor117"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.7.3.4"></a><h3>7.3.4.&nbsp;
+ipv4</h3>
+
+<a name="anchor118"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.7.3.4.1"></a><h3>7.3.4.1.&nbsp;
+Applicability</h3>
+
+<p>
+                            This attribute applies to string instances.
+                        
+</p>
+<a name="anchor119"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.7.3.4.2"></a><h3>7.3.4.2.&nbsp;
+Validation</h3>
+
+<p>
+                            A string instance is valid against this attribute if it is a valid
+                            representation of an IPv4 address according to the "dotted-quad" ABNF
+                            syntax as defined in <a class='info' href='#RFC2673'>RFC 2673, section
+                            3.2<span> (</span><span class='info'>Crawford, M., &ldquo;Binary Labels in the Domain Name System,&rdquo; August&nbsp;1999.</span><span>)</span></a> [RFC2673].
+                        
+</p>
+<a name="anchor120"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.7.3.5"></a><h3>7.3.5.&nbsp;
+ipv6</h3>
+
+<a name="anchor121"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.7.3.5.1"></a><h3>7.3.5.1.&nbsp;
+Applicability</h3>
+
+<p>
+                            This attribute applies to string instances.
+                        
+</p>
+<a name="anchor122"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.7.3.5.2"></a><h3>7.3.5.2.&nbsp;
+Validation</h3>
+
+<p>
+                            A string instance is valid against this attribute if it is a valid
+                            representation of an IPv6 address as defined in <a class='info' href='#RFC2373'>RFC 2373, section 2.2<span> (</span><span class='info'>Hinden, R. and S. Deering, &ldquo;IP Version 6 Addressing Architecture,&rdquo; July&nbsp;1998.</span><span>)</span></a> [RFC2373].
+                        
+</p>
+<a name="anchor123"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.7.3.6"></a><h3>7.3.6.&nbsp;
+uri</h3>
+
+<a name="anchor124"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.7.3.6.1"></a><h3>7.3.6.1.&nbsp;
+Applicability</h3>
+
+<p>
+                            This attribute applies to string instances.
+                        
+</p>
+<a name="anchor125"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.7.3.6.2"></a><h3>7.3.6.2.&nbsp;
+Validation</h3>
+
+<p>
+                            A string instance is valid against this attribute if it is a valid URI,
+                            according to <a class='info' href='#RFC3986'>[RFC3986]<span> (</span><span class='info'>Berners-Lee, T., Fielding, R., and L. Masinter, &ldquo;Uniform Resource Identifier (URI): Generic Syntax,&rdquo; January&nbsp;2005.</span><span>)</span></a>.
+                        
+</p>
+<a name="anchor126"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.8"></a><h3>8.&nbsp;
+Reference algorithms for calculating children schemas</h3>
+
+<a name="anchor127"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.8.1"></a><h3>8.1.&nbsp;
+Foreword</h3>
+
+<p>
+                    Calculating the schema, or schemas, a child instance must validate against is
+                    influenced by the following:
+
+                    </p>
+<blockquote class="text">
+<p>the container instance type;
+</p>
+<p>the child instance's defining characteristic in the container
+                        instance;
+</p>
+<p>the value of keywords implied in the calculation.
+</p>
+</blockquote><p>
+                
+</p>
+<p>
+                    In addition, it is important that if one or more keyword(s) implied in the
+                    calculation are not defined, they be considered present with their default
+                    value, which will be recalled in this section.
+                
+</p>
+<a name="anchor128"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.8.2"></a><h3>8.2.&nbsp;
+Array elements</h3>
+
+<a name="anchor129"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.8.2.1"></a><h3>8.2.1.&nbsp;
+Defining characteristic</h3>
+
+<p>
+                        The defining characteristic of the child instance is its index within the
+                        array. Recall: array indices start at 0.
+                    
+</p>
+<a name="anchor130"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.8.2.2"></a><h3>8.2.2.&nbsp;
+Implied keywords and default values.</h3>
+
+<p>
+                        The two implied keywords in this calculation are "items" and
+                        "additionalItems".
+                    
+</p>
+<p>
+                        If either keyword is absent, it is considered present with an empty schema as a
+                        value. In addition, boolean value true for "additionalItems" is considered
+                        equivalent to an empty schema.
+                    
+</p>
+<a name="anchor131"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.8.2.3"></a><h3>8.2.3.&nbsp;
+Calculation</h3>
+
+<a name="anchor132"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.8.2.3.1"></a><h3>8.2.3.1.&nbsp;
+If "items" is a schema</h3>
+
+<p>
+                            If items is a schema, then the child instance must be valid against this
+                            schema, regardless of its index, and regardless of the value of
+                            "additionalItems".
+                        
+</p>
+<a name="anchor133"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.8.2.3.2"></a><h3>8.2.3.2.&nbsp;
+If "items" is an array</h3>
+
+<p>
+                            In this situation, the schema depends on the index:
+
+                            </p>
+<blockquote class="text">
+<p>if the index is less than, or equal to, the size of "items", the
+                                child instance must be valid against the corresponding schema in the
+                                "items" array;
+</p>
+<p>otherwise, it must be valid against the schema defined by
+                                "additionalItems".
+</p>
+</blockquote><p>
+                        
+</p>
+<a name="anchor134"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.8.3"></a><h3>8.3.&nbsp;
+Object members</h3>
+
+<a name="anchor135"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.8.3.1"></a><h3>8.3.1.&nbsp;
+Defining characteristic</h3>
+
+<p>
+                        The defining characteristic is the property name of the child.
+                    
+</p>
+<a name="anchor136"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.8.3.2"></a><h3>8.3.2.&nbsp;
+Implied keywords</h3>
+
+<p>
+                        The three keywords implied in this calculation are "properties",
+                        "patternProperties" and "additionalProperties".
+                    
+</p>
+<p>
+                        If "properties" or "patternProperties" are absent, they are considered
+                        present with an empty object as a value.
+                    
+</p>
+<p>
+                        If "additionalProperties" is absent, it is considered present with an empty
+                        schema as a value. In addition, boolean value true is considered equivalent
+                        to an empty schema.
+                    
+</p>
+<a name="anchor137"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.8.3.3"></a><h3>8.3.3.&nbsp;
+Calculation</h3>
+
+<a name="anchor138"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.8.3.3.1"></a><h3>8.3.3.1.&nbsp;
+Names used in this calculation</h3>
+
+<p>
+                            The calculation below uses the following names:
+
+                            </p>
+<blockquote class="text"><dl>
+<dt>m</dt>
+<dd>The property name of the child.
+</dd>
+<dt>p</dt>
+<dd>The property set from "properties".
+</dd>
+<dt>pp</dt>
+<dd>The property set from "patternProperties". Elements
+                                of this set will be called regexes for convenience.
+</dd>
+<dt>s</dt>
+<dd>The set of schemas for the child instance.
+</dd>
+</dl></blockquote><p>
+                        
+</p>
+<a name="anchor139"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.8.3.3.2"></a><h3>8.3.3.2.&nbsp;
+First step: schemas in "properties"</h3>
+
+<p>
+                            If set "p" contains value "m", then the corresponding schema in
+                            "properties" is added to "s".
+                        
+</p>
+<a name="anchor140"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.8.3.3.3"></a><h3>8.3.3.3.&nbsp;
+Second step: schemas in "patternProperties"</h3>
+
+<p>
+                            For each regex in "pp", if it matches "m" successfully, the
+                            corresponding schema in "patternProperties" is added to "s".
+                        
+</p>
+<a name="anchor141"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.8.3.3.4"></a><h3>8.3.3.4.&nbsp;
+Third step: "additionalProperties"</h3>
+
+<p>
+                            The schema defined by "additionalProperties" is added to "s" if and only
+                            if, at this stage, "s" is empty.
+                        
+</p>
+<a name="anchor142"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.9"></a><h3>9.&nbsp;
+IANA Considerations</h3>
+
+<p>
+                This specification does not have any influence with regards to IANA.
+            
+</p>
+<a name="rfc.references"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.10"></a><h3>10.&nbsp;
+References</h3>
+
+<a name="rfc.references1"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<h3>10.1.&nbsp;Normative References</h3>
+<table width="99%" border="0">
+<tr><td class="author-text" valign="top"><a name="RFC2119">[RFC2119]</a></td>
+<td class="author-text"><a href="mailto:sob@harvard.edu">Bradner, S.</a>, &ldquo;<a href="http://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>,&rdquo; BCP&nbsp;14, RFC&nbsp;2119, March&nbsp;1997 (<a href="http://www.rfc-editor.org/rfc/rfc2119.txt">TXT</a>, <a href="http://xml.resource.org/public/rfc/html/rfc2119.html">HTML</a>, <a href="http://xml.resource.org/public/rfc/xml/rfc2119.xml">XML</a>).</td></tr>
+</table>
+
+<a name="rfc.references2"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<h3>10.2.&nbsp;Informative References</h3>
+<table width="99%" border="0">
+<tr><td class="author-text" valign="top"><a name="RFC1034">[RFC1034]</a></td>
+<td class="author-text">Mockapetris, P., &ldquo;<a href="http://tools.ietf.org/html/rfc1034">Domain names - concepts and facilities</a>,&rdquo; STD&nbsp;13, RFC&nbsp;1034, November&nbsp;1987 (<a href="http://www.rfc-editor.org/rfc/rfc1034.txt">TXT</a>).</td></tr>
+<tr><td class="author-text" valign="top"><a name="RFC2373">[RFC2373]</a></td>
+<td class="author-text"><a href="mailto:hinden@iprg.nokia.com">Hinden, R.</a> and <a href="mailto:deering@cisco.com">S. Deering</a>, &ldquo;<a href="http://tools.ietf.org/html/rfc2373">IP Version 6 Addressing Architecture</a>,&rdquo; RFC&nbsp;2373, July&nbsp;1998 (<a href="http://www.rfc-editor.org/rfc/rfc2373.txt">TXT</a>, <a href="http://xml.resource.org/public/rfc/xml/rfc2373.xml">XML</a>).</td></tr>
+<tr><td class="author-text" valign="top"><a name="RFC2673">[RFC2673]</a></td>
+<td class="author-text"><a href="mailto:crawdad@fnal.gov">Crawford, M.</a>, &ldquo;<a href="http://tools.ietf.org/html/rfc2673">Binary Labels in the Domain Name System</a>,&rdquo; RFC&nbsp;2673, August&nbsp;1999 (<a href="http://www.rfc-editor.org/rfc/rfc2673.txt">TXT</a>).</td></tr>
+<tr><td class="author-text" valign="top"><a name="RFC3339">[RFC3339]</a></td>
+<td class="author-text"><a href="mailto:GK@ACM.ORG">Klyne, G., Ed.</a> and <a href="mailto:chris.newman@sun.com">C. Newman</a>, &ldquo;<a href="http://tools.ietf.org/html/rfc3339">Date and Time on the Internet: Timestamps</a>,&rdquo; RFC&nbsp;3339, July&nbsp;2002 (<a href="http://www.rfc-editor.org/rfc/rfc3339.txt">TXT</a>, <a href="http://xml.resource.org/public/rfc/html/rfc3339.html">HTML</a>, <a href="http://xml.resource.org/public/rfc/xml/rfc3339.xml">XML</a>).</td></tr>
+<tr><td class="author-text" valign="top"><a name="RFC3986">[RFC3986]</a></td>
+<td class="author-text"><a href="mailto:timbl@w3.org">Berners-Lee, T.</a>, <a href="mailto:fielding@gbiv.com">Fielding, R.</a>, and <a href="mailto:LMM@acm.org">L. Masinter</a>, &ldquo;<a href="http://tools.ietf.org/html/rfc3986">Uniform Resource Identifier (URI): Generic Syntax</a>,&rdquo; STD&nbsp;66, RFC&nbsp;3986, January&nbsp;2005 (<a href="http://www.rfc-editor.org/rfc/rfc3986.txt">TXT</a>, <a href="http://xml.resource.org/public/rfc/html/rfc3986.html">HTML</a>, <a href="http://xml.resource.org/public/rfc/xml/rfc3986.xml">XML</a>).</td></tr>
+<tr><td class="author-text" valign="top"><a name="RFC4627">[RFC4627]</a></td>
+<td class="author-text">Crockford, D., &ldquo;<a href="http://tools.ietf.org/html/rfc4627">The application/json Media Type for JavaScript Object Notation (JSON)</a>,&rdquo; RFC&nbsp;4627, July&nbsp;2006 (<a href="http://www.rfc-editor.org/rfc/rfc4627.txt">TXT</a>).</td></tr>
+<tr><td class="author-text" valign="top"><a name="RFC5322">[RFC5322]</a></td>
+<td class="author-text"><a href="mailto:presnick@qualcomm.com">Resnick, P., Ed.</a>, &ldquo;<a href="http://tools.ietf.org/html/rfc5322">Internet Message Format</a>,&rdquo; RFC&nbsp;5322, October&nbsp;2008 (<a href="http://www.rfc-editor.org/rfc/rfc5322.txt">TXT</a>, <a href="http://xml.resource.org/public/rfc/html/rfc5322.html">HTML</a>, <a href="http://xml.resource.org/public/rfc/xml/rfc5322.xml">XML</a>).</td></tr>
+<tr><td class="author-text" valign="top"><a name="ecma262">[ecma262]</a></td>
+<td class="author-text">&ldquo;<a href="http://www.ecma-international.org/publications/files/ECMA-ST/Ecma-262.pdf">ECMA 262 specification</a>.&rdquo;</td></tr>
+</table>
+
+<a name="anchor145"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.A"></a><h3>Appendix A.&nbsp;
+ChangeLog</h3>
+
+<p>
+                </p>
+<blockquote class="text"><dl>
+<dt>draft-00</dt>
+<dd>
+                        
+<ul class="text">
+<li>Initial draft.
+</li>
+<li>Salvaged from draft v3.
+</li>
+<li>Redefine the "required" keyword.
+</li>
+<li>Remove "extends", "disallow"
+</li>
+<li>Add "anyOf", "allOf", "oneOf", "not", "definitions", "minProperties",
+                            "maxProperties".
+</li>
+<li>"dependencies" member values can no longer be single strings; at
+                            least one element is required in a property dependency array.
+</li>
+<li>Rename "divisibleBy" to "multipleOf".
+</li>
+<li>"type" arrays can no longer have schemas; remove "any" as a possible
+                            value.
+</li>
+<li>Rework the "format" section; make support optional.
+</li>
+<li>"format": remove attributes "phone", "style", "color"; rename
+                            "ip-address" to "ipv4"; add references for all attributes.
+</li>
+<li>Provide algorithms to calculate schema(s) for array/object
+                            instances.
+</li>
+<li>Add interoperability considerations.
+</li>
+</ul>
+                    
+</dd>
+</dl></blockquote><p>
+            
+</p>
+<a name="rfc.authors"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<h3>Authors' Addresses</h3>
+<table width="99%" border="0" cellpadding="0" cellspacing="0">
+<tr><td class="author-text">&nbsp;</td>
+<td class="author-text">Francis Galiegue</td></tr>
+<tr><td class="author" align="right">EMail:&nbsp;</td>
+<td class="author-text"><a href="mailto:fgaliegue@gmail.com">fgaliegue@gmail.com</a></td></tr>
+<tr cellpadding="3"><td>&nbsp;</td><td>&nbsp;</td></tr>
+<tr><td class="author-text">&nbsp;</td>
+<td class="author-text">Kris Zyp (editor)</td></tr>
+<tr><td class="author-text">&nbsp;</td>
+<td class="author-text">SitePen (USA)</td></tr>
+<tr><td class="author-text">&nbsp;</td>
+<td class="author-text">530 Lytton Avenue</td></tr>
+<tr><td class="author-text">&nbsp;</td>
+<td class="author-text">Palo Alto, CA 94301</td></tr>
+<tr><td class="author-text">&nbsp;</td>
+<td class="author-text">USA</td></tr>
+<tr><td class="author" align="right">Phone:&nbsp;</td>
+<td class="author-text">+1 650 968 8787</td></tr>
+<tr><td class="author" align="right">EMail:&nbsp;</td>
+<td class="author-text"><a href="mailto:kris@sitepen.com">kris@sitepen.com</a></td></tr>
+<tr cellpadding="3"><td>&nbsp;</td><td>&nbsp;</td></tr>
+<tr><td class="author-text">&nbsp;</td>
+<td class="author-text">Gary Court</td></tr>
+<tr><td class="author-text">&nbsp;</td>
+<td class="author-text">Calgary, AB</td></tr>
+<tr><td class="author-text">&nbsp;</td>
+<td class="author-text">Canada</td></tr>
+<tr><td class="author" align="right">EMail:&nbsp;</td>
+<td class="author-text"><a href="mailto:gary.court@gmail.com">gary.court@gmail.com</a></td></tr>
+</table>
+</body></html>


### PR DESCRIPTION
This PR aims to resolve https://github.com/json-schema-org/json-schema-org.github.io/issues/59 by adding the old draft-04 docs to the draft-04 directory. 

They will end up being hosted on the website, but will not have direct links to them. This will allow us to maintain links to the older version from docs that depend on it.

If merged, I'll update the OAI/Swagger 2.0 spec with the links to the new location.