### PR TITLE
Enforce consistency in supported draft display for libraries

### DIFF
--- a/_data/validator-cli.yaml
+++ b/_data/validator-cli.yaml
@@ -3,13 +3,11 @@
   url: 'https://www.npmjs.com/package/ajv-cli'
   draft:
     - 4
-    - 5
     - 6
 - name: Polyglottal JSON Schema Validator
   license: MIT
   url: 'https://www.npmjs.com/package/pajv'
   draft:
     - 4
-    - 5
     - 6
   notes: can be used with YAML and many other formats besides JSON

--- a/_data/validator-libraries.yml
+++ b/_data/validator-libraries.yml
@@ -6,7 +6,8 @@
       license: "MIT"
     - name: NJsonSchema
       url: http://NJsonSchema.org
-      notes: "- *supports draft 4*"
+      notes: 
+      draft: [4]
       license: Ms-PL
 - name: ActionScript 3
   anchor-name: action-script-3
@@ -24,27 +25,32 @@
   implementations:
     - name: wjelement-cpp
       url: https://github.com/petehug/wjelement-cpp
-      notes: "- *supports draft 4*"
+      notes: 
+      draft: [4]
       license: LGPLv3
     - name: Header-only C++ library for JSON Schema validation
       url: https://github.com/tristanpenman/valijson
-      notes: "- *supports only draft 4*"
+      notes: 
+      draft: [4]
       license: BSD-2-Clause
     - name: Modern C++ JSON schema validator
       url: https://github.com/pboettch/json-schema-validator
-      notes: "- *supports only draft 4* based on JSON for Modern C++"
+      notes: "based on JSON for Modern C++"
+      draft: [4]
       license: "MIT"
 - name: Clojure
   implementations:
     - name: scjsv
       url: https://github.com/metosin/scjsv
-      notes: "- *supports draft 4* (wrapper for [java-json-tools/json-schema-validator](https://github.com/java-json-tools/json-schema-validator))"
+      notes: "(wrapper for [java-json-tools/json-schema-validator](https://github.com/java-json-tools/json-schema-validator))"
+      draft: [4]
       license: Eclipse Public License v1.0
 - name:  Dart
   implementations:
     - name: json_schema
       url: https://github.com/patefacio/json_schema
-      notes: "*supports draft 4*"
+      notes: 
+      draft: [4]
       license: BSL-1.0
 - name: Erlang
   implementations:
@@ -58,7 +64,8 @@
       license: "Apache 2.0"
     - name: jsonschema
       url: https://github.com/santhosh-tekuri/jsonschema
-      notes: "*supports draft 4, draft 6*"
+      notes: 
+      draft: [4, 6]
       license: BSD-3-Clause
 - name: Haskell
   implementations:
@@ -67,51 +74,62 @@
       license: "MIT"
     - name: hjsonschema
       url: https://github.com/seagreen/hjsonschema
-      notes: "- *supports draft 4*"
+      notes: 
+      draft: [4]
       license: MIT
 - name: Java
   implementations:
     - name: json-schema-validator
       url: https://github.com/java-json-tools/json-schema-validator
-      notes: "- *supports draft 4*"
+      notes: 
+      draft: [4]
       license: LGPLv3
     - name: json-schema (implementation based on the org.json API)
       url: https://github.com/everit-org/json-schema
-      notes: "- *supports draft 4, draft 6*"
+      notes: 
+      draft: [4, 6]
       license: Apache License 2.0
     - name: json-schema-validator
       url: https://github.com/networknt/json-schema-validator
-      notes: "- *supports draft 4*"
+      notes: 
+      draft: [4]
       license: Apache License 2.0
 - name: JavaScript
   implementations:
     - name: ajv
       url: https://github.com/epoberezkin/ajv
-      notes: "for Node.js and browsers - *supports draft 4, draft 6, [custom keywords](https://github.com/epoberezkin/ajv-keywords) and [$data reference](https://github.com/json-schema-org/json-schema-spec/issues/51)*"
+      notes: "for Node.js and browsers - *supports [custom keywords](https://github.com/epoberezkin/ajv-keywords) and [$data reference](https://github.com/json-schema-org/json-schema-spec/issues/51)*"
+      draft: [4, 5, 6]
       license: MIT
     - name: djv
       url: https://github.com/korzio/djv
-      notes: "for Node.js and browsers - *supports draft 4*"
+      notes: "for Node.js and browsers"
+      draft: [4]
       license: MIT
     - name: jsonschema
       url: https://github.com/tdegrunt/jsonschema
-      notes: "for Node.js - *supports draft 4*"
+      notes: "for Node.js"
+      draft: [4]
       license: MIT
     - name: is-my-json-valid
       url: https://github.com/mafintosh/is-my-json-valid
-      notes: "- *supports draft 4*"
+      notes: 
+      draft: [4]
       license: MIT
     - name: tv4
       url: http://geraintluff.github.com/tv4/
-      notes: "- *supports draft 4*"
+      notes: 
+      draft: [4]
       license: [Public Domain, MIT]
     - name: JaySchema
       url: https://github.com/natesilva/jayschema
-      notes: "for Node.js - *supports draft 4*"
+      notes: "for Node.js"
+      draft: [4]
       license: BSD
     - name: z-schema
       url: https://github.com/zaggino/z-schema
-      notes: "for Node.js - *supports draft 4*"
+      notes: "for Node.js"
+      draft: [4]
       license: MIT
     - name: direct-schema
       url: http://github.com/IreneKnapp/direct-schema
@@ -131,13 +149,15 @@
       license: "MIT"
     - name: JSEN
       url: https://github.com/bugventure/jsen
-      notes: "for Node.js - *supports draft 4*"
+      notes: "for Node.js"
+      draft: [4]
       license: "MIT"
 - name: PHP
   implementations:
     - name: jsv4-php
       url: https://github.com/geraintluff/jsv4-php
-      notes: "- *supports draft 4*"
+      notes: 
+      draft: [4]
       license: [Public Domain, MIT]
     - name: php-json-schema
       url: https://github.com/hasbridge/php-json-schema
@@ -147,11 +167,13 @@
       license: "Berkeley"
     - name: JVal
       url: https://github.com/stefk/jval
-      notes: "- *supports draft 4*"
+      notes: 
+      draft: [4]
       license: "MIT"
     - name: JSON Guard
       url: https://github.com/thephpleague/json-guard
-      notes: "- *supports draft 4*"
+      notes: 
+      draft: [4]
       license: "MIT"
 - name: Perl
   implementations:
@@ -165,7 +187,8 @@
   implementations:
     - name: jsonschema
       url: https://github.com/Julian/jsonschema
-      notes: "- *supports draft 4*"
+      notes: 
+      draft: [4]
       license: "MIT"
     - name: json-schema-validator
       url: https://github.com/zyga/json-schema-validator
@@ -177,17 +200,20 @@
       license: "MIT"
     - name: json-schema
       url: https://github.com/hoxworth/json-schema
-      notes: "- *supports draft 4*"
+      notes: 
+      draft: [4]
       license: MIT
 - name: Rust
   implementations:
     - name: valico
       url: https://github.com/rustless/valico
-      notes: "- *supports draft 4*"
+      notes: 
+      draft: [4]
       license: MIT
 - name: Scala
   implementations:
     - name: json-schema-parser
       url: https://github.com/VoxSupplyChain/json-schema-parser
-      notes: "- Schema parser and validator, *supports draft 4*"
+      notes: "Schema parser and validator"
+      draft: [4]
       license: Apache 2.0

--- a/_data/validator-libraries.yml
+++ b/_data/validator-libraries.yml
@@ -99,7 +99,7 @@
     - name: ajv
       url: https://github.com/epoberezkin/ajv
       notes: "for Node.js and browsers - *supports [custom keywords](https://github.com/epoberezkin/ajv-keywords) and [$data reference](https://github.com/json-schema-org/json-schema-spec/issues/51)*"
-      draft: [4, 5, 6]
+      draft: [4, 6]
       license: MIT
     - name: djv
       url: https://github.com/korzio/djv

--- a/implementations.md
+++ b/implementations.md
@@ -30,13 +30,29 @@ Validators
 
 <!-- To add a validator library, add it in _data/validator-libraries.yml -->
 
-{% for language in validator-libraries %}
+<ul>
+  {% for language in validator-libraries %}
+  <li>
+    {{language.name}} <a id="validator-{% if language.anchor-name %}{{ language.anchor-name }}{% else %}{{ language.name | downcase }}{% endif %}"></a>
+    <ul>
+    {% for implementation in language.implementations %}
+        <li>
+        <a href="{{implementation.url}}">{{ implementation.name }}</a>
+        
+        {% if implementation.draft %}
+            <em>supports draft {{ implementation.draft | join: ", draft " }}</em>
+        {% endif %}
 
-- {{language.name}} <a id="validator-{% if language.anchor-name %}{{ language.anchor-name }}{% else %}{{ language.name | downcase }}{% endif %}"></a>{% for implementation in language.implementations %}
-    - [{{ implementation.name }}]({{implementation.url}}) {{implementation.notes}}
-    ({{implementation.license | join: ", "}}){% endfor %}
+        {{implementation.notes | markdownify | remove: '<p>' | remove: '</p>'}}
+        ({{ implementation.license | join: ", " }})
 
-{% endfor %}
+        </li>
+    {% endfor %}
+    </ul>
+  </li>
+  {% endfor %}
+</ul>
+
 
 
 ### Online


### PR DESCRIPTION
This moves supported draft information out of `notes` and into a specific member of the object.

Switches the relevant template piece to HTML (from Markdown) because it is more manageable.