### PR TITLE
Add Core API Hyper-Schema implementation

### DIFF
--- a/implementations.md
+++ b/implementations.md
@@ -166,6 +166,8 @@ Hyper-schema handling
 
 -   JavaScript
     -   [Jsonary](http://jsonary.com/) - *supports draft 4* (MIT)
+-   Python
+    -   [Core API Hyper-Schema codec](https://github.com/core-api/python-jsonhyperschema-codec) - *supports draft 4* (BSD-2-Clause)
 
 Documentation generation
 ------------------------


### PR DESCRIPTION
It's still draft-04, but it exists and is referenced by
Django REST Framework and probably other things.

Tested locally and seems to work.