### PR TITLE
Add Justify to the validator list

### DIFF
--- a/_data/validator-libraries-modern.yml
+++ b/_data/validator-libraries-modern.yml
@@ -52,6 +52,11 @@
       notes:
       draft: [7, 6, 4]
       license: Apache License 2.0
+    - name: Justify
+      url: https://github.com/leadpony/justify
+      notes:
+      draft: [7]
+      license: Apache License 2.0
 - name: JavaScript
   implementations:
     - name: ajv


### PR DESCRIPTION
Could you please add my [Justify](https://github.com/leadpony/justify) to your validators list?
The library supports draft-07 and passes all test cases including optional ones in JSON Schema Test Suite.
Thank you.