### PR TITLE
Add link to quicktype tool in Online section

### DIFF
--- a/implementations.md
+++ b/implementations.md
@@ -59,6 +59,7 @@ Validators
 
 -   [JSON Schema Lint](http://jsonschemalint.com/) - validate against your own schemas
 -   [SchemaStore.org](http://schemastore.org/validator/) - validate against common JSON Schemas
+-   [quicktype.io](https://app.quicktype.io/#l=schema) - infer JSON Schema from samples, and generate TypeScript, C++, go, Java, C#, Swift, etc. types from JSON Schema 
 
 ### Command Line
 


### PR DESCRIPTION
[quicktype](https://app.quicktype.io/#l=schema) infers JSON Schema from samples, and generates TypeScript, C++, go, Java, C#, Swift, etc. types from JSON Schema.

Here's an example of [generating golang structs and marshaling functions](https://app.quicktype.io/#l=go&s=address) for a sample from [json-schema.org](http://json-schema.org/examples.html).