### PR TITLE
Align page and file names

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -27,7 +27,7 @@ markdown: kramdown
 theme: minima
 
 header_pages:
-- documentation.md
+- specification.md
 - examples.md
 - implementations.md
 
@@ -36,5 +36,6 @@ exclude:
 - Gemfile
 - node_modules
 
-gems:
+plugins:
   - jekyll-relative-links
+  - jekyll-redirect-from

--- a/draft-01/draft-zyp-json-schema-01.html
+++ b/draft-01/draft-zyp-json-schema-01.html
@@ -1,4 +1,6 @@
 ---
+redirect_from: "/draft-zyp-json-schema-01.html"
+permalink: "/draft-01/draft-zyp-json-schema-01.html"
 ---
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <html lang="en"><head><title>A JSON Media Type for Describing the Structure and Meaning of JSON Documents</title>

--- a/implementations.md
+++ b/implementations.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: Software
+title: Implementations
 permalink: /implementations.html
 ---
 

--- a/index.md
+++ b/index.md
@@ -4,7 +4,7 @@ title: JSON Schema
 permalink: /
 ---
 
-***Draft-07 has been [published](documentation.md)!***
+***Draft-07 has been [published](specification.html)!***
 {: style="color:gray; font-size: 150%; text-align: center;"}
 
 **JSON Schema** is a vocabulary that allows you to **annotate** and **validate** JSON documents.
@@ -86,9 +86,9 @@ More
 
 Interested? Check out:
 
--   the [specification](documentation.md)
+-   the [specification](specification.html)
 -   some [examples](examples.md)
--   the growing list of [JSON (Hyper-)Schema software](implementations.md)
+-   the growing list of [JSON (Hyper-)Schema software](implementations.html)
 
 We encourage updating to the latest specification, as described by the draft-07 meta-schemas.  However, if you are still using draft-04, you may be interested in:
 -   this [excellent guide](http://spacetelescope.github.io/understanding-json-schema/) for schema authors, from the [Space Telescope Science Institute](http://www.stsci.edu/)

--- a/specification-links.md
+++ b/specification-links.md
@@ -5,7 +5,7 @@ layout: page
 
 <!-- Links on this page should be immutable - none of them should go to `/latest`, etc. -->
 
-You can find the latest released draft on the [Specification](/documentation.md) page.  Older drafts are expired, but may be of historical interest.
+You can find the latest released draft on the [Specification](/specification.html) page.  Older drafts are expired, but may be of historical interest.
 
 **A note on draft naming and numbering:**  
 IETF Internet-Drafts (I-Ds) are named with the editor's name and a sequential number which resets with each new editor.  Meta-schemas are numbered sequentially.  Additionally, drafts 00-03 used one document for all three current specs.  Most people find it easier to remember the sequential meta-schema numbers, so those are used throughout the site.

--- a/specification.md
+++ b/specification.md
@@ -1,5 +1,7 @@
 ---
 layout: page
+redirect_from: "/documentation.html"
+permalink: /specification.html
 title: Specification
 ---
 


### PR DESCRIPTION
It has long annoyed me that our page names and filenames don't
match.  I open specification-links.md when I mean to open
documentation.md probably half the time at least.

I decided that I prefer "Specification" over "Documentation"
and "Implementations" over "Software", but that's definitely
open to discussion.

* Update "gems" to "plugins" to get jekyll to stop complaining
* Add the redirect plugin
* Rename documentation.md to specification.md and add a redirect
* Change the title of implementations.md to Implementations

Remove most remaining links to ".md" URIs and standardize on
".html" which seems to be what we've been going for.  I think
there are still example links with ".md" but I did not want
to touch the examples at all for now.

@adamvoss let me know if this will mess up anything you're doing
with analytics.  Or perhaps we should just take stock of what the
analytics have told us so far and then feel free to change things?