### PR TITLE
Split implementations page by draft support

### DIFF
--- a/_data/hyper-libraries-modern.yml
+++ b/_data/hyper-libraries-modern.yml
@@ -8,5 +8,6 @@
   implementations:
     - name: Core API Hyper-Schema codec
       url: "https://github.com/core-api/python-jsonhyperschema-codec"
+      notes: "Draft-06+ progress: issue [12](https://github.com/core-api/python-jsonhyperschema-codec/issues/12)"
       draft: [4]
       license: BSD-2-Clause

--- a/_data/hyper-libraries-modern.yml
+++ b/_data/hyper-libraries-modern.yml
@@ -4,10 +4,6 @@
       url: "https://github.com/mokkabonna/json-hyper-schema"
       license: MIT
       draft: [7]
-    - name: Jsonary
-      url: "http://jsonary.com/"
-      license: MIT
-      draft: [4]
 - name: Python
   implementations:
     - name: Core API Hyper-Schema codec

--- a/_data/hyper-libraries-obsolete.yml
+++ b/_data/hyper-libraries-obsolete.yml
@@ -1,0 +1,6 @@
+- name: JavaScript
+  implementations:
+    - name: Jsonary
+      url: "http://jsonary.com/"
+      license: MIT
+      draft: [4]

--- a/_data/validator-cli.yaml
+++ b/_data/validator-cli.yaml
@@ -2,12 +2,13 @@
   license: MIT
   url: 'https://www.npmjs.com/package/ajv-cli'
   draft:
-    - 4
+    - 7
     - 6
+    - 4
 - name: Polyglottal JSON Schema Validator
   license: MIT
   url: 'https://www.npmjs.com/package/pajv'
   draft:
-    - 4
     - 6
+    - 4
   notes: can be used with YAML and many other formats besides JSON

--- a/_data/validator-libraries-modern.yml
+++ b/_data/validator-libraries-modern.yml
@@ -14,7 +14,7 @@
     - name: Elixir JSON Schema validator
       url: https://github.com/jonasschmidt/ex_json_schema
       draft: [4]
-      notes: Support for more recent drafts in progress
+      notes: "Draft-06+ progress: issue [24](https://github.com/jonasschmidt/ex_json_schema/issues/24); branch [multi-draft-support](https://github.com/jonasschmidt/ex_json_schema/tree/multi-draft-support)"
       license: MIT
 - name: Go
   implementations:
@@ -66,7 +66,7 @@
   implementations:
     - name: jsonschema
       url: https://github.com/Julian/jsonschema
-      notes: Support for draft-06 nearing beta
+      notes: "Draft-06+ progress: issues [337](https://github.com/Julian/jsonschema/issues/337), [400](https://github.com/Julian/jsonschema/issues/400); branches [draft6](https://github.com/Julian/jsonschema/tree/draft6), [draft7](https://github.com/Julian/jsonschema/tree/draft7)"
       draft: [4, 3]
       license: "MIT"
 - name: Ruby

--- a/_data/validator-libraries-modern.yml
+++ b/_data/validator-libraries-modern.yml
@@ -1,0 +1,78 @@
+- name: .NET
+  anchor-name: dotnet
+  implementations:
+    - name: Json.NET Schema
+      url: https://www.newtonsoft.com/jsonschema
+      draft: [7, 6, 4, 3]
+      license: "AGPL-3.0-only"
+    - name: Manatee.Json
+      url: https://github.com/gregsdennis/Manatee.Json
+      draft: [7, 6, 4]
+      license: MIT
+- name: Elixir
+  implementations:
+    - name: Elixir JSON Schema validator
+      url: https://github.com/jonasschmidt/ex_json_schema
+      draft: [4]
+      notes: Support for more recent drafts in progress
+      license: MIT
+- name: Go
+  implementations:
+    - name: gojsonschema
+      url: https://github.com/xeipuuv/gojsonschema
+      draft: [7, 6, 4]
+      license: "Apache 2.0"
+    - name: jsonschema
+      url: https://github.com/santhosh-tekuri/jsonschema
+      notes:
+      draft: [7, 6, 4]
+      license: BSD-3-Clause
+- name: Java
+  implementations:
+    - name: everit-org/json-schema
+      url: https://github.com/everit-org/json-schema
+      notes:
+      draft: [7, 6, 4]
+      license: Apache License 2.0
+- name: JavaScript
+  implementations:
+    - name: ajv
+      url: https://github.com/epoberezkin/ajv
+      notes: "for Node.js and browsers - *supports [custom keywords](https://github.com/epoberezkin/ajv-keywords) and [$data reference](https://github.com/json-schema-org/json-schema-spec/issues/51)*"
+      draft: [7, 6, 4]
+      license: MIT
+    - name: djv
+      url: https://github.com/korzio/djv
+      notes: "for Node.js and browsers"
+      draft: [6, 4]
+      license: MIT
+    - name: vue-vuelidate-jsonschema
+      url: https://github.com/mokkabonna/vue-vuelidate-jsonschema
+      draft: [6]
+      license: MIT
+- name: PHP
+  implementations:
+    - name: Opis Json Schema
+      url: https://github.com/opis/json-schema
+      notes:
+      draft: [7, 6]
+      license: "Apache License 2.0"
+    - name: Swaggest Json Schema
+      url: https://github.com/swaggest/php-json-schema
+      notes:
+      draft: [7, 6, 4]
+      license: "MIT"
+- name: Python
+  implementations:
+    - name: jsonschema
+      url: https://github.com/Julian/jsonschema
+      notes: Support for draft-06 nearing beta
+      draft: [4, 3]
+      license: "MIT"
+- name: Ruby
+  implementations:
+    - name: JSONSchemer
+      url: https://github.com/davishmcclurg/json_schemer
+      notes:
+      draft: [7, 6, 4]
+      license: MIT

--- a/_data/validator-libraries-obsolete.yml
+++ b/_data/validator-libraries-obsolete.yml
@@ -1,26 +1,11 @@
 - name: .NET
   anchor-name: dotnet
   implementations:
-    - name: Json.NET Schema
-      url: https://www.newtonsoft.com/jsonschema
-      draft: [3, 4, 6, 7]
-      license: "AGPL-3.0-only"
-    - name: Manatee.Json
-      url: https://github.com/gregsdennis/Manatee.Json
-      draft: [4, 6, 7]
-      license: MIT
     - name: NJsonSchema
       url: http://NJsonSchema.org
       notes:
       draft: [4]
       license: Ms-PL
-- name: ActionScript 3
-  anchor-name: action-script-3
-  implementations:
-    - name: Frigga
-      url: https://github.com/raulbajales/Frigga
-      draft: [3]
-      license: "MIT"
 - name: C
   implementations:
     - name: WJElement
@@ -39,7 +24,7 @@
     - name: Header-only C++ library for JSON Schema validation
       url: https://github.com/tristanpenman/valijson
       notes:
-      draft: [4]
+      draft: [4, 3]
       license: BSD-2-Clause
     - name: Modern C++ JSON schema validator
       url: https://github.com/pboettch/json-schema-validator
@@ -61,7 +46,7 @@
   implementations:
     - name: JSCK
       url: https://github.com/pandastrike/jsck
-      draft: [3, 4]
+      draft: [4, 3]
       license: MIT
 - name:  Dart
   implementations:
@@ -70,39 +55,20 @@
       notes:
       draft: [4]
       license: BSL-1.0
-- name: Elixir
-  implementations:
-    - name: Elixir JSON Schema validator
-      url: https://github.com/jonasschmidt/ex_json_schema
-      draft: [4]
-      license: MIT
 - name: Erlang
   implementations:
     - name: JeSSE
       url: https://github.com/for-GET/jesse
-      draft: [3, 4]
+      draft: [4, 3]
       license: "Apache 2.0"
 - name: Go
   implementations:
-    - name: gojsonschema
-      url: https://github.com/sigu-399/gojsonschema
-      draft: [4]
-      license: "Apache 2.0"
-    - name: jsonschema
-      url: https://github.com/santhosh-tekuri/jsonschema
-      notes:
-      draft: [4, 6, 7]
-      license: BSD-3-Clause
     - name: validate-json
       url: https://github.com/cesanta/validate-json
       draft: [4]
       license: GPLv2
 - name: Haskell
   implementations:
-    - name: aeson-schema
-      url: https://github.com/Fuuzetsu/aeson-schema
-      draft: [3]
-      license: MIT
     - name: hjsonschema
       url: https://github.com/seagreen/hjsonschema
       notes:
@@ -112,14 +78,8 @@
   implementations:
     - name: json-schema-validator
       url: https://github.com/java-json-tools/json-schema-validator
-      notes: "includes draft-04 hype-schema syntax support"
       draft: [4]
       license: LGPLv3
-    - name: everit-org/json-schema
-      url: https://github.com/everit-org/json-schema
-      notes:
-      draft: [4, 6, 7]
-      license: Apache License 2.0
     - name: json-schema-validator
       url: https://github.com/networknt/json-schema-validator
       notes:
@@ -127,24 +87,9 @@
       license: Apache License 2.0
 - name: JavaScript
   implementations:
-    - name: ajv
-      url: https://github.com/epoberezkin/ajv
-      notes: "for Node.js and browsers - *supports [custom keywords](https://github.com/epoberezkin/ajv-keywords) and [$data reference](https://github.com/json-schema-org/json-schema-spec/issues/51)*"
-      draft: [4, 6]
-      license: MIT
-    - name: djv
-      url: https://github.com/korzio/djv
-      notes: "for Node.js and browsers"
-      draft: [4, 6]
-      license: MIT
     - name: jsonschema
       url: https://github.com/tdegrunt/jsonschema
       notes: "for Node.js"
-      draft: [4]
-      license: MIT
-    - name: is-my-json-valid
-      url: https://github.com/mafintosh/is-my-json-valid
-      notes:
       draft: [4]
       license: MIT
     - name: tv4
@@ -152,6 +97,11 @@
       notes:
       draft: [4]
       license: [Public Domain, MIT]
+    - name: is-my-json-valid
+      url: https://github.com/mafintosh/is-my-json-valid
+      notes:
+      draft: [4]
+      license: MIT
     - name: JaySchema
       url: https://github.com/natesilva/jayschema
       notes: "for Node.js"
@@ -199,25 +149,17 @@
       url: https://github.com/ericgj/json-schema-valid
       draft: [4]
       license: MIT
-    - name: vue-vuelidate-jsonschema
-      url: https://github.com/mokkabonna/vue-vuelidate-jsonschema
-      draft: [6]
-      license: MIT
 - name: PHP
   implementations:
+    - name: json-schema
+      url: https://github.com/justinrainbow/json-schema
+      draft: [4, 3]
+      license: "Berkeley"
     - name: jsv4-php
       url: https://github.com/geraintluff/jsv4-php
       notes:
       draft: [4]
       license: [Public Domain, MIT]
-    - name: php-json-schema
-      url: https://github.com/hasbridge/php-json-schema
-      draft: [3]
-      license: "MIT"
-    - name: json-schema
-      url: https://github.com/justinrainbow/json-schema
-      draft: [3, 4]
-      license: "Berkeley"
     - name: JVal
       url: https://github.com/stefk/jval
       notes:
@@ -228,25 +170,16 @@
       notes:
       draft: [4]
       license: "MIT"
-    - name: Opis Json Schema
-      url: https://github.com/opis/json-schema
-      notes:
-      draft: [6, 7]
-      license: "Apache License 2.0"
     - name: Swaggest Json Schema
       url: https://github.com/swaggest/php-json-schema
       notes:
-      draft: [4, 6, 7]
+      draft: [4]
       license: "MIT"
 - name: Perl
   implementations:
     - name: JSV::Validator
       url: https://metacpan.org/module/JSV::Validator
       draft: [4]
-      license: "MIT"
-    - name: JSON::Schema
-      url: https://metacpan.org/module/JSON::Schema
-      draft: [3]
       license: "MIT"
 - name: PostgreSQL
   implementations:
@@ -255,17 +188,6 @@
       notes: "PL/pgSQL implementation, no remote (http) references"
       draft: [4]
       license: PostgreSQL
-- name: Python
-  implementations:
-    - name: jsonschema
-      url: https://github.com/Julian/jsonschema
-      notes:
-      draft: [3, 4]
-      license: "MIT"
-    - name: json-schema-validator
-      url: https://github.com/zyga/json-schema-validator
-      draft: [2]
-      license: "LGPL"
 - name: Ruby
   implementations:
     - name: json_schema
@@ -276,7 +198,7 @@
     - name: json-schema
       url: https://github.com/hoxworth/json-schema
       notes:
-      draft: [1, 2, 3, 4]
+      draft: [4, 3, 2, 1]
       license: MIT
 - name: Rust
   implementations:

--- a/implementations.md
+++ b/implementations.md
@@ -4,7 +4,7 @@ title: Implementations
 permalink: /implementations.html
 ---
 
-_**NOTE:** This page lists implementations supporting draft-06 or later._
+_**NOTE:** This page lists implementations with (or actively working towards) support for draft-06 or later._
 
 _For implementations supporting only draft-04 or older, see the [Obsolete Implementations](obsolete-implementations) page._
 
@@ -77,10 +77,7 @@ Validators
 
 ### Benchmarks
 
--   Java
-    -   [json-schema-validator-benchmark](https://github.com/networknt/json-schema-validator-perftest) - compares performance of three JSON schema validator implementations in Java(Apache 2.0)
-
-<!-- -->
+Benchmarks that compare at least two implementations supporting draft-06+ may be listed here.
 
 -   JavaScript
     -   [json-schema-benchmark](https://github.com/ebdrup/json-schema-benchmark) - an independent benchmark for Node.js JSON-schema validators based on JSON-Schema Test Suite (MIT)
@@ -130,31 +127,33 @@ Hyper-Schema
 Schema generation
 -----------------
 
+Generators that produce schemas that are compatible with draft-06+ (e.g. no boolean `exlusiveMaximum`/`exclusiveMinimum`, no `id`, no hardwired draft-04 `$schema`) may be listed here.  Such tools need not necessarily be able to generate every keyword from recent drafts.
+
 -   .NET
     -   [Json.NET](https://www.newtonsoft.com/jsonschema) (AGPL-3.0) - generates schemas from .NET types
+    -   [NJsonSchema](http://NJsonSchema.org) - (Ms-PL) - generates schemas from .NET types, see issue [574](https://github.com/RSuter/NJsonSchema/issues/574) for draft-06+ support progress
+-   Orderly
+    -   [Orderly](https://github.com/lloyd/orderly) (BSD-3-Clause)
 -   PHP
     -   [Liform](https://github.com/Limenius/liform) (MIT) - generates schemas from Symfony forms
 -   Scala
-    -   [Schema Guru](https://github.com/snowplow/schema-guru) (Apache 2.0) - CLI util, Spark Job and Web UI for deriving JSON Schemas out of corpus of JSON instances
+    -   [Schema Guru](https://github.com/snowplow/schema-guru) (Apache 2.0) - CLI util, Spark Job and Web UI for deriving JSON Schemas out of corpus of JSON instances; see issue [178](https://github.com/snowplow/schema-guru/issues/178) for progress towards draft-06+ support
 -   TypeScript
     -   [typescript-json-schema](https://github.com/YousefED/typescript-json-schema)
 -   Online (web tool)
-    -   [jsonschema.net](http://jsonschema.net/) - generates schemas from example data
+    -   [jsonschema.net](http://www.jsonschema.net) - generates schemas from example data
 
 Data parsing and code generation
 --------------------------------
 
--   Scala
-    -   [json-schema-codegen](https://github.com/VoxSupplyChain/json-schema-codegen) - Tool and SBT plugin for generating Scala, TypeScript models and parsers from Json-Schema definitions, *supports draft 4* (Apache 2.0)
-    -   [Argus](https://github.com/aishfenton/argus) (MIT) - Macros for building models from JSON Schemas
--   Swift
-    -   [Bric-à-brac](https://github.com/glimpseio/BricBrac) (MIT) - generates idiomatic swift structs and parser/serializer from JSON schemas
 -   Golang
-    -  [gojsonschema](https://github.com/andy-zhangtao/gojsonschema)(Apache 2.0) - golang package for generating golang struct *supports Draft 4*. [Demo](http://json.golang.chinazt.cc)
     -  [jsonschema](https://github.com/qri-io/jsonschema)(MIT) - idiomatic go implementation with custom validator support, coding to and from json, rich error returns *supports Draft 7*
 
 UI generation
 -------------
+
+_TODO: Sort by draft support._
+
 Various levels of support for UI generation primarily from the validation vocabulary or combined with UI specific definition.
 
 -   JavaScript
@@ -175,6 +174,8 @@ Various levels of support for UI generation primarily from the validation vocabu
 Editors
 -------
 
+_TODO: Sort by draft support._
+
 -   [Liquid XML Studio 2016](https://www.liquid-technologies.com/json-schema-editor) - *Graphical JSON schema editor for draft 4, context sensitive intellisense for JSON documents.*
 -   [Visual Studio 2013](http://www.visualstudio.com/) - *Auto-completion and tooltips based on JSON schema draft 3 and draft 4*
 -   [JSONBuddy](http://www.json-buddy.com/) - *Grid-style JSON editor and context sensitive entry-helpers based on JSON schema*
@@ -189,29 +190,26 @@ Editors
 Compatibility
 -------------
 
--   JavaScript
-    -   [JSON Schema Compatibility](https://github.com/geraintluff/json-schema-compatability) - *converts draft 3 to draft 4* (Public Domain)
+Do you know of a tool that converts any version of JSON Schema to draft-07 or later?  If so, please open a PR!
 
 Documentation generation
 ------------------------
 
 -   JavaScript
-    -   [Matic](https://github.com/mattyod/matic) (MIT)
-    -   [Docson](https://github.com/lbovet/docson) (Apache 2.0)
-    -   [doca](https://github.com/cloudflare/doca/) (BSD)
-    -   [prmd](https://github.com/interagent/prmd) (MIT)
+    -   [@cloudflare/json-schema-apidoc-loader](https://github.com/cloudflare/json-schema-tools/tree/master/workspaces/json-schema-apidoc-loader) Back-end for [@cloudflare/doca](https://github.com/cloudflare/json-schema-tools/tree/master/workspaces/doca), supporting draft-04, -06, -07, and Doca extensions (UI forthcoming)
 
 Other
 -----
 
 -   JavaScript
-    -   [Orderly](https://github.com/lloyd/orderly) (BSD-3-Clause)
-    -   [Dojo](http://www.dojotoolkit.org/) (AFL or BSD) - supports some aspects of JSON Schema
-    -   [Schematic Ipsum](http://schematic-ipsum.herokuapp.com/) (MIT)
-    -   [JSON-Schema-Instantiator](https://github.com/tomarad/JSON-Schema-Instantiator) (MIT)
-    -   [JSON Schema Random](https://github.com/andreineculau/json-schema-random) (Apache 2.0)
+    -   [JSON Schema Tools](https://github.com/cloudflare/json-schema-tools) (BSD-3-Clause) Monorepo for various JSON Schema-related packages, including:
+        -   [@cloudflare/json-schema-walker](https://github.com/cloudflare/json-schema-tools/tree/master/workspaces/json-schema-walker) (BSD-3-Clause) Walks schemas (draft-04, -06, 07, and Cloudflare's Doca extensions) and runs pre- and post-walk callbacks.  Can modify schemas in place.
+        -   [@cloudflare/json-schema-transform](https://github.com/cloudflare/json-schema-tools/tree/master/workspaces/json-schema-transform) (BSD-3-Clause) Utilities using @cloudflare/json-schema-walker for transformations including `allOf` merging and example roll-up.
+        -   [@cloudflare/json-schema-ref-loader](https://github.com/cloudflare/json-schema-tools/tree/master/workspaces/json-schema-ref-loader) (BSD-3-Clause) Webpack loader for dereference-able schemas in JSON, JSON5, YAML, or JavaScript
+        -   [@cloudflare/json-hyper-schema](https://github.com/cloudflare/json-schema-tools/tree/master/workspaces/json-hyper-schema) (BSD-3-Clause) Utilities for working with Link Description Objects
     -   [json-schema-merge-allof](https://github.com/mokkabonna/json-schema-merge-allof) (MIT)
     -   [json-schema-compare](https://github.com/mokkabonna/json-schema-compare) (MIT)
+    -   [JSON-Schema-Instantiator](https://github.com/tomarad/JSON-Schema-Instantiator) (MIT)
 
 ### Schema Repositories
 -   [SchemaStore.org](http://schemastore.org/json/) - validate against common JSON Schemas

--- a/implementations.md
+++ b/implementations.md
@@ -93,7 +93,7 @@ Hyper-Schema
 
 <nav class="intra" markdown="1">
 
-{% assign hyper-schema-libraries = site.data.hyper-schema-libraries | sort:"name" %}
+{% assign hyper-schema-libraries = site.data.hyper-libraries-modern | sort:"name" %}
 
 {% for language in hyper-schema-libraries %}
 -   [{{ language.name }}](#hyper-schema-{% if language.anchor-name %}{{ language.anchor-name }}{% else %}{{ language.name | downcase }}{% endif %})
@@ -111,7 +111,7 @@ Hyper-Schema
     {% for implementation in language.implementations %}
         <li>
         <a href="{{implementation.url}}">{{ implementation.name }}</a>
-        
+
         {% if implementation.draft %}
             <em>supports draft {{ implementation.draft | join: ", draft " }}</em>
         {% endif %}

--- a/implementations.md
+++ b/implementations.md
@@ -38,7 +38,7 @@ Validators
     {% for implementation in language.implementations %}
         <li>
         <a href="{{implementation.url}}">{{ implementation.name }}</a>
-        
+
         {% if implementation.draft %}
             <em>supports draft {{ implementation.draft | join: ", draft " }}</em>
         {% endif %}
@@ -60,7 +60,7 @@ Validators
 -   [JSON Schema Validator](https://www.jsonschemavalidator.net/) - validate against your own schemas
 -   [JSON Schema Lint](http://jsonschemalint.com/) - validate against your own schemas
 -   [SchemaStore.org](http://schemastore.org/validator/) - validate against common JSON Schemas
--   [quicktype.io](https://app.quicktype.io/#l=schema) - infer JSON Schema from samples, and generate TypeScript, C++, go, Java, C#, Swift, etc. types from JSON Schema 
+-   [quicktype.io](https://app.quicktype.io/#l=schema) - infer JSON Schema from samples, and generate TypeScript, C++, go, Java, C#, Swift, etc. types from JSON Schema
 
 ### Command Line
 

--- a/obsolete-implementations.md
+++ b/obsolete-implementations.md
@@ -70,8 +70,7 @@ Validators
   - {{ tool.notes }} {% endif %}{% endfor %}
 
 
-Validation benchmarks
----------------------
+### Benchmarks
 
 -   Java
     -   [json-schema-validator-benchmark](https://github.com/networknt/json-schema-validator-perftest) - compares performance of three JSON schema validator implementations in Java(Apache 2.0)
@@ -85,6 +84,44 @@ Validation benchmarks
 
 -   PHP
     -   [php-json-schema-bench](https://github.com/swaggest/php-json-schema-bench) - comparative benchmark for JSON-schema PHP validators using JSON-Schema Test Suite and z-schema/JSCK (MIT)
+
+Hyper-Schema
+---------------------
+
+<nav class="intra" markdown="1">
+
+{% assign hyper-schema-libraries = site.data.hyper-libraries-obsolete | sort:"name" %}
+
+{% for language in hyper-schema-libraries %}
+-   [{{ language.name }}](#hyper-schema-{% if language.anchor-name %}{{ language.anchor-name }}{% else %}{{ language.name | downcase }}{% endif %})
+{% endfor %}
+
+</nav>
+
+<!-- To add a hyper-schema library, add it in _data/hyper-schema-libraries.yml -->
+
+<ul>
+  {% for language in hyper-schema-libraries %}
+  <li>
+    {{language.name}} <a id="hyper-schema-{% if language.anchor-name %}{{ language.anchor-name }}{% else %}{{ language.name | downcase }}{% endif %}"></a>
+    <ul>
+    {% for implementation in language.implementations %}
+        <li>
+        <a href="{{implementation.url}}">{{ implementation.name }}</a>
+
+        {% if implementation.draft %}
+            <em>supports draft {{ implementation.draft | join: ", draft " }}</em>
+        {% endif %}
+
+        {{implementation.notes | markdownify | remove: '<p>' | remove: '</p>'}}
+        ({{ implementation.license | join: ", " }})
+
+        </li>
+    {% endfor %}
+    </ul>
+  </li>
+  {% endfor %}
+</ul>
 
 Schema generation
 -----------------
@@ -168,13 +205,6 @@ Compatibility
 -   JavaScript
     -   [JSON Schema Compatibility](https://github.com/geraintluff/json-schema-compatability) - *converts draft 3 to draft 4* (Public Domain)
 
-Hyper-schema handling
----------------------
-
--   JavaScript
-    -   [Jsonary](http://jsonary.com/) - *supports draft 4* (MIT)
--   Python
-    -   [Core API Hyper-Schema codec](https://github.com/core-api/python-jsonhyperschema-codec) - *supports draft 4* (BSD-2-Clause)
 
 Documentation generation
 ------------------------

--- a/obsolete-implementations.md
+++ b/obsolete-implementations.md
@@ -4,6 +4,12 @@ title: Obsolete Implementations
 permalink: /obsolete-implementations.html
 ---
 
+_**NOTE:** Due to the long gap after draft-04, many projects that implemented that draft became inactive by the time draft-06 was published, or are looking for new contributors to move forward.  Such projects are listed here_
+
+_For implementations supporting (or actively working towards) draft-06 or later, see the main [Implementations](implementations) page._
+
+_Projects supporting only draft-03 or earlier are no longer listed._
+
 * TOC
 {:toc}
 
@@ -73,7 +79,7 @@ Validators
 ### Benchmarks
 
 -   Java
-    -   [json-schema-validator-benchmark](https://github.com/networknt/json-schema-validator-perftest) - compares performance of three JSON schema validator implementations in Java(Apache 2.0)
+    -   [json-schema-validator-benchmark](https://github.com/networknt/json-schema-validator-perftest) - compares performance of three JSON schema validator implementations (only one of which supports draft-06+) in Java(Apache 2.0)
 
 <!-- -->
 
@@ -126,23 +132,12 @@ Hyper-Schema
 Schema generation
 -----------------
 
--   .NET
-    -   [Json.NET](http://james.newtonking.com/projects/json-net.aspx) (MIT) - generates schemas from .NET types
-    -   [NJsonSchema](http://NJsonSchema.org) - *supports draft 4* (Ms-PL) - generates schemas from .NET types
--   PHP
-    -   [Liform](https://github.com/Limenius/liform) (MIT) - generates schemas from Symfony forms
 -   Python
     -   [JSL](https://github.com/aromanovich/jsl) (BSD) - a Python DSL for defining JSON Schemas
--   Scala
-    -   [Schema Guru](https://github.com/snowplow/schema-guru) (Apache 2.0) - CLI util, Spark Job and Web UI for deriving JSON Schemas out of corpus of JSON instances
 -   JavaScript
     -   [json-schema-generator](https://github.com/krg7880/json-schema-generator) (MIT) - Node.js library usable both as a CLI util and as a Node module
 -   TypeScript
-    -   [typescript-json-schema](https://github.com/YousefED/typescript-json-schema)
     -   [Typson](https://github.com/lbovet/typson) (Apache 2.0)
--   Online (web tool)
-    -   [jsonschema.net](http://www.jsonschema.net/) - generates schemas from example data
-    -   [Schema Guru Web UI](http://schemaguru.snowplowanalytics.com/) - derives precise Schemas using several JSON instances. Based on [Schema Guru](link-impl-guru)
 -   Visual Studio
     -   [JSON Schema Generator](http://visualstudiogallery.msdn.microsoft.com/b4515ef8-a518-41ca-b48c-bb1fd4e6faf7) - free extension
 -   Sparx Enterprise Architect
@@ -169,6 +164,9 @@ Data parsing and code generation
 
 UI generation
 -------------
+
+_TODO: Sort by draft support._
+
 Various levels of support for UI generation primarily from the validation vocabulary or combined with UI specific definition.
 
 -   JavaScript
@@ -188,6 +186,8 @@ Various levels of support for UI generation primarily from the validation vocabu
 
 Editors
 -------
+
+_TODO: Sort by draft support._
 
 -   [Liquid XML Studio 2016](https://www.liquid-technologies.com/json-schema-editor) - *Graphical JSON schema editor for draft 4, context sensitive intellisense for JSON documents.*
 -   [Visual Studio 2013](http://www.visualstudio.com/) - *Auto-completion and tooltips based on JSON schema draft 3 and draft 4*
@@ -212,17 +212,14 @@ Documentation generation
 -   JavaScript
     -   [Matic](https://github.com/mattyod/matic) (MIT)
     -   [Docson](https://github.com/lbovet/docson) (Apache 2.0)
-    -   [doca](https://github.com/cloudflare/doca/) (BSD)
+    -   [doca](https://github.com/cloudflare/doca/) (BSD) See [@cloudflare/doca](https://github.com/cloudflare/json-schema-tools/tree/master/workspaces/doca) for draft-06+ support
     -   [prmd](https://github.com/interagent/prmd) (MIT)
 
 Other
 -----
 
 -   JavaScript
-    -   [Orderly](https://github.com/lloyd/orderly) (BSD-3-Clause)
     -   [Dojo](http://www.dojotoolkit.org/) (AFL or BSD) - supports some aspects of JSON Schema
-    -   [Schematic Ipsum](http://schematic-ipsum.herokuapp.com/) (MIT)
-    -   [JSON-Schema-Instantiator](https://github.com/tomarad/JSON-Schema-Instantiator) (MIT)
     -   [JSON Schema Random](https://github.com/andreineculau/json-schema-random) (Apache 2.0)
     -   [json-schema-merge-allof](https://github.com/mokkabonna/json-schema-merge-allof) (MIT)
     -   [json-schema-compare](https://github.com/mokkabonna/json-schema-compare) (MIT)

--- a/obsolete-implementations.md
+++ b/obsolete-implementations.md
@@ -1,19 +1,13 @@
 ---
 layout: page
-title: Implementations
-permalink: /implementations.html
+title: Obsolete Implementations
+permalink: /obsolete-implementations.html
 ---
-
-_**NOTE:** This page lists implementations supporting draft-06 or later._
-
-_For implementations supporting only draft-04 or older, see the [Obsolete Implementations](obsolete-implementations) page._
-
 
 * TOC
 {:toc}
 
-Implementations below are written in different languages, and support part, or all, of at least one recent version of the specification.
-
+Implementations below are written in different languages, and support part, or all, of the specification.
 
 Implementations are classified based on their functionality. When known, the license of the project is also mentioned.
 
@@ -26,7 +20,7 @@ Validators
 
 <nav class="intra" markdown="1">
 
-{% assign validator-libraries = site.data.validator-libraries-modern | sort:"name" %}
+{% assign validator-libraries = site.data.validator-libraries-obsolete | sort:"name" %}
 
 {% for language in validator-libraries %}
 -   [{{ language.name }}](#validator-{% if language.anchor-name %}{{ language.anchor-name }}{% else %}{{ language.name | downcase }}{% endif %})
@@ -34,7 +28,7 @@ Validators
 
 </nav>
 
-<!-- To add a validator library, add it in _data/validator-libraries-modern.yml -->
+<!-- To add a validator library, add it in _data/validator-libraries-obsolete.yml -->
 
 <ul>
   {% for language in validator-libraries %}
@@ -46,7 +40,7 @@ Validators
         <a href="{{implementation.url}}">{{ implementation.name }}</a>
 
         {% if implementation.draft %}
-            <em>supports draft-0{{ implementation.draft | join: ", draft-0" }}</em>
+            <em>supports draft {{ implementation.draft | join: ", draft " }}</em>
         {% endif %}
 
         {{implementation.notes | markdownify | remove: '<p>' | remove: '</p>'}}
@@ -63,19 +57,21 @@ Validators
 
 ### Online
 
--   [JSON Schema Validator](https://www.jsonschemavalidator.net/) - validate against your own schemas
 -   [JSON Schema Lint](http://jsonschemalint.com/) - validate against your own schemas
+-   [SchemaStore.org](http://schemastore.org/validator/) - validate against common JSON Schemas
 -   [quicktype.io](https://app.quicktype.io/#l=schema) - infer JSON Schema from samples, and generate TypeScript, C++, go, Java, C#, Swift, etc. types from JSON Schema
 
 ### Command Line
 
-<!-- To add a validator library, add it in _data/validator-libraries-modern.yml -->
+<!-- To add a validator library, add it in _data/validator-libraries-obsolete.yml -->
 
 {% for tool in site.data.validator-cli %}
-- [{{ tool.name }}]({{ tool.url }}) <em>[draft-0{{ tool.draft | join: ", draft-0" }}]</em> ({{ tool.license | join: ", " }}){% if tool.notes %}
+- [{{ tool.name }}]({{ tool.url }}) [draft {{ tool.draft | join: ", draft " }}] ({{ tool.license | join: ", " }}){% if tool.notes %}
   - {{ tool.notes }} {% endif %}{% endfor %}
 
-### Benchmarks
+
+Validation benchmarks
+---------------------
 
 -   Java
     -   [json-schema-validator-benchmark](https://github.com/networknt/json-schema-validator-perftest) - compares performance of three JSON schema validator implementations in Java(Apache 2.0)
@@ -84,66 +80,48 @@ Validators
 
 -   JavaScript
     -   [json-schema-benchmark](https://github.com/ebdrup/json-schema-benchmark) - an independent benchmark for Node.js JSON-schema validators based on JSON-Schema Test Suite (MIT)
+    -   [z-schema validator benchmark](https://github.com/zaggino/z-schema#benchmarks) - compares performance in the individual tests from JSON-Schema Test Suite (MIT)
+    -   [JSCK validator benchmark](https://github.com/pandastrike/jsck#benchmarks) - shows performance for JSON-schemas of different complexity (MIT)
 
 -   PHP
     -   [php-json-schema-bench](https://github.com/swaggest/php-json-schema-bench) - comparative benchmark for JSON-schema PHP validators using JSON-Schema Test Suite and z-schema/JSCK (MIT)
-
-Hyper-Schema
----------------------
-
-<nav class="intra" markdown="1">
-
-{% assign hyper-schema-libraries = site.data.hyper-schema-libraries | sort:"name" %}
-
-{% for language in hyper-schema-libraries %}
--   [{{ language.name }}](#hyper-schema-{% if language.anchor-name %}{{ language.anchor-name }}{% else %}{{ language.name | downcase }}{% endif %})
-{% endfor %}
-
-</nav>
-
-<!-- To add a hyper-schema library, add it in _data/hyper-schema-libraries.yml -->
-
-<ul>
-  {% for language in hyper-schema-libraries %}
-  <li>
-    {{language.name}} <a id="hyper-schema-{% if language.anchor-name %}{{ language.anchor-name }}{% else %}{{ language.name | downcase }}{% endif %}"></a>
-    <ul>
-    {% for implementation in language.implementations %}
-        <li>
-        <a href="{{implementation.url}}">{{ implementation.name }}</a>
-        
-        {% if implementation.draft %}
-            <em>supports draft {{ implementation.draft | join: ", draft " }}</em>
-        {% endif %}
-
-        {{implementation.notes | markdownify | remove: '<p>' | remove: '</p>'}}
-        ({{ implementation.license | join: ", " }})
-
-        </li>
-    {% endfor %}
-    </ul>
-  </li>
-  {% endfor %}
-</ul>
-
 
 Schema generation
 -----------------
 
 -   .NET
-    -   [Json.NET](https://www.newtonsoft.com/jsonschema) (AGPL-3.0) - generates schemas from .NET types
+    -   [Json.NET](http://james.newtonking.com/projects/json-net.aspx) (MIT) - generates schemas from .NET types
+    -   [NJsonSchema](http://NJsonSchema.org) - *supports draft 4* (Ms-PL) - generates schemas from .NET types
 -   PHP
     -   [Liform](https://github.com/Limenius/liform) (MIT) - generates schemas from Symfony forms
+-   Python
+    -   [JSL](https://github.com/aromanovich/jsl) (BSD) - a Python DSL for defining JSON Schemas
 -   Scala
     -   [Schema Guru](https://github.com/snowplow/schema-guru) (Apache 2.0) - CLI util, Spark Job and Web UI for deriving JSON Schemas out of corpus of JSON instances
+-   JavaScript
+    -   [json-schema-generator](https://github.com/krg7880/json-schema-generator) (MIT) - Node.js library usable both as a CLI util and as a Node module
 -   TypeScript
     -   [typescript-json-schema](https://github.com/YousefED/typescript-json-schema)
+    -   [Typson](https://github.com/lbovet/typson) (Apache 2.0)
 -   Online (web tool)
-    -   [jsonschema.net](http://jsonschema.net/) - generates schemas from example data
+    -   [jsonschema.net](http://www.jsonschema.net/) - generates schemas from example data
+    -   [Schema Guru Web UI](http://schemaguru.snowplowanalytics.com/) - derives precise Schemas using several JSON instances. Based on [Schema Guru](link-impl-guru)
+-   Visual Studio
+    -   [JSON Schema Generator](http://visualstudiogallery.msdn.microsoft.com/b4515ef8-a518-41ca-b48c-bb1fd4e6faf7) - free extension
+-   Sparx Enterprise Architect
+    -   [API-Add-In](https://github.com/bayeslife/api-add-in) - Sparx EA extension for exporting JSON Schema from UML models
 
 Data parsing and code generation
 --------------------------------
 
+-   Delphi
+    - [DJsonSchema](https://github.com/schlothauer-wauer/DJsonSchema) (MIT) - JSON Schema reader and code generator for Delphi.
+-   Groovy
+    - [jsonCodeGen](https://github.com/schlothauer-wauer/jsoncodegen) (MIT) - Groovy based generation tasks from JSON schema. Already includes generators for Java Beans, Swagger specification files and PlantUML diagrams.
+-   Haskell
+    -   [aeson-schema](https://github.com/Fuuzetsu/aeson-schema) (MIT) - generates code for a parser
+-   Ruby
+    -   [autoparse](https://github.com/google/autoparse) (ASL 2.0)
 -   Scala
     -   [json-schema-codegen](https://github.com/VoxSupplyChain/json-schema-codegen) - Tool and SBT plugin for generating Scala, TypeScript models and parsers from Json-Schema definitions, *supports draft 4* (Apache 2.0)
     -   [Argus](https://github.com/aishfenton/argus) (MIT) - Macros for building models from JSON Schemas
@@ -151,7 +129,6 @@ Data parsing and code generation
     -   [Bric-à-brac](https://github.com/glimpseio/BricBrac) (MIT) - generates idiomatic swift structs and parser/serializer from JSON schemas
 -   Golang
     -  [gojsonschema](https://github.com/andy-zhangtao/gojsonschema)(Apache 2.0) - golang package for generating golang struct *supports Draft 4*. [Demo](http://json.golang.chinazt.cc)
-    -  [jsonschema](https://github.com/qri-io/jsonschema)(MIT) - idiomatic go implementation with custom validator support, coding to and from json, rich error returns *supports Draft 7*
 
 UI generation
 -------------
@@ -184,13 +161,20 @@ Editors
 -   [JSON Schema Editor](https://json-schema-editor.tangramjs.com) - *An intuitive editor for JSON schema online*
 -   [JSON Editor](https://json-editor.tangramjs.com) - *An online, schema-aware editor for JSON document*
 -   [Eclipse IDE](https://www.eclipse.org/downloads/eclipse-packages) - *Rich JSON edition supporting schema for instantaneous validation and error reporting, completion, documentation.*
--   [WebStorm](https://www.jetbrains.com/webstorm/), [IntelliJ IDEA](https://www.jetbrains.com/idea/), and other [JetBrains IDEs](https://www.jetbrains.com/products.html?fromMenu#type=ide) - *Code completion, documentation, and validation for JSON files using JSON Schema*
 
 Compatibility
 -------------
 
 -   JavaScript
     -   [JSON Schema Compatibility](https://github.com/geraintluff/json-schema-compatability) - *converts draft 3 to draft 4* (Public Domain)
+
+Hyper-schema handling
+---------------------
+
+-   JavaScript
+    -   [Jsonary](http://jsonary.com/) - *supports draft 4* (MIT)
+-   Python
+    -   [Core API Hyper-Schema codec](https://github.com/core-api/python-jsonhyperschema-codec) - *supports draft 4* (BSD-2-Clause)
 
 Documentation generation
 ------------------------
@@ -212,6 +196,3 @@ Other
     -   [JSON Schema Random](https://github.com/andreineculau/json-schema-random) (Apache 2.0)
     -   [json-schema-merge-allof](https://github.com/mokkabonna/json-schema-merge-allof) (MIT)
     -   [json-schema-compare](https://github.com/mokkabonna/json-schema-compare) (MIT)
-
-### Schema Repositories
--   [SchemaStore.org](http://schemastore.org/json/) - validate against common JSON Schemas


### PR DESCRIPTION
We really want to drive people towards projects supporting (or working towards supporting) the new drafts.  Also, many of the draft-04-only projects are dead or on life support.

Projects supporting only draft-03 and earlier have been dropped entirely (a few validators, and a lorem ipsum generator).

Editors and UI generators still need splitting- I'm just tired of trying to sort out draft support for now and don't want this to stall for months *again* (this is the third time I've tried to do this) so I'll do that later.
