### PR TITLE
Add f5-json-schema to the implementations list

### DIFF
--- a/_data/validator-libraries-modern.yml
+++ b/_data/validator-libraries-modern.yml
@@ -16,6 +16,12 @@
       draft: [4, 3]
       license: LGPL-3.0
       notes: "Draft-06+ progress: issue [17](https://github.com/netmail-open/wjelement/issues/17#issuecomment-390899432)"
+- name: C++
+  implementations:
+    - name: f5-json-schema
+      url: https://github.com/KayEss/json-schema
+      draft: [7]
+      license: Boost Software License 1.0
 - name: Elixir
   implementations:
     - name: Elixir JSON Schema validator


### PR DESCRIPTION
This is now fully conforming to the v7 test suite. It includes a command line validation tool as well