### PR TITLE
Correct license information of validator libraries data

### DIFF
--- a/_data/validator-libraries.yml
+++ b/_data/validator-libraries.yml
@@ -4,7 +4,7 @@
     - name: Json.NET Schema
       url: https://www.newtonsoft.com/jsonschema
       draft: [3, 4, 6]
-      license: "MIT"
+      license: "AGPL-3.0-only"
     - name: Manatee.Json
       url: https://github.com/gregsdennis/Manatee.Json
       draft: [4, 6, 7]


### PR DESCRIPTION
License names in the YAML file do not have the same pattern, so I picked the name in [SPDX license list](https://spdx.org/licenses/). Json.NET is MIT, but Json.NET Schema has always been AGPL 3.0; they live by the “AGPL + commercial” pattern.