### PR TITLE
Show that we are an active project

### DIFF
--- a/index.md
+++ b/index.md
@@ -31,6 +31,18 @@ Advantages
 
 </div>
 
+Project Status
+--------------
+
+Publication of Internet-Draft documents can be tracked through the IETF:
+- [JSON Schema (core)](https://datatracker.ietf.org/doc/draft-wright-json-schema/)
+- [JSON Schema Validation](https://datatracker.ietf.org/doc/draft-wright-json-schema-validation/)
+- [JSON Hyper-Schema](https://datatracker.ietf.org/doc/draft-wright-json-schema-hyperschema/)
+
+Internet-Drafts expire after six months, so our goal is to publish often enough to always have a set of unexpired drafts available.  There may be brief gaps as we wrap up each draft and finalize the text.
+
+Progress on the next set of Internet-Drafts can be tracked on GitHub.  The current milestone is [draft-07 (wright-\*-02)](https://github.com/json-schema-org/json-schema-spec/milestone/5)
+
 <div style="clear:both"></div>
 
 Quickstart


### PR DESCRIPTION
The front page doesn't really make it clear that the project
is as active as it is.  Let's put up some actual text on that,
and link to where people can see the status and timeline of
the various drafts.  And a link to the current active milestone,
which will need to be kept up to date but twice a year isn't
exactly burdensome.  And if it's out of date people will see
that the milestone is complete and figure it out anyway.

Unlike the other tweaks to the web site, I plan to leave this
PR open for a while as it's a significant change to the feel of things.

In addition to @adamvoss, I would appreciate if @awwright and @Relequestual could take a look.
