### PR TITLE
Update hyper-schema section and make it more prominent

### DIFF
--- a/_data/hyper-schema-libraries.yml
+++ b/_data/hyper-schema-libraries.yml
@@ -1,0 +1,16 @@
+- name: JavaScript
+  implementations:
+    - name: mokkabonna/json-hyper-schema
+      url: "https://github.com/mokkabonna/json-hyper-schema"
+      license: MIT
+      draft: [7]
+    - name: Jsonary
+      url: "http://jsonary.com/"
+      license: MIT
+      draft: [4]
+- name: Python
+  implementations:
+    - name: Core API Hyper-Schema codec
+      url: "https://github.com/core-api/python-jsonhyperschema-codec"
+      draft: [4]
+      license: BSD-2-Clause

--- a/implementations.md
+++ b/implementations.md
@@ -70,6 +70,44 @@ Validators
 - [{{ tool.name }}]({{ tool.url }}) [draft {{ tool.draft | join: ", draft " }}] ({{ tool.license | join: ", " }}){% if tool.notes %}
   - {{ tool.notes }} {% endif %}{% endfor %}
 
+Hyper-Schema
+---------------------
+
+<nav class="intra" markdown="1">
+
+{% assign hyper-schema-libraries = site.data.hyper-schema-libraries | sort:"name" %}
+
+{% for language in hyper-schema-libraries %}
+-   [{{ language.name }}](#hyper-schema-{% if language.anchor-name %}{{ language.anchor-name }}{% else %}{{ language.name | downcase }}{% endif %})
+{% endfor %}
+
+</nav>
+
+<!-- To add a hyper-schema library, add it in _data/hyper-schema-libraries.yml -->
+
+<ul>
+  {% for language in hyper-schema-libraries %}
+  <li>
+    {{language.name}} <a id="hyper-schema-{% if language.anchor-name %}{{ language.anchor-name }}{% else %}{{ language.name | downcase }}{% endif %}"></a>
+    <ul>
+    {% for implementation in language.implementations %}
+        <li>
+        <a href="{{implementation.url}}">{{ implementation.name }}</a>
+        
+        {% if implementation.draft %}
+            <em>supports draft {{ implementation.draft | join: ", draft " }}</em>
+        {% endif %}
+
+        {{implementation.notes | markdownify | remove: '<p>' | remove: '</p>'}}
+        ({{ implementation.license | join: ", " }})
+
+        </li>
+    {% endfor %}
+    </ul>
+  </li>
+  {% endfor %}
+</ul>
+
 
 Validation benchmarks
 ---------------------
@@ -168,14 +206,6 @@ Compatibility
 
 -   JavaScript
     -   [JSON Schema Compatibility](https://github.com/geraintluff/json-schema-compatability) - *converts draft 3 to draft 4* (Public Domain)
-
-Hyper-schema handling
----------------------
-
--   JavaScript
-    -   [Jsonary](http://jsonary.com/) - *supports draft 4* (MIT)
--   Python
-    -   [Core API Hyper-Schema codec](https://github.com/core-api/python-jsonhyperschema-codec) - *supports draft 4* (BSD-2-Clause)
 
 Documentation generation
 ------------------------

--- a/implementations.md
+++ b/implementations.md
@@ -70,6 +70,21 @@ Validators
 - [{{ tool.name }}]({{ tool.url }}) [draft {{ tool.draft | join: ", draft " }}] ({{ tool.license | join: ", " }}){% if tool.notes %}
   - {{ tool.notes }} {% endif %}{% endfor %}
 
+### Benchmarks
+
+-   Java
+    -   [json-schema-validator-benchmark](https://github.com/networknt/json-schema-validator-perftest) - compares performance of three JSON schema validator implementations in Java(Apache 2.0)
+
+<!-- -->
+
+-   JavaScript
+    -   [json-schema-benchmark](https://github.com/ebdrup/json-schema-benchmark) - an independent benchmark for Node.js JSON-schema validators based on JSON-Schema Test Suite (MIT)
+    -   [z-schema validator benchmark](https://github.com/zaggino/z-schema#benchmarks) - compares performance in the individual tests from JSON-Schema Test Suite (MIT)
+    -   [JSCK validator benchmark](https://github.com/pandastrike/jsck#benchmarks) - shows performance for JSON-schemas of different complexity (MIT)
+
+-   PHP
+    -   [php-json-schema-bench](https://github.com/swaggest/php-json-schema-bench) - comparative benchmark for JSON-schema PHP validators using JSON-Schema Test Suite and z-schema/JSCK (MIT)
+
 Hyper-Schema
 ---------------------
 
@@ -108,22 +123,6 @@ Hyper-Schema
   {% endfor %}
 </ul>
 
-
-Validation benchmarks
----------------------
-
--   Java
-    -   [json-schema-validator-benchmark](https://github.com/networknt/json-schema-validator-perftest) - compares performance of three JSON schema validator implementations in Java(Apache 2.0)
-
-<!-- -->
-
--   JavaScript
-    -   [json-schema-benchmark](https://github.com/ebdrup/json-schema-benchmark) - an independent benchmark for Node.js JSON-schema validators based on JSON-Schema Test Suite (MIT)
-    -   [z-schema validator benchmark](https://github.com/zaggino/z-schema#benchmarks) - compares performance in the individual tests from JSON-Schema Test Suite (MIT)
-    -   [JSCK validator benchmark](https://github.com/pandastrike/jsck#benchmarks) - shows performance for JSON-schemas of different complexity (MIT)
-
--   PHP
-    -   [php-json-schema-bench](https://github.com/swaggest/php-json-schema-bench) - comparative benchmark for JSON-schema PHP validators using JSON-Schema Test Suite and z-schema/JSCK (MIT)
 
 Schema generation
 -----------------


### PR DESCRIPTION
Make a _data YAML file for it (sadly Jekyll insists on .yml)
and move it up directly under validation.

The programming language menu is a bit silly with two entries,
but a.) I'm optimistic, and b.) when I took it out it broke and
I can't be bothered to debug that today.

Make benchmarks a subsection of Validators 
It looked odd as a top level section either after Hyper-Schema
(too far from the validators) or before (which made benchmarks
seem more important than hyper-schema, which also isn't right)