### PR TITLE
Use $id consistently in examples

### DIFF
--- a/learn/examples/geographical-location.schema.json
+++ b/learn/examples/geographical-location.schema.json
@@ -1,5 +1,5 @@
 {
-  "id": "https://example.com/geographical-location.schema.json",
+  "$id": "https://example.com/geographical-location.schema.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Longitude and Latitude Values",
   "description": "A geographical coordinate.",

--- a/learn/miscellaneous-examples.md
+++ b/learn/miscellaneous-examples.md
@@ -61,7 +61,7 @@ This example introduces:
 
 ```json
 {
-  "id": "https://example.com/geographical-location.schema.json",
+  "$id": "https://example.com/geographical-location.schema.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Longitude and Latitude Values",
   "description": "A geographical coordinate.",
@@ -105,7 +105,7 @@ We also introduce the following with this example:
 
 ```json
 {
-  "id": "https://example.com/arrays.schema.json",
+  "$id": "https://example.com/arrays.schema.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "description": "A representation of a person, company, organization, or place",
   "type": "object",


### PR DESCRIPTION
Currently, some of the miscellaneous examples still use the old `id` key when defining a schema, instead of `$id` which is the correct version as of [draft-06](https://json-schema.org/draft-06/json-schema-release-notes.html#backwards-incompatible-changes). This pull request corrects all remaining cases of this error under https://json-schema.org/learn/.