### PR TITLE
Add google analytics code on old drafts

### DIFF
--- a/draft-04/json-schema-core.html
+++ b/draft-04/json-schema-core.html
@@ -1,3 +1,6 @@
+---
+---
+
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" 
   "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 
@@ -425,6 +428,10 @@
   <meta name="dct.issued" scheme="ISO8601" content="2013" />
   <meta name="dct.abstract" content="JSON Schema defines the media type &quot;application/schema+json&quot;, a JSON based format for defining the structure of JSON data. JSON Schema provides a contract for what JSON data is required for a given application and how to interact with it. JSON Schema is intended to define validation, documentation, hyperlink navigation, and interaction control of JSON data.  " />
   <meta name="description" content="JSON Schema defines the media type &quot;application/schema+json&quot;, a JSON based format for defining the structure of JSON data. JSON Schema provides a contract for what JSON data is required for a given application and how to interact with it. JSON Schema is intended to define validation, documentation, hyperlink navigation, and interaction control of JSON data.  " />
+
+  {% if jekyll.environment == 'production' and site.google_analytics %}
+  {% include google-analytics.html %}
+  {% endif %}
 
 </head>
 

--- a/draft-04/json-schema-hypermedia.html
+++ b/draft-04/json-schema-hypermedia.html
@@ -1,3 +1,6 @@
+---
+---
+
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" 
   "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 
@@ -421,6 +424,9 @@
   <meta name="dct.abstract" content="JSON Schema is a JSON based format for defining the structure of JSON data.  This document specifies hyperlink- and hypermedia-related keywords of JSON Schema.  " />
   <meta name="description" content="JSON Schema is a JSON based format for defining the structure of JSON data.  This document specifies hyperlink- and hypermedia-related keywords of JSON Schema.  " />
 
+  {% if jekyll.environment == 'production' and site.google_analytics %}
+  {% include google-analytics.html %}
+  {% endif %}
 </head>
 
 <body>
@@ -763,6 +769,7 @@
 <p>For example, here are some possible values for "href", followed by the results after pre-processing:</p>
 <pre>
 
+{% raw %}
 Input                    Output
 -----------------------------------------
 "no change"              "no change"
@@ -777,7 +784,7 @@ Input                    Output
 "{()}"                   "{%65mpty}
 "{+$*}"                   "{+%73elf*}
 "{+($)*}"                 "{+%24*}
-
+{% endraw %}
                                     </pre>
 <p>Note that in the final example, because the "+" was outside the brackets, it remained unescaped, whereas in the fourth example the "+" was escaped.  </p>
 <h1 id="rfc.section.5.1.1.2"><a href="#rfc.section.5.1.1.2">5.1.1.2.</a> Values for substitution</h1>

--- a/draft-04/json-schema-validation.html
+++ b/draft-04/json-schema-validation.html
@@ -1,3 +1,6 @@
+---
+---
+
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" 
   "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 
@@ -457,6 +460,10 @@
   <meta name="dct.issued" scheme="ISO8601" content="2013" />
   <meta name="dct.abstract" content="JSON Schema (application/schema+json) has several purposes, one of which is instance validation. The validation process may be interactive or non interactive. For instance, applications may use JSON Schema to build a user interface enabling interactive content generation in addition to user input checking, or validate data retrieved from various sources. This specification describes schema keywords dedicated to validation purposes.  " />
   <meta name="description" content="JSON Schema (application/schema+json) has several purposes, one of which is instance validation. The validation process may be interactive or non interactive. For instance, applications may use JSON Schema to build a user interface enabling interactive content generation in addition to user input checking, or validate data retrieved from various sources. This specification describes schema keywords dedicated to validation purposes.  " />
+
+  {% if jekyll.environment == 'production' and site.google_analytics %}
+  {% include google-analytics.html %}
+  {% endif %}
 
 </head>
 

--- a/draft-zyp-json-schema-01.html
+++ b/draft-zyp-json-schema-01.html
@@ -1,3 +1,5 @@
+---
+---
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <html lang="en"><head><title>A JSON Media Type for Describing the Structure and Meaning of JSON Documents</title>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
@@ -138,6 +140,10 @@
                 color: #CCC; background-color: #CCC;
         }
 --></style>
+
+  {% if jekyll.environment == 'production' and site.google_analytics %}
+  {% include google-analytics.html %}
+  {% endif %}
 </head>
 <body>
 <table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>


### PR DESCRIPTION
Add google analytics code on old drafts to determine usage.

I suspect we do do not need to host these anymore and this should help confirm that.  They are accessible on IEFT, and if/when json-schema-org/json-schema-spec#327 is old drafts will not be not too difficult to find in history.  The [Swaggar spec](http://swagger.io/specification/) which brought about #78 to add Draft 4 hosting now points to IETF for the specification.