### PR TITLE
Make links to Software consistent

### DIFF
--- a/implementations.md
+++ b/implementations.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Software
-permalink: /implementations
+permalink: /implementations.html
 ---
 
 Implementations below are written in different languages, and support part, or all, of the specification.


### PR DESCRIPTION
Adds `.html` to the permalink so that all links to the page have the same name.  This affects analytics which sees `implementations` and `implementations.html` as two different pages.