### PR TITLE
Add Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: ruby
+dist: trusty
+sudo: false
+script:
+- bundle exec jekyll build


### PR DESCRIPTION
Adds appropriate configuration for a CI build on Travis CI.  At the moment, all it checks is that Jekyll can successfully build the site.

A project member will need to actually sign on to Travis CI to enable the build (it only takes a few clicks).