### PR TITLE
Update the supported drafts for Justify

### DIFF
--- a/_data/validator-libraries-modern.yml
+++ b/_data/validator-libraries-modern.yml
@@ -69,7 +69,7 @@
     - name: Justify
       url: https://github.com/leadpony/justify
       notes:
-      draft: [7]
+      draft: [7, 6, 4]
       license: Apache License 2.0
 - name: Kotlin
   implementations:


### PR DESCRIPTION
Hello again,
Would you please update the validator list?
All test cases for Draft-07, -06, and -04 including optional ones from JSON-Schema-Test-Suite are now correctly handled by [the library](https://github.com/leadpony/justify).
Thank you.