### PR TITLE
Add Google Analytics

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,6 +20,7 @@ baseurl: "" # the subpath of your site, e.g. /blog
 url: "" # the base hostname & protocol for your site
 #twitter_username: jekyllrb
 github_username:  json-schema-org
+google_analytics: UA-99695987-1
 
 # Build settings
 markdown: kramdown


### PR DESCRIPTION
As mentioned by @Relequestual in https://github.com/json-schema-org/json-schema-org.github.io/issues/31#issuecomment-300739895

This only affects html pages processed by Jekyll, so things like the specifications are not covered.

I granted @Relequestual full permissions to the analytics account so he should be able to add other users and remove me as appropriate.