### PR TITLE
Use Markdown link syntax for implementation links

### DIFF
--- a/implementations.md
+++ b/implementations.md
@@ -38,162 +38,162 @@ Validators
 <!-- -->
 
 - .NET <a id="validator-dotnet"></a>
-    -   <a href="http://james.newtonking.com/projects/json-net.aspx" id="link-impl-json-net">Json.NET</a> (MIT)
-    -   <a href="http://NJsonSchema.org" id="link-impl-n-json-schema">NJsonSchema</a> - *supports version 4* (Ms-PL)
+    -   [Json.NET](http://james.newtonking.com/projects/json-net.aspx) (MIT)
+    -   [NJsonSchema](http://NJsonSchema.org) - *supports version 4* (Ms-PL)
 - ActionScript 3 <a id="validator-action-script-3"></a>
-    -   <a href="https://github.com/raulbajales/Frigga" id="link-impl-frigga">Frigga</a> (MIT)
+    -   [Frigga](https://github.com/raulbajales/Frigga) (MIT)
 - C <a id="validator-c"></a>
-    -   <a href="https://github.com/netmail-open/wjelement" id="link-impl-wjelement">WJElement</a> (LGPLv3)
+    -   [WJElement](https://github.com/netmail-open/wjelement) (LGPLv3)
 - C++ <a id="validator-cpp"></a>
-    -   <a href="https://github.com/petehug/wjelement-cpp" id="link-impl-wjelement">wjelement-cpp</a> - *supports version 4* (LGPLv3)
-    -   <a href="https://github.com/tristanpenman/valijson" id="link-impl-valijson">Header-only C++ library for JSON Schema validation</a> - *supports only version 4* (BSD-2-Clause)
-    -   <a href="https://github.com/pboettch/json-schema-validator" id="link-impl-modern-c++-validator">Modern C++ JSON schema validator</a> - *supports only version 4* based on JSON for Modern C++ (MIT)
+    -   [wjelement-cpp](https://github.com/petehug/wjelement-cpp) - *supports version 4* (LGPLv3)
+    -   [Header-only C++ library for JSON Schema validation](https://github.com/tristanpenman/valijson) - *supports only version 4* (BSD-2-Clause)
+    -   [Modern C++ JSON schema validator](https://github.com/pboettch/json-schema-validator) - *supports only version 4* based on JSON for Modern C++ (MIT)
 - Clojure <a id="validator-clojure"></a>
-    -   <a href="https://github.com/metosin/scjsv" id="link-impl-metosin-scjsv">scjsv</a> - *supports version 4* (wrapper for [fge/json-schema-validator](https://github.com/fge/json-schema-validator)) (Eclipse Public License v1.0)
+    -   [scjsv](https://github.com/metosin/scjsv) - *supports version 4* (wrapper for [fge/json-schema-validator](https://github.com/fge/json-schema-validator)) (Eclipse Public License v1.0)
 -  Dart <a id="validator-dart"></a>
-    -   <a href="https://github.com/patefacio/json_schema" id="link-impl-dart-jsonschema">json_schema</a> *supports version 4* (BSL-1.0)
+    -   [json_schema](https://github.com/patefacio/json_schema) *supports version 4* (BSL-1.0)
 - Erlang <a name="validator-erlang"></a>
-    -   <a href="https://github.com/for-GET/jesse" id="link-impl-jesse">JeSSE</a> (Apache 2.0)
+    -   [JeSSE](https://github.com/for-GET/jesse) (Apache 2.0)
 - Go <a name="validator-go"></a>
-    -   <a href="https://github.com/sigu-399/gojsonschema" id="link-impl-gojsonschema">gojsonschema</a> (Apache 2.0)
-    -   <a href="https://github.com/santhosh-tekuri/jsonschema" id="link-impl-st-jsonschema">jsonschema</a> *supports version 4* (BSD-3-Clause)
+    -   [gojsonschema](https://github.com/sigu-399/gojsonschema) (Apache 2.0)
+    -   [jsonschema](https://github.com/santhosh-tekuri/jsonschema) *supports version 4* (BSD-3-Clause)
 - Haskell <a id="validator-haskell"></a>
-    -   <a href="https://github.com/timjb/aeson-schema" id="link-impl-aeson-schema">aeson-schema</a> (MIT)
-    -   <a href="https://github.com/seagreen/hjsonschema" id="link-impl-hjsonschema">hjsonschema</a> - *supports version 4* (MIT)
+    -   [aeson-schema](https://github.com/timjb/aeson-schema) (MIT)
+    -   [hjsonschema](https://github.com/seagreen/hjsonschema) - *supports version 4* (MIT)
 - Java <a id="validator-java"></a>
-    -   <a href="https://github.com/fge/json-schema-validator" id="link-impl-fge-json-schema-validator">json-schema-validator</a> - *supports version 4* (LGPLv3)
-    -   <a href="https://github.com/everit-org/json-schema" id="link-impl-everit-json-schema">json-schema (implementation based on the org.json API)</a> - *supports version 4* (Apache License 2.0)
-    -   <a href="https://github.com/networknt/json-schema-validator" id="link-impl-networknt-json-schema">json-schema-validator</a> - *supports version 4* (Apache License 2.0)
+    -   [json-schema-validator](https://github.com/fge/json-schema-validator) - *supports version 4* (LGPLv3)
+    -   [json-schema (implementation based on the org.json API)](https://github.com/everit-org/json-schema) - *supports version 4* (Apache License 2.0)
+    -   [json-schema-validator](https://github.com/networknt/json-schema-validator) - *supports version 4* (Apache License 2.0)
 - JavaScript <a id="validator-javascript"></a>
-    -   <a href="https://github.com/epoberezkin/ajv" id="link-impl-ajv">ajv</a> for Node.js and browsers - *supports version 4, version 6, [custom keywords](https://github.com/epoberezkin/ajv-keywords) and [$data reference](https://github.com/json-schema-org/json-schema-spec/issues/51)* (MIT)
-    -   <a href="https://github.com/korzio/djv" id="link-impl-djv">djv</a> for Node.js and browsers - *supports version 4* (MIT)
-    -   <a href="https://github.com/tdegrunt/jsonschema" id="link-impl-tdegrunt-jsonschema">jsonschema</a> for Node.js - *supports version 4* (MIT)
-    -   <a href="https://github.com/mafintosh/is-my-json-valid" id="link-impl-is-my-json-valid">is-my-json-valid</a> - *supports version 4* (MIT)
-    -   <a href="http://geraintluff.github.com/tv4/" id="link-impl-tv4">tv4</a> - *supports version 4* (Public Domain)
-    -   <a href="https://github.com/natesilva/jayschema" id="link-impl-jayschema">JaySchema</a> for Node.js - *supports version 4* (BSD)
-    -   <a href="https://github.com/zaggino/z-schema" id="link-impl-z-schema">z-schema</a> for Node.js - *supports version 4* (MIT)
-    -   <a href="http://github.com/IreneKnapp/direct-schema" id="link-impl-direct-schema">direct-schema</a> (BSD)
-    -   <a href="http://github.com/garycourt/JSV" id="link-impl-jsv">JSV</a> (BSD)
-    -   <a href="http://github.com/kriszyp/json-schema" id="link-impl-kriszyp-jsonschema">json-schema</a> (AFL or BSD) as part of <a href="http://www.persvr.org/" id="link-impl-persvr">Persevere</a>
-    -   <a href="https://github.com/akidee/schema.js" id="link-impl-schema-js">schema.js</a> (MIT)
-    -   <a href="https://github.com/oferei/json-gate" id="link-impl-json-gate">json-gate</a> (MIT)
-    -   <a href="https://github.com/bugventure/jsen" id="link-impl-jsen">JSEN</a> for Node.js - *supports version 4* (MIT)
+    -   [ajv](https://github.com/epoberezkin/ajv) for Node.js and browsers - *supports version 4, version 6, [custom keywords](https://github.com/epoberezkin/ajv-keywords) and [$data reference](https://github.com/json-schema-org/json-schema-spec/issues/51)* (MIT)
+    -   [djv](https://github.com/korzio/djv) for Node.js and browsers - *supports version 4* (MIT)
+    -   [jsonschema](https://github.com/tdegrunt/jsonschema) for Node.js - *supports version 4* (MIT)
+    -   [is-my-json-valid](https://github.com/mafintosh/is-my-json-valid) - *supports version 4* (MIT)
+    -   [tv4](http://geraintluff.github.com/tv4/) - *supports version 4* (Public Domain)
+    -   [JaySchema](https://github.com/natesilva/jayschema) for Node.js - *supports version 4* (BSD)
+    -   [z-schema](https://github.com/zaggino/z-schema) for Node.js - *supports version 4* (MIT)
+    -   [direct-schema](http://github.com/IreneKnapp/direct-schema) (BSD)
+    -   [JSV](http://github.com/garycourt/JSV) (BSD)
+    -   [json-schema</a> (AFL or BSD) as part of <a href="http://www.persvr.org/" id="link-impl-persvr">Persevere](http://github.com/kriszyp/json-schema)
+    -   [schema.js](https://github.com/akidee/schema.js) (MIT)
+    -   [json-gate](https://github.com/oferei/json-gate) (MIT)
+    -   [JSEN](https://github.com/bugventure/jsen) for Node.js - *supports version 4* (MIT)
 - PHP <a id="validator-php"></a>
-    -   <a href="https://github.com/geraintluff/jsv4-php" id="link-impl-jsv4-php">jsv4-php</a> - *supports version 4* (Public Domain / MIT)
-    -   <a href="https://github.com/hasbridge/php-json-schema" id="link-impl-php-json-schema">php-json-schema</a> (MIT)
-    -   <a href="https://github.com/justinrainbow/json-schema" id="link-impl-json-schema">json-schema</a> (Berkeley)
-    -   <a href="https://github.com/stefk/jval" id="link-impl-jval">JVal</a> - *supports version 4* (MIT)
-    -   <a href="https://github.com/thephpleague/json-guard" id="link-impl-json-guard">JSON Guard</a> - *supports version 4* (MIT)
+    -   [jsv4-php](https://github.com/geraintluff/jsv4-php) - *supports version 4* (Public Domain / MIT)
+    -   [php-json-schema](https://github.com/hasbridge/php-json-schema) (MIT)
+    -   [json-schema](https://github.com/justinrainbow/json-schema) (Berkeley)
+    -   [JVal](https://github.com/stefk/jval) - *supports version 4* (MIT)
+    -   [JSON Guard](https://github.com/thephpleague/json-guard) - *supports version 4* (MIT)
 - Perl <a id="validator-perl"></a>
-    -   <a href="https://metacpan.org/module/JSV::Validator" id="link-impl-perl-jsv-validator">JSV::Validator</a> (MIT)
-    -   <a href="https://metacpan.org/module/JSON::Schema" id="link-impl-perl-json-schema">JSON::Schema</a> (MIT)
+    -   [JSV::Validator](https://metacpan.org/module/JSV::Validator) (MIT)
+    -   [JSON::Schema](https://metacpan.org/module/JSON::Schema) (MIT)
 - Python <a id="validator-python"></a>
-    -   <a href="https://github.com/Julian/jsonschema" id="link-impl-jsonschema">jsonschema</a> - *supports version 4* (MIT)
-    -   <a href="https://github.com/zyga/json-schema-validator" id="link-impl-zyga-json-schema-validator">json-schema-validator</a> (LGPL)
+    -   [jsonschema](https://github.com/Julian/jsonschema) - *supports version 4* (MIT)
+    -   [json-schema-validator](https://github.com/zyga/json-schema-validator) (LGPL)
 - Ruby <a id="validator-ruby"></a>
-    -   <a href="https://github.com/Constellation/ruby-jsonchema" id="link-impl-ruby-jsonchema">ruby-jsonschema</a> (MIT)
-    -   <a href="https://github.com/hoxworth/json-schema" id="link-impl-ruby-hoxworth-json-schema">json-schema</a> - *supports version 4* (MIT)
+    -   [ruby-jsonschema](https://github.com/Constellation/ruby-jsonchema) (MIT)
+    -   [json-schema](https://github.com/hoxworth/json-schema) - *supports version 4* (MIT)
 
 ### Online
 
--   <a href="http://jsonschemalint.com/" id="link-impl-jsonschemalint">JSON Schema Lint</a> - validate against your own schemas
--   <a href="http://schemastore.org/validator/" id="link-impl-schemastore">SchemaStore.org</a> - validate against common JSON Schemas
+-   [JSON Schema Lint](http://jsonschemalint.com/) - validate against your own schemas
+-   [SchemaStore.org](http://schemastore.org/validator/) - validate against common JSON Schemas
 
 Validation benchmarks
 ---------------------
 
 -   Java
-    -   <a href="https://github.com/networknt/json-schema-validator-perftest" id="link-bench-networknt">json-schema-validator-benchmark</a> - compares performance of three JSON schema validator implementations in Java(Apache 2.0)
+    -   [json-schema-validator-benchmark](https://github.com/networknt/json-schema-validator-perftest) - compares performance of three JSON schema validator implementations in Java(Apache 2.0)
 
 <!-- -->
 
 -   JavaScript
-    -   <a href="https://github.com/ebdrup/json-schema-benchmark" id="link-bench-ebdrup">json-schema-benchmark</a> - an independent benchmark for Node.js JSON-schema validators based on JSON-Schema Test Suite (MIT)
-    -   <a href="https://github.com/zaggino/z-schema#benchmarks" id="link-bench-z-schema">z-schema validator benchmark</a> - compares performance in the individual tests from JSON-Schema Test Suite (MIT)
-    -   <a href="https://github.com/pandastrike/jsck#benchmarks" id="link-bench-jsck">JSCK validator benchmark</a> - shows performance for JSON-schemas of different complexity (MIT)
+    -   [json-schema-benchmark](https://github.com/ebdrup/json-schema-benchmark) - an independent benchmark for Node.js JSON-schema validators based on JSON-Schema Test Suite (MIT)
+    -   [z-schema validator benchmark](https://github.com/zaggino/z-schema#benchmarks) - compares performance in the individual tests from JSON-Schema Test Suite (MIT)
+    -   [JSCK validator benchmark](https://github.com/pandastrike/jsck#benchmarks) - shows performance for JSON-schemas of different complexity (MIT)
 
 Schema generation
 -----------------
 
 -   .NET
-    -   <a href="http://james.newtonking.com/projects/json-net.aspx" id="link-impl-json-net">Json.NET</a> (MIT) - generates schemas from .NET types
-    -   <a href="http://NJsonSchema.org" id="link-impl-n-json-schema">NJsonSchema</a> - *supports version 4* (Ms-PL) - generates schemas from .NET types
+    -   [Json.NET](http://james.newtonking.com/projects/json-net.aspx) (MIT) - generates schemas from .NET types
+    -   [NJsonSchema](http://NJsonSchema.org) - *supports version 4* (Ms-PL) - generates schemas from .NET types
 -   PHP
-    -   <a href="https://github.com/Limenius/liform" id="link-impl-liform">Liform</a> (MIT) - generates schemas from Symfony forms
+    -   [Liform](https://github.com/Limenius/liform) (MIT) - generates schemas from Symfony forms
 -   Python
-    -   <a href="https://github.com/aromanovich/jsl" id="link-impl-jsl">JSL</a> (BSD) - a Python DSL for defining JSON Schemas
+    -   [JSL](https://github.com/aromanovich/jsl) (BSD) - a Python DSL for defining JSON Schemas
 -   Scala
-    -   <a href="https://github.com/snowplow/schema-guru" id="link-impl-guru">Schema Guru</a> (Apache 2.0) - CLI util, Spark Job and Web UI for deriving JSON Schemas out of corpus of JSON instances
+    -   [Schema Guru](https://github.com/snowplow/schema-guru) (Apache 2.0) - CLI util, Spark Job and Web UI for deriving JSON Schemas out of corpus of JSON instances
 -   TypeScript
-    -   <a href="https://github.com/YousefED/typescript-json-schema" id="link-impl-typescript-json-schema">typescript-json-schema</a>
-    -   <a href="https://github.com/lbovet/typson" id="link-impl-typson">Typson</a> (Apache 2.0)
+    -   [typescript-json-schema](https://github.com/YousefED/typescript-json-schema)
+    -   [Typson](https://github.com/lbovet/typson) (Apache 2.0)
 -   Online (web tool)
     -   [jsonschema.net](http://www.jsonschema.net/) - generates schemas from example data
-    -   <a href="http://schemaguru.snowplowanalytics.com/" id="link-impl-guru-ui">Schema Guru Web UI</a> - derives precise Schemas using several JSON instances. Based on [Schema Guru](link-impl-guru)
+    -   [Schema Guru Web UI](http://schemaguru.snowplowanalytics.com/) - derives precise Schemas using several JSON instances. Based on [Schema Guru](link-impl-guru)
 -   Visual Studio
-    -   <a href="http://visualstudiogallery.msdn.microsoft.com/b4515ef8-a518-41ca-b48c-bb1fd4e6faf7" id="link-impl-vs">JSON Schema Generator</a> - free extension
+    -   [JSON Schema Generator](http://visualstudiogallery.msdn.microsoft.com/b4515ef8-a518-41ca-b48c-bb1fd4e6faf7) - free extension
 -   Sparx Enterprise Architect
-    -   <a href="https://github.com/bayeslife/api-add-in" id="link-impl-uml">API-Add-In</a> - Sparx EA extension for exporting JSON Schema from UML models
+    -   [API-Add-In](https://github.com/bayeslife/api-add-in) - Sparx EA extension for exporting JSON Schema from UML models
 
 Data parsing
 ------------
 
 -   Haskell
-    -   <a href="https://github.com/timjb/aeson-schema" id="link-impl-aeson-schema">aeson-schema</a> (MIT) - generates code for a parser
+    -   [aeson-schema](https://github.com/timjb/aeson-schema) (MIT) - generates code for a parser
 -   Ruby
-    -   <a href="https://github.com/google/autoparse" id="link-impl-autoparse">autoparse</a> (ASL 2.0)
+    -   [autoparse](https://github.com/google/autoparse) (ASL 2.0)
 -   Scala
-    -   <a href="https://github.com/VoxSupplyChain/json-schema-codegen" id="link-impl-json-schema-codegen">json-schema-codegen</a> - Tool and SBT plugin for generating Scala, TypeScript models and parsers from Json-Schema definitions, *supports version 4* (Apache 2.0)
-    -   <a href="https://github.com/aishfenton/argus" id="link-impl-argus">Argus</a> (MIT) - Macros for building models from JSON Schemas
+    -   [json-schema-codegen](https://github.com/VoxSupplyChain/json-schema-codegen) - Tool and SBT plugin for generating Scala, TypeScript models and parsers from Json-Schema definitions, *supports version 4* (Apache 2.0)
+    -   [Argus](https://github.com/aishfenton/argus) (MIT) - Macros for building models from JSON Schemas
 
 UI generation
 -------------
 
 -   JavaScript
-    -   <a href="http://jsonary.com/" id="link-impl-jsonary">Jsonary</a> - *supports version 4* (MIT)
-    -   <a href="http://metawidget.org/" id="link-impl-metawidget">Metawidget</a> (LGPL)
-    -   <a href="https://github.com/Limenius/liform-react" id="link-impl-liform-react">Liform-react</a> (MIT)
-    -   <a href="http://jsonforms.io" id="link-impl-jsonforms">JSON Forms</a> (MIT)
+    -   [Jsonary](http://jsonary.com/) - *supports version 4* (MIT)
+    -   [Metawidget](http://metawidget.org/) (LGPL)
+    -   [Liform-react](https://github.com/Limenius/liform-react) (MIT)
+    -   [JSON Forms](http://jsonforms.io) (MIT)
 
 Editors
 -------
 
--   <a href="https://www.liquid-technologies.com/json-schema-editor" id="link-impl-liquidxml">Liquid XML Studio 2016</a> - *Graphical JSON schema editor for v4, context sensitive intellisense for JSON documents.*
--   <a href="http://www.visualstudio.com/" id="link-impl-visualstudio">Visual Studio 2013</a> - *Auto-completion and tooltips based on JSON schema v3 and v4*
--   <a href="http://www.json-buddy.com/" id="link-impl-jsonbuddy">JSONBuddy</a> - *Grid-style JSON editor and context sensitive entry-helpers based on JSON schema*
--   <a href="https://www.jetbrains.com/resharper/" id="link-impl-resharer">ReSharper 2016.1</a> - *code completion, inspections and quick fixes for JSON schema in Visual Studio 2010 - 2015, including support for JSON Path and regular expressions for schema editing*
--   <a href="https://code.visualstudio.com/" id="link-impl-vscode">Visual Studio Code</a> - *Schema driven code completion, hovers and validation for editing JSON files (including schemas)*
--   <a href="http://jsoneditoronline.org" id="link-impl-jsoneditoronline">JSONEditor Online</a> - *View, edit, format, and validate JSON online*
--   <a href="https://json-schema-editor.tangramjs.com" id="link-impl-jsonschemaeditor">Json Schema Editor</a> - *An intuitive editor for json schema online*
+-   [Liquid XML Studio 2016](https://www.liquid-technologies.com/json-schema-editor) - *Graphical JSON schema editor for v4, context sensitive intellisense for JSON documents.*
+-   [Visual Studio 2013](http://www.visualstudio.com/) - *Auto-completion and tooltips based on JSON schema v3 and v4*
+-   [JSONBuddy](http://www.json-buddy.com/) - *Grid-style JSON editor and context sensitive entry-helpers based on JSON schema*
+-   [ReSharper 2016.1](https://www.jetbrains.com/resharper/) - *code completion, inspections and quick fixes for JSON schema in Visual Studio 2010 - 2015, including support for JSON Path and regular expressions for schema editing*
+-   [Visual Studio Code](https://code.visualstudio.com/) - *Schema driven code completion, hovers and validation for editing JSON files (including schemas)*
+-   [JSONEditor Online](http://jsoneditoronline.org) - *View, edit, format, and validate JSON online*
+-   [Json Schema Editor](https://json-schema-editor.tangramjs.com) - *An intuitive editor for json schema online*
 
 Compatibility
 -------------
 
 -   JavaScript
-    -   <a href="https://github.com/geraintluff/json-schema-compatability" id="link-json-schema-compatibility">JSON Schema Compatibility</a> - *converts v3 to v4* (Public Domain)
+    -   [JSON Schema Compatibility](https://github.com/geraintluff/json-schema-compatability) - *converts v3 to v4* (Public Domain)
 
 Hyper-schema handling
 ---------------------
 
 -   JavaScript
-    -   <a href="http://jsonary.com/" id="link-impl-jsonary">Jsonary</a> - *supports version 4* (MIT)
+    -   [Jsonary](http://jsonary.com/) - *supports version 4* (MIT)
 -   Scala
-    -   <a href="https://github.com/VoxSupplyChain/json-schema-parser" id="link-impl-json-schema-parser">json-schema-parser</a> - Schema parser and validator, *supports version 4* (Apache 2.0)
+    -   [json-schema-parser](https://github.com/VoxSupplyChain/json-schema-parser) - Schema parser and validator, *supports version 4* (Apache 2.0)
 
 Documentation generation
 ------------------------
 
 -   JavaScript
-    -   <a href="https://github.com/mattyod/matic" id="link-impl-matic">Matic</a> (MIT)
-    -   <a href="https://github.com/lbovet/docson" id="link-impl-docson">Docson</a> (Apache 2.0)
-    -   <a href="https://github.com/cloudflare/doca/" id="link-impl-docs-generator">doca</a> (BSD)
+    -   [Matic](https://github.com/mattyod/matic) (MIT)
+    -   [Docson](https://github.com/lbovet/docson) (Apache 2.0)
+    -   [doca](https://github.com/cloudflare/doca/) (BSD)
 
 Other
 -----
 
 -   JavaScript
-    -   <a href="http://orderly-json.org" id="link-impl-orderly">Orderly</a> (BSD)
-    -   <a href="http://www.dojotoolkit.org/" id="link-impl-dojo">Dojo</a> (AFL or BSD) - supports some aspects of JSON Schema
-    -   <a href="http://schematic-ipsum.herokuapp.com/" id="link-impl-schematic-ipsum">Schematic Ipsum</a> (MIT)
-    -   <a href="https://github.com/tomarad/JSON-Schema-Instantiator" id="link-impl-json-schema-instantiator">JSON-Schema-Instantiator</a> (MIT)
-    -   <a href="https://github.com/andreineculau/json-schema-random" id="link-impl-json-schema-random">JSON Schema Random</a> (Apache 2.0)
+    -   [Orderly](http://orderly-json.org) (BSD)
+    -   [Dojo](http://www.dojotoolkit.org/) (AFL or BSD) - supports some aspects of JSON Schema
+    -   [Schematic Ipsum](http://schematic-ipsum.herokuapp.com/) (MIT)
+    -   [JSON-Schema-Instantiator](https://github.com/tomarad/JSON-Schema-Instantiator) (MIT)
+    -   [JSON Schema Random](https://github.com/andreineculau/json-schema-random) (Apache 2.0)


### PR DESCRIPTION
New additions on this page keep following style of existing links rather than the more concise Markdown syntax even though I doubt there is specific need to be able to anchor the page to the new link.  This changes all the links to Markdown syntax to try to change the syntax used by new additions.

This does remove the ability to anchor the page to a specific link, possibly breaking the anchoring of existing external links.  However, I doubt there is much that depends on this functionality.  Additionally, I would argue if you are trying to link directly to an implementation's link, likely could just link directly to the implementation's site.

Method of implementation: Find and Replace
Find: `<a href="(.*?)".*?>(.*)</a>`
Replace: `[$2]($1)`