### PR TITLE
Add pre-release table styling from minima

### DIFF
--- a/_sass/_tables.scss
+++ b/_sass/_tables.scss
@@ -1,0 +1,31 @@
+/* Pilfered from https://github.com/jekyll/minima/pull/144
+ * Once a new version of minima is released, this (an the include in `main.scss`
+ * can probably be deleted.
+ */
+$table-text-align: left !default;
+
+
+table {
+    margin-bottom: $spacing-unit;
+    width: 100%;
+    text-align: $table-text-align;
+    color: lighten($text-color, 18%);
+    border-collapse: collapse;
+    border: 1px solid $grey-color-light;
+    tr {
+        &:nth-child(even) {
+        background-color: lighten($grey-color-light, 6%);
+        }
+    }
+    th, td {
+        padding: ($spacing-unit / 3) ($spacing-unit / 2);
+    }
+    th {
+        background-color: lighten($grey-color-light, 3%);
+        border: 1px solid darken($grey-color-light, 4%);
+        border-bottom-color: darken($grey-color-light, 12%);
+    }
+    td {
+        border: 1px solid $grey-color-light;
+    }
+}

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -6,6 +6,7 @@
 // Import partials from the `minima` theme.
 @import "minima";
 @import "minima/syntax-highlighting";
+@import "tables";
 
 // Import navigation partial for Software page
 @import "intra-navigation";


### PR DESCRIPTION
Pilfered from https://github.com/jekyll/minima/pull/144
Once a new version of minima is released, this (an the include in `main.scss` can probably be deleted.