### PR TITLE
Updated Manatee.Json support

### DIFF
--- a/_data/validator-libraries.yml
+++ b/_data/validator-libraries.yml
@@ -7,7 +7,7 @@
       license: "MIT"
     - name: Manatee.Json
       url: https://github.com/gregsdennis/Manatee.Json
-      draft: [4, 6]
+      draft: [4, 6, 7]
       license: MIT
     - name: NJsonSchema
       url: http://NJsonSchema.org


### PR DESCRIPTION
As of v9.5.0, Manatee.Json supports draft 7 validation.