### PR TITLE
Add page titles

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -19,7 +19,7 @@
         </label>
 
         <div class="trigger">
-          <a class="page-link" href="{{ "/documentation.html" | relative_url }}">Docs</a>
+          <a class="page-link" href="{{ "/documentation.html" | relative_url }}">Specification</a>
           <a class="page-link" href="{{ "/examples.html" | relative_url }}">Examples</a>
           <a class="page-link" href="{{ "/implementations.html" | relative_url }}">Software</a>
           {% for path in page_paths %}

--- a/documentation.md
+++ b/documentation.md
@@ -1,9 +1,7 @@
 ---
 layout: page
+title: Specification
 ---
-
-Specification
--------------
 
 The latest Internet-Drafts at the IETF are the draft-wright-json-schema\*-01 documents, which correspond to the draft-06 meta-schemas. These were published on 2017-04-15. (Due to a change in authorship the I-D numbering was reset with the previous draft). The specification is split into three parts, Core, Validation, and Hyper-Schema:
 

--- a/example1.md
+++ b/example1.md
@@ -1,9 +1,7 @@
 ---
 layout: page
+title: Building a product schema
 ---
-
-Example data
-------------
 
 Let's pretend we're interacting with a JSON based product catalog. This catalog has a product which has an *id*, a *name*, a *price*, and an optional set of *tags*.
 

--- a/example2.md
+++ b/example2.md
@@ -1,9 +1,7 @@
 ---
 layout: page
+title: Building a mount point schema
 ---
-
-Purpose
--------
 
 This example shows a possible JSON representation of a hypothetical machine's mount points as represented in an `/etc/fstab` file.
 

--- a/examples.md
+++ b/examples.md
@@ -1,9 +1,7 @@
 ---
 layout: page
+title: Examples
 ---
-
-Basic example
--------------
 
 Here is a basic example of a JSON Schema:
 


### PR DESCRIPTION
Adds page titles.  This also renames the 'Docs' entry to 'Specification' better matching the page content.

Page layout generally looked better (no whitespace gap) when displaying the title rather than an initial heading, so I removed the initial heading where applicable.

Resolves #93