### PR TITLE
Build work-in-progress documents and description page

### DIFF
--- a/index.md
+++ b/index.md
@@ -7,6 +7,9 @@ permalink: /
 ***The current version is [draft-07](specification.html)!***
 {: style="color:gray; font-size: 150%; text-align: center;"}
 
+***The next draft work-in-progres is [in final review](work-in-progress/)!***
+{: style="color:red; font-size: 150%; text-align: center;"}
+
 **JSON Schema** is a vocabulary that allows you to **annotate** and **validate** JSON documents.
 
 
@@ -37,21 +40,13 @@ permalink: /
 
 ## Project Status
 
-### Update as of 31 March 2019
+### Update as of 27 May 2019
 
-**You may be wondering _what in the world is going on with this draft?_  The short version is: we are entering the home stretch.  There are some ideas for simplifying `$id` that we are considering, and then there will be a final review period for feedback on overall flow and clarity.**
-
-As for the long version:  The original intent was to publish by the time the previous draft by or at least soon after the current Core and Validation drafts expired on 20 September, 2018.  The project is a volunteer project, and one editor was driving most of the large changes in this draft.
-
-Unfortunately, that editor had a lot of Real Life Stuff(tm) to deal with this past year, including changing jobs (which put things on hold from about May through August or so) and then a run of minor health issues (which put things on hold from November through February).  Other contributors made progress during those times,
-
-As of March, everyone is back to working towards the publication of the draft as schedules permit.
-
-We expect to publish a new round of drafts (Core, Validation, Hyper-Schema, Relative JSON Pointer) in the next month or two, and are actively working on the last few PRs.  While the drafts are currently expired, they are still under active development.  This project is staffed by volunteers, and life occasionally disregards IETF expiration schedules.
+**The forthcoming draft is in [final review](work-in-progress/).**
 
 This draft has also taken more time than expected because it tackles deep, long-term issues that have long been a challenge for JSON Schema.  This includes building in a formal extensibility mechanism so that we can more easily draw a line to finalize the contents of the Core and Validation specifications.
 
-Progress on the next set of Internet-Drafts can be tracked on GitHub. The [draft-08](https://github.com/json-schema-org/json-schema-spec/milestone/6) milestone will track the evolving scope of the draft (although see [issue #612](https://github.com/json-schema-org/json-schema-spec/issues/612) for a discussion of whether "draft-08" is the right name for this milestone).
+Additionally, numerous life issues reduced the availability of key contributors during the process.
 
 ### The Path to Standardization
 

--- a/work-in-progress/WIP-hyper-schema.json
+++ b/work-in-progress/WIP-hyper-schema.json
@@ -1,21 +1,21 @@
 {
-    "$schema": "http://json-schema.org/draft/2019-04/hyper-schema#",
-    "$id": "http://json-schema.org/draft/2019-04/hyper-schema",
+    "$schema": "http://json-schema.org/draft/2019-WIP/hyper-schema#",
+    "$id": "http://json-schema.org/draft/2019-WIP/hyper-schema",
     "$vocabulary": {
-        "https://json-schema.org/draft/2019-04/vocab/core": true,
-        "https://json-schema.org/draft/2019-04/vocab/applicator": true,
-        "https://json-schema.org/draft/2019-04/vocab/validation": true,
-        "https://json-schema.org/draft/2019-04/vocab/meta-data": true,
-        "https://json-schema.org/draft/2019-04/vocab/format": true,
-        "https://json-schema.org/draft/2019-04/vocab/content": true,
-        "https://json-schema.org/draft/2019-04/vocab/hyper-schema": true
+        "https://json-schema.org/draft/2019-WIP/vocab/core": true,
+        "https://json-schema.org/draft/2019-WIP/vocab/applicator": true,
+        "https://json-schema.org/draft/2019-WIP/vocab/validation": true,
+        "https://json-schema.org/draft/2019-WIP/vocab/meta-data": true,
+        "https://json-schema.org/draft/2019-WIP/vocab/format": true,
+        "https://json-schema.org/draft/2019-WIP/vocab/content": true,
+        "https://json-schema.org/draft/2019-WIP/vocab/hyper-schema": true
     },
     "$recursiveAnchor": true,
 
     "title": "JSON Hyper-Schema",
     "allOf": [
-        {"$ref": "http://json-schema.org/draft/2019-04/schema"},
-        {"$ref": "http://json-schema.org/draft/2019-04/meta/hyper-schema"}
+        {"$ref": "http://json-schema.org/draft/2019-WIP/schema"},
+        {"$ref": "http://json-schema.org/draft/2019-WIP/meta/hyper-schema"}
     ],
     "links": [
         {

--- a/work-in-progress/WIP-hyper-schema.json
+++ b/work-in-progress/WIP-hyper-schema.json
@@ -1,0 +1,26 @@
+{
+    "$schema": "http://json-schema.org/draft/2019-04/hyper-schema#",
+    "$id": "http://json-schema.org/draft/2019-04/hyper-schema",
+    "$vocabulary": {
+        "https://json-schema.org/draft/2019-04/vocab/core": true,
+        "https://json-schema.org/draft/2019-04/vocab/applicator": true,
+        "https://json-schema.org/draft/2019-04/vocab/validation": true,
+        "https://json-schema.org/draft/2019-04/vocab/meta-data": true,
+        "https://json-schema.org/draft/2019-04/vocab/format": true,
+        "https://json-schema.org/draft/2019-04/vocab/content": true,
+        "https://json-schema.org/draft/2019-04/vocab/hyper-schema": true
+    },
+    "$recursiveAnchor": true,
+
+    "title": "JSON Hyper-Schema",
+    "allOf": [
+        {"$ref": "http://json-schema.org/draft/2019-04/schema"},
+        {"$ref": "http://json-schema.org/draft/2019-04/meta/hyper-schema"}
+    ],
+    "links": [
+        {
+            "rel": "self",
+            "href": "{+%24id}"
+        }
+    ]
+}

--- a/work-in-progress/WIP-jsonschema-core.html
+++ b/work-in-progress/WIP-jsonschema-core.html
@@ -477,7 +477,7 @@
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Wright, A., Ed., Andrews, H., Ed., Hutton, B., Ed., and G. Dennis" />
-  <meta name="dct.identifier" content="urn:ietf:id:draft-handrews-json-schema-02" />
+  <meta name="dct.identifier" content="urn:ietf:id:draft-handrews-json-schema-WIP" />
   <meta name="dct.issued" scheme="ISO8601" content="2019-25" />
   <meta name="dct.abstract" content="JSON Schema defines the media type &quot;application/schema+json&quot;, a JSON-based format for describing the structure of JSON data.  JSON Schema asserts what a JSON document must look like, ways to extract information from it, and how to interact with it.  The &quot;application/schema-instance+json&quot; media type provides additional feature-rich integration with &quot;application/schema+json&quot; beyond what can be offered for &quot;application/json&quot; documents.  " />
   <meta name="description" content="JSON Schema defines the media type &quot;application/schema+json&quot;, a JSON-based format for describing the structure of JSON data.  JSON Schema asserts what a JSON document must look like, ways to extract information from it, and how to interact with it.  The &quot;application/schema-instance+json&quot; media type provides additional feature-rich integration with &quot;application/schema+json&quot; beyond what can be offered for &quot;application/json&quot; documents.  " />
@@ -527,7 +527,7 @@
   </table>
 
   <p class="title">JSON Schema: A Media Type for Describing JSON Documents<br />
-  <span class="filename">draft-handrews-json-schema-02</span></p>
+  <span class="filename">draft-handrews-json-schema-WIP</span></p>
   
   <h1 id="rfc.abstract"><a href="#rfc.abstract">Abstract</a></h1>
 <p>JSON Schema defines the media type "application/schema+json", a JSON-based format for describing the structure of JSON data.  JSON Schema asserts what a JSON document must look like, ways to extract information from it, and how to interact with it.  The "application/schema-instance+json" media type provides additional feature-rich integration with "application/schema+json" beyond what can be offered for "application/json" documents.  </p>
@@ -2047,12 +2047,12 @@ User-Agent: product-name/5.4.1 so-cool-json-schema/1.0.2 curl/7.43.0
 <tr>
 <td class="reference"><b id="json-hyper-schema">[json-hyper-schema]</b></td>
 <td class="top">
-<a>Andrews, H.</a> and <a>A. Wright</a>, "<a href="https://tools.ietf.org/html/draft-handrews-json-schema-hyperschema-02">JSON Hyper-Schema: A Vocabulary for Hypermedia Annotation of JSON</a>", Internet-Draft draft-handrews-json-schema-hyperschema-02, November 2017.</td>
+<a>Andrews, H.</a> and <a>A. Wright</a>, "<a href="https://tools.ietf.org/html/draft-handrews-json-schema-hyperschema-02">JSON Hyper-Schema: A Vocabulary for Hypermedia Annotation of JSON</a>", Internet-Draft draft-handrews-json-schema-hyperschema-WIP, November 2017.</td>
 </tr>
 <tr>
 <td class="reference"><b id="json-schema-validation">[json-schema-validation]</b></td>
 <td class="top">
-<a>Wright, A.</a>, <a>Andrews, H.</a> and <a>G. Luff</a>, "<a href="https://tools.ietf.org/html/draft-handrews-json-schema-validation-02">JSON Schema Validation: A Vocabulary for Structural Validation of JSON</a>", Internet-Draft draft-handrews-json-schema-validation-02, November 2017.</td>
+<a>Wright, A.</a>, <a>Andrews, H.</a> and <a>G. Luff</a>, "<a href="https://tools.ietf.org/html/draft-handrews-json-schema-validation-02">JSON Schema Validation: A Vocabulary for Structural Validation of JSON</a>", Internet-Draft draft-handrews-json-schema-validation-WIP, November 2017.</td>
 </tr>
 <tr>
 <td class="reference"><b id="RFC7049">[RFC7049]</b></td>
@@ -2085,7 +2085,7 @@ User-Agent: product-name/5.4.1 so-cool-json-schema/1.0.2 curl/7.43.0
 <p></p>
 
 <dl>
-<dt>draft-handrews-json-schema-02</dt>
+<dt>draft-handrews-json-schema-WIP</dt>
 <dd style="margin-left: 8">
 <ul>
 <li>Update to RFC 8359 for JSON specification</li>

--- a/work-in-progress/WIP-jsonschema-core.html
+++ b/work-in-progress/WIP-jsonschema-core.html
@@ -1,0 +1,2280 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" 
+  "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+<head profile="http://www.w3.org/2006/03/hcard http://dublincore.org/documents/2008/08/04/dc-html/">
+  <meta http-equiv="Content-Type" content="text/html; charset=us-ascii" />
+
+  <title>JSON Schema: A Media Type for Describing JSON Documents</title>
+
+  <style type="text/css" title="Xml2Rfc (sans serif)">
+  /*<![CDATA[*/
+	  a {
+	  text-decoration: none;
+	  }
+      /* info code from SantaKlauss at http://www.madaboutstyle.com/tooltip2.html */
+      a.info {
+          /* This is the key. */
+          position: relative;
+          z-index: 24;
+          text-decoration: none;
+      }
+      a.info:hover {
+          z-index: 25;
+          color: #FFF; background-color: #900;
+      }
+      a.info span { display: none; }
+      a.info:hover span.info {
+          /* The span will display just on :hover state. */
+          display: block;
+          position: absolute;
+          font-size: smaller;
+          top: 2em; left: -5em; width: 15em;
+          padding: 2px; border: 1px solid #333;
+          color: #900; background-color: #EEE;
+          text-align: left;
+      }
+	  a.smpl {
+	  color: black;
+	  }
+	  a:hover {
+	  text-decoration: underline;
+	  }
+	  a:active {
+	  text-decoration: underline;
+	  }
+	  address {
+	  margin-top: 1em;
+	  margin-left: 2em;
+	  font-style: normal;
+	  }
+	  body {
+	  color: black;
+	  font-family: verdana, helvetica, arial, sans-serif;
+	  font-size: 10pt;
+	  max-width: 55em;
+	  
+	  }
+	  cite {
+	  font-style: normal;
+	  }
+	  dd {
+	  margin-right: 2em;
+	  }
+	  dl {
+	  margin-left: 2em;
+	  }
+	
+	  ul.empty {
+	  list-style-type: none;
+	  }
+	  ul.empty li {
+	  margin-top: .5em;
+	  }
+	  dl p {
+	  margin-left: 0em;
+	  }
+	  dt {
+	  margin-top: .5em;
+	  }
+	  h1 {
+	  font-size: 14pt;
+	  line-height: 21pt;
+	  page-break-after: avoid;
+	  }
+	  h1.np {
+	  page-break-before: always;
+	  }
+	  h1 a {
+	  color: #333333;
+	  }
+	  h2 {
+	  font-size: 12pt;
+	  line-height: 15pt;
+	  page-break-after: avoid;
+	  }
+	  h3, h4, h5, h6 {
+	  font-size: 10pt;
+	  page-break-after: avoid;
+	  }
+	  h2 a, h3 a, h4 a, h5 a, h6 a {
+	  color: black;
+	  }
+	  img {
+	  margin-left: 3em;
+	  }
+	  li {
+	  margin-left: 2em;
+	  margin-right: 2em;
+	  }
+	  ol {
+	  margin-left: 2em;
+	  margin-right: 2em;
+	  }
+	  ol p {
+	  margin-left: 0em;
+	  }
+	  p {
+	  margin-left: 2em;
+	  margin-right: 2em;
+	  }
+	  pre {
+	  margin-left: 3em;
+	  background-color: lightyellow;
+	  padding: .25em;
+	  }
+	  pre.text2 {
+	  border-style: dotted;
+	  border-width: 1px;
+	  background-color: #f0f0f0;
+	  width: 69em;
+	  }
+	  pre.inline {
+	  background-color: white;
+	  padding: 0em;
+	  }
+	  pre.text {
+	  border-style: dotted;
+	  border-width: 1px;
+	  background-color: #f8f8f8;
+	  width: 69em;
+	  }
+	  pre.drawing {
+	  border-style: solid;
+	  border-width: 1px;
+	  background-color: #f8f8f8;
+	  padding: 2em;
+	  }
+	  table {
+	  margin-left: 2em;
+	  }
+	  table.tt {
+	  vertical-align: top;
+	  }
+	  table.full {
+	  border-style: outset;
+	  border-width: 1px;
+	  }
+	  table.headers {
+	  border-style: outset;
+	  border-width: 1px;
+	  }
+	  table.tt td {
+	  vertical-align: top;
+	  }
+	  table.full td {
+	  border-style: inset;
+	  border-width: 1px;
+	  }
+	  table.tt th {
+	  vertical-align: top;
+	  }
+	  table.full th {
+	  border-style: inset;
+	  border-width: 1px;
+	  }
+	  table.headers th {
+	  border-style: none none inset none;
+	  border-width: 1px;
+	  }
+	  table.left {
+	  margin-right: auto;
+	  }
+	  table.right {
+	  margin-left: auto;
+	  }
+	  table.center {
+	  margin-left: auto;
+	  margin-right: auto;
+	  }
+	  caption {
+	  caption-side: bottom;
+	  font-weight: bold;
+	  font-size: 9pt;
+	  margin-top: .5em;
+	  }
+	
+	  table.header {
+	  border-spacing: 1px;
+	  width: 95%;
+	  font-size: 10pt;
+	  color: white;
+	  }
+	  td.top {
+	  vertical-align: top;
+	  }
+	  td.topnowrap {
+	  vertical-align: top;
+	  white-space: nowrap; 
+	  }
+	  table.header td {
+	  background-color: gray;
+	  width: 50%;
+	  }
+	  table.header a {
+	  color: white;
+	  }
+	  td.reference {
+	  vertical-align: top;
+	  white-space: nowrap;
+	  padding-right: 1em;
+	  }
+	  thead {
+	  display:table-header-group;
+	  }
+	  ul.toc, ul.toc ul {
+	  list-style: none;
+	  margin-left: 1.5em;
+	  margin-right: 0em;
+	  padding-left: 0em;
+	  }
+	  ul.toc li {
+	  line-height: 150%;
+	  font-weight: bold;
+	  font-size: 10pt;
+	  margin-left: 0em;
+	  margin-right: 0em;
+	  }
+	  ul.toc li li {
+	  line-height: normal;
+	  font-weight: normal;
+	  font-size: 9pt;
+	  margin-left: 0em;
+	  margin-right: 0em;
+	  }
+	  li.excluded {
+	  font-size: 0pt;
+	  }
+	  ul p {
+	  margin-left: 0em;
+	  }
+	
+	  .comment {
+	  background-color: yellow;
+	  }
+	  .center {
+	  text-align: center;
+	  }
+	  .error {
+	  color: red;
+	  font-style: italic;
+	  font-weight: bold;
+	  }
+	  .figure {
+	  font-weight: bold;
+	  text-align: center;
+	  font-size: 9pt;
+	  }
+	  .filename {
+	  color: #333333;
+	  font-weight: bold;
+	  font-size: 12pt;
+	  line-height: 21pt;
+	  text-align: center;
+	  }
+	  .fn {
+	  font-weight: bold;
+	  }
+	  .hidden {
+	  display: none;
+	  }
+	  .left {
+	  text-align: left;
+	  }
+	  .right {
+	  text-align: right;
+	  }
+	  .title {
+	  color: #990000;
+	  font-size: 18pt;
+	  line-height: 18pt;
+	  font-weight: bold;
+	  text-align: center;
+	  margin-top: 36pt;
+	  }
+	  .vcardline {
+	  display: block;
+	  }
+	  .warning {
+	  font-size: 14pt;
+	  background-color: yellow;
+	  }
+	
+	
+	  @media print {
+	  .noprint {
+		display: none;
+	  }
+	
+	  a {
+		color: black;
+		text-decoration: none;
+	  }
+	
+	  table.header {
+		width: 90%;
+	  }
+	
+	  td.header {
+		width: 50%;
+		color: black;
+		background-color: white;
+		vertical-align: top;
+		font-size: 12pt;
+	  }
+	
+	  ul.toc a::after {
+		content: leader('.') target-counter(attr(href), page);
+	  }
+	
+	  ul.ind li li a {
+		content: target-counter(attr(href), page);
+	  }
+	
+	  .print2col {
+		column-count: 2;
+		-moz-column-count: 2;
+		column-fill: auto;
+	  }
+	  }
+	
+	  @page {
+	  @top-left {
+		   content: "Internet-Draft"; 
+	  } 
+	  @top-right {
+		   content: "December 2010"; 
+	  } 
+	  @top-center {
+		   content: "Abbreviated Title";
+	  } 
+	  @bottom-left {
+		   content: "Doe"; 
+	  } 
+	  @bottom-center {
+		   content: "Expires June 2011"; 
+	  } 
+	  @bottom-right {
+		   content: "[Page " counter(page) "]"; 
+	  } 
+	  }
+	
+	  @page:first { 
+		@top-left {
+		  content: normal;
+		}
+		@top-right {
+		  content: normal;
+		}
+		@top-center {
+		  content: normal;
+		}
+	  }
+  /*]]>*/
+  </style>
+
+  <link href="#rfc.toc" rel="Contents">
+<link href="#rfc.section.1" rel="Chapter" title="1 Introduction">
+<link href="#rfc.section.2" rel="Chapter" title="2 Conventions and Terminology">
+<link href="#rfc.section.3" rel="Chapter" title="3 Overview">
+<link href="#rfc.section.3.1" rel="Chapter" title="3.1 Keyword Behaviors">
+<link href="#rfc.section.3.1.1" rel="Chapter" title="3.1.1 Keyword Interactions">
+<link href="#rfc.section.3.1.2" rel="Chapter" title="3.1.2 Default Behaviors">
+<link href="#rfc.section.3.1.3" rel="Chapter" title="3.1.3 Applicators">
+<link href="#rfc.section.3.1.4" rel="Chapter" title="3.1.4 Assertions">
+<link href="#rfc.section.3.1.5" rel="Chapter" title="3.1.5 Annotations">
+<link href="#rfc.section.3.2" rel="Chapter" title="3.2 Schema Vocabularies">
+<link href="#rfc.section.3.2.1" rel="Chapter" title="3.2.1 Subschema Application">
+<link href="#rfc.section.3.2.2" rel="Chapter" title="3.2.2 Validation">
+<link href="#rfc.section.3.2.3" rel="Chapter" title="3.2.3 Basic Meta-Data">
+<link href="#rfc.section.3.2.4" rel="Chapter" title="3.2.4 Hypermedia and Linking">
+<link href="#rfc.section.4" rel="Chapter" title="4 Definitions">
+<link href="#rfc.section.4.1" rel="Chapter" title="4.1 JSON Document">
+<link href="#rfc.section.4.2" rel="Chapter" title="4.2 Instance">
+<link href="#rfc.section.4.2.1" rel="Chapter" title="4.2.1 Instance Data Model">
+<link href="#rfc.section.4.2.2" rel="Chapter" title="4.2.2 Instance Media Types">
+<link href="#rfc.section.4.2.3" rel="Chapter" title="4.2.3 Instance Equality">
+<link href="#rfc.section.4.3" rel="Chapter" title="4.3 JSON Schema Documents">
+<link href="#rfc.section.4.3.1" rel="Chapter" title="4.3.1 JSON Schema Objects and Keywords">
+<link href="#rfc.section.4.3.2" rel="Chapter" title="4.3.2 Boolean JSON Schemas">
+<link href="#rfc.section.4.3.3" rel="Chapter" title="4.3.3 Root Schema and Subschemas">
+<link href="#rfc.section.4.3.4" rel="Chapter" title="4.3.4 Lexical Scope and Dynamic Scope">
+<link href="#rfc.section.4.3.5" rel="Chapter" title="4.3.5 Referenced and Referencing Schemas">
+<link href="#rfc.section.5" rel="Chapter" title="5 Fragment Identifiers">
+<link href="#rfc.section.6" rel="Chapter" title="6 General Considerations">
+<link href="#rfc.section.6.1" rel="Chapter" title="6.1 Range of JSON Values">
+<link href="#rfc.section.6.2" rel="Chapter" title="6.2 Programming Language Independence">
+<link href="#rfc.section.6.3" rel="Chapter" title="6.3 Mathematical Integers">
+<link href="#rfc.section.6.4" rel="Chapter" title="6.4 Regular Expressions">
+<link href="#rfc.section.6.5" rel="Chapter" title="6.5 Extending JSON Schema">
+<link href="#rfc.section.7" rel="Chapter" title="7 Meta-Schemas and Vocabularies">
+<link href="#rfc.section.7.1" rel="Chapter" title='7.1 The "$schema" Keyword'>
+<link href="#rfc.section.7.2" rel="Chapter" title='7.2 The "$vocabulary" Keyword'>
+<link href="#rfc.section.7.3" rel="Chapter" title="7.3 Detecting a Meta-Schema">
+<link href="#rfc.section.7.4" rel="Chapter" title="7.4 Best Practices for Vocabulary and Meta-Schema Authors">
+<link href="#rfc.section.7.5" rel="Chapter" title="7.5 The JSON Schema Core Vocabulary">
+<link href="#rfc.section.7.6" rel="Chapter" title="7.6 Example Meta-Schema With Vocabulary Declarations">
+<link href="#rfc.section.8" rel="Chapter" title="8 Base URI and Dereferencing">
+<link href="#rfc.section.8.1" rel="Chapter" title="8.1 Initial Base URI">
+<link href="#rfc.section.8.2" rel="Chapter" title='8.2 The "$id" Keyword'>
+<link href="#rfc.section.8.2.1" rel="Chapter" title="8.2.1 Identifying the root schema">
+<link href="#rfc.section.8.2.2" rel="Chapter" title="8.2.2 Changing the base URI within a schema file">
+<link href="#rfc.section.8.2.3" rel="Chapter" title="8.2.3 Location-independent identifiers">
+<link href="#rfc.section.8.2.4" rel="Chapter" title="8.2.4 Schema identification examples">
+<link href="#rfc.section.8.3" rel="Chapter" title="8.3 Schema References">
+<link href="#rfc.section.8.3.1" rel="Chapter" title='8.3.1 Direct References with "$ref"'>
+<link href="#rfc.section.8.3.2" rel="Chapter" title='8.3.2 Recursive References with "$recursiveRef" and "$recursiveAnchor"'>
+<link href="#rfc.section.8.3.3" rel="Chapter" title="8.3.3 Guarding Against Infinite Recursion">
+<link href="#rfc.section.8.3.4" rel="Chapter" title="8.3.4 References to Possible Non-Schemas">
+<link href="#rfc.section.8.3.5" rel="Chapter" title="8.3.5 Loading a referenced schema">
+<link href="#rfc.section.8.3.6" rel="Chapter" title="8.3.6 Dereferencing">
+<link href="#rfc.section.8.4" rel="Chapter" title='8.4 Schema Re-Use With "$defs"'>
+<link href="#rfc.section.9" rel="Chapter" title='9 Comments With "$comment"'>
+<link href="#rfc.section.10" rel="Chapter" title="10 Collecting Annotations">
+<link href="#rfc.section.10.1" rel="Chapter" title="10.1 Distinguishing Among Multiple Values">
+<link href="#rfc.section.10.2" rel="Chapter" title="10.2 Annotations and Assertions">
+<link href="#rfc.section.10.3" rel="Chapter" title="10.3 Annotations and Applicators">
+<link href="#rfc.section.11" rel="Chapter" title="11 A Vocabulary for Applying Subschemas">
+<link href="#rfc.section.11.1" rel="Chapter" title="11.1 Keyword Independence">
+<link href="#rfc.section.11.2" rel="Chapter" title="11.2 Keywords for Applying Subschemas in Place">
+<link href="#rfc.section.11.2.1" rel="Chapter" title="11.2.1 Keywords for Applying Subschemas With Boolean Logic">
+<link href="#rfc.section.11.2.2" rel="Chapter" title="11.2.2 Keywords for Applying Subschemas Conditionally">
+<link href="#rfc.section.11.3" rel="Chapter" title="11.3 Keywords for Applying Subschemas to Child Instances">
+<link href="#rfc.section.11.3.1" rel="Chapter" title="11.3.1 Keywords for Applying Subschemas to Arrays">
+<link href="#rfc.section.11.3.2" rel="Chapter" title="11.3.2 Keywords for Applying Subschemas to Objects">
+<link href="#rfc.section.12" rel="Chapter" title="12 Output Formatting">
+<link href="#rfc.section.12.1" rel="Chapter" title="12.1 Format">
+<link href="#rfc.section.12.2" rel="Chapter" title="12.2 Output Formats">
+<link href="#rfc.section.12.3" rel="Chapter" title="12.3 Minimum Information">
+<link href="#rfc.section.12.3.1" rel="Chapter" title="12.3.1 Keyword Relative Location">
+<link href="#rfc.section.12.3.2" rel="Chapter" title="12.3.2 Keyword Absolute Location">
+<link href="#rfc.section.12.3.3" rel="Chapter" title="12.3.3 Instance Location">
+<link href="#rfc.section.12.3.4" rel="Chapter" title="12.3.4 Error or Annotation">
+<link href="#rfc.section.12.3.5" rel="Chapter" title="12.3.5 Nested Results">
+<link href="#rfc.section.12.4" rel="Chapter" title="12.4 Output Structure">
+<link href="#rfc.section.12.4.1" rel="Chapter" title="12.4.1 Flag">
+<link href="#rfc.section.12.4.2" rel="Chapter" title="12.4.2 Basic">
+<link href="#rfc.section.12.4.3" rel="Chapter" title="12.4.3 Detailed">
+<link href="#rfc.section.12.4.4" rel="Chapter" title="12.4.4 Verbose">
+<link href="#rfc.section.12.4.5" rel="Chapter" title="12.4.5 Output validation schemas">
+<link href="#rfc.section.13" rel="Chapter" title="13 Usage for Hypermedia">
+<link href="#rfc.section.13.1" rel="Chapter" title="13.1 Linking to a Schema">
+<link href="#rfc.section.13.2" rel="Chapter" title="13.2 Identifying a Schema via a Media Type Parameter">
+<link href="#rfc.section.13.3" rel="Chapter" title="13.3 Usage Over HTTP">
+<link href="#rfc.section.14" rel="Chapter" title="14 Security Considerations">
+<link href="#rfc.section.15" rel="Chapter" title="15 IANA Considerations">
+<link href="#rfc.section.15.1" rel="Chapter" title="15.1 application/schema+json">
+<link href="#rfc.section.15.2" rel="Chapter" title="15.2 application/schema-instance+json">
+<link href="#rfc.references" rel="Chapter" title="16 References">
+<link href="#rfc.references.1" rel="Chapter" title="16.1 Normative References">
+<link href="#rfc.references.2" rel="Chapter" title="16.2 Informative References">
+<link href="#rfc.appendix.A" rel="Chapter" title="A Acknowledgments">
+<link href="#rfc.appendix.B" rel="Chapter" title="B ChangeLog">
+<link href="#rfc.authors" rel="Chapter">
+
+
+  <meta name="generator" content="xml2rfc version 2.20.1 - https://tools.ietf.org/tools/xml2rfc" />
+  <link rel="schema.dct" href="http://purl.org/dc/terms/" />
+
+  <meta name="dct.creator" content="Wright, A., Ed., Andrews, H., Ed., Hutton, B., Ed., and G. Dennis" />
+  <meta name="dct.identifier" content="urn:ietf:id:draft-handrews-json-schema-02" />
+  <meta name="dct.issued" scheme="ISO8601" content="2019-25" />
+  <meta name="dct.abstract" content="JSON Schema defines the media type &quot;application/schema+json&quot;, a JSON-based format for describing the structure of JSON data.  JSON Schema asserts what a JSON document must look like, ways to extract information from it, and how to interact with it.  The &quot;application/schema-instance+json&quot; media type provides additional feature-rich integration with &quot;application/schema+json&quot; beyond what can be offered for &quot;application/json&quot; documents.  " />
+  <meta name="description" content="JSON Schema defines the media type &quot;application/schema+json&quot;, a JSON-based format for describing the structure of JSON data.  JSON Schema asserts what a JSON document must look like, ways to extract information from it, and how to interact with it.  The &quot;application/schema-instance+json&quot; media type provides additional feature-rich integration with &quot;application/schema+json&quot; beyond what can be offered for &quot;application/json&quot; documents.  " />
+
+</head>
+
+<body>
+
+  <table class="header">
+    <tbody>
+    
+    	<tr>
+<td class="left">Internet Engineering Task Force</td>
+<td class="right">A. Wright, Ed.</td>
+</tr>
+<tr>
+<td class="left">Internet-Draft</td>
+<td class="right"></td>
+</tr>
+<tr>
+<td class="left">Intended status: Informational</td>
+<td class="right">H. Andrews, Ed.</td>
+</tr>
+<tr>
+<td class="left">Expires: November 26, 2019</td>
+<td class="right">Riverbed Technology</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="right">B. Hutton, Ed.</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="right">Wellcome Sanger Institute</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="right">G. Dennis</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="right">May 25, 2019</td>
+</tr>
+
+    	
+    </tbody>
+  </table>
+
+  <p class="title">JSON Schema: A Media Type for Describing JSON Documents<br />
+  <span class="filename">draft-handrews-json-schema-02</span></p>
+  
+  <h1 id="rfc.abstract"><a href="#rfc.abstract">Abstract</a></h1>
+<p>JSON Schema defines the media type "application/schema+json", a JSON-based format for describing the structure of JSON data.  JSON Schema asserts what a JSON document must look like, ways to extract information from it, and how to interact with it.  The "application/schema-instance+json" media type provides additional feature-rich integration with "application/schema+json" beyond what can be offered for "application/json" documents.  </p>
+<h1><a>Note to Readers</a></h1>
+<p>The issues list for this draft can be found at <span>&lt;</span><a href="https://github.com/json-schema-org/json-schema-spec/issues">https://github.com/json-schema-org/json-schema-spec/issues</a><span>&gt;</span>.  </p>
+<p>For additional information, see <span>&lt;</span><a href="http://json-schema.org/">http://json-schema.org/</a><span>&gt;</span>.  </p>
+<p>To provide feedback, use this issue tracker, the communication methods listed on the homepage, or email the document editors.  </p>
+<h1 id="rfc.status"><a href="#rfc.status">Status of This Memo</a></h1>
+<p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.</p>
+<p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at https://datatracker.ietf.org/drafts/current/.</p>
+<p>Internet-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use Internet-Drafts as reference material or to cite them other than as "work in progress."</p>
+<p>This Internet-Draft will expire on November 26, 2019.</p>
+<h1 id="rfc.copyrightnotice"><a href="#rfc.copyrightnotice">Copyright Notice</a></h1>
+<p>Copyright (c) 2019 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
+<p>This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating to IETF Documents (https://trustee.ietf.org/license-info) in effect on the date of publication of this document.  Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.</p>
+
+  
+  <hr class="noprint" />
+  <h1 class="np" id="rfc.toc"><a href="#rfc.toc">Table of Contents</a></h1>
+  <ul class="toc">
+
+  	<li>1.   <a href="#rfc.section.1">Introduction</a>
+</li>
+<li>2.   <a href="#rfc.section.2">Conventions and Terminology</a>
+</li>
+<li>3.   <a href="#rfc.section.3">Overview</a>
+</li>
+<ul><li>3.1.   <a href="#rfc.section.3.1">Keyword Behaviors</a>
+</li>
+<ul><li>3.1.1.   <a href="#rfc.section.3.1.1">Keyword Interactions</a>
+</li>
+<li>3.1.2.   <a href="#rfc.section.3.1.2">Default Behaviors</a>
+</li>
+<li>3.1.3.   <a href="#rfc.section.3.1.3">Applicators</a>
+</li>
+<li>3.1.4.   <a href="#rfc.section.3.1.4">Assertions</a>
+</li>
+<li>3.1.5.   <a href="#rfc.section.3.1.5">Annotations</a>
+</li>
+</ul><li>3.2.   <a href="#rfc.section.3.2">Schema Vocabularies</a>
+</li>
+<ul><li>3.2.1.   <a href="#rfc.section.3.2.1">Subschema Application</a>
+</li>
+<li>3.2.2.   <a href="#rfc.section.3.2.2">Validation</a>
+</li>
+<li>3.2.3.   <a href="#rfc.section.3.2.3">Basic Meta-Data</a>
+</li>
+<li>3.2.4.   <a href="#rfc.section.3.2.4">Hypermedia and Linking</a>
+</li>
+</ul></ul><li>4.   <a href="#rfc.section.4">Definitions</a>
+</li>
+<ul><li>4.1.   <a href="#rfc.section.4.1">JSON Document</a>
+</li>
+<li>4.2.   <a href="#rfc.section.4.2">Instance</a>
+</li>
+<ul><li>4.2.1.   <a href="#rfc.section.4.2.1">Instance Data Model</a>
+</li>
+<li>4.2.2.   <a href="#rfc.section.4.2.2">Instance Media Types</a>
+</li>
+<li>4.2.3.   <a href="#rfc.section.4.2.3">Instance Equality</a>
+</li>
+</ul><li>4.3.   <a href="#rfc.section.4.3">JSON Schema Documents</a>
+</li>
+<ul><li>4.3.1.   <a href="#rfc.section.4.3.1">JSON Schema Objects and Keywords</a>
+</li>
+<li>4.3.2.   <a href="#rfc.section.4.3.2">Boolean JSON Schemas</a>
+</li>
+<li>4.3.3.   <a href="#rfc.section.4.3.3">Root Schema and Subschemas</a>
+</li>
+<li>4.3.4.   <a href="#rfc.section.4.3.4">Lexical Scope and Dynamic Scope</a>
+</li>
+<li>4.3.5.   <a href="#rfc.section.4.3.5">Referenced and Referencing Schemas</a>
+</li>
+</ul></ul><li>5.   <a href="#rfc.section.5">Fragment Identifiers</a>
+</li>
+<li>6.   <a href="#rfc.section.6">General Considerations</a>
+</li>
+<ul><li>6.1.   <a href="#rfc.section.6.1">Range of JSON Values</a>
+</li>
+<li>6.2.   <a href="#rfc.section.6.2">Programming Language Independence</a>
+</li>
+<li>6.3.   <a href="#rfc.section.6.3">Mathematical Integers</a>
+</li>
+<li>6.4.   <a href="#rfc.section.6.4">Regular Expressions</a>
+</li>
+<li>6.5.   <a href="#rfc.section.6.5">Extending JSON Schema</a>
+</li>
+</ul><li>7.   <a href="#rfc.section.7">Meta-Schemas and Vocabularies</a>
+</li>
+<ul><li>7.1.   <a href="#rfc.section.7.1">The "$schema" Keyword</a>
+</li>
+<li>7.2.   <a href="#rfc.section.7.2">The "$vocabulary" Keyword</a>
+</li>
+<li>7.3.   <a href="#rfc.section.7.3">Detecting a Meta-Schema</a>
+</li>
+<li>7.4.   <a href="#rfc.section.7.4">Best Practices for Vocabulary and Meta-Schema Authors</a>
+</li>
+<li>7.5.   <a href="#rfc.section.7.5">The JSON Schema Core Vocabulary</a>
+</li>
+<li>7.6.   <a href="#rfc.section.7.6">Example Meta-Schema With Vocabulary Declarations</a>
+</li>
+</ul><li>8.   <a href="#rfc.section.8">Base URI and Dereferencing</a>
+</li>
+<ul><li>8.1.   <a href="#rfc.section.8.1">Initial Base URI</a>
+</li>
+<li>8.2.   <a href="#rfc.section.8.2">The "$id" Keyword</a>
+</li>
+<ul><li>8.2.1.   <a href="#rfc.section.8.2.1">Identifying the root schema</a>
+</li>
+<li>8.2.2.   <a href="#rfc.section.8.2.2">Changing the base URI within a schema file</a>
+</li>
+<li>8.2.3.   <a href="#rfc.section.8.2.3">Location-independent identifiers</a>
+</li>
+<li>8.2.4.   <a href="#rfc.section.8.2.4">Schema identification examples</a>
+</li>
+</ul><li>8.3.   <a href="#rfc.section.8.3">Schema References</a>
+</li>
+<ul><li>8.3.1.   <a href="#rfc.section.8.3.1">Direct References with "$ref"</a>
+</li>
+<li>8.3.2.   <a href="#rfc.section.8.3.2">Recursive References with "$recursiveRef" and "$recursiveAnchor"</a>
+</li>
+<li>8.3.3.   <a href="#rfc.section.8.3.3">Guarding Against Infinite Recursion</a>
+</li>
+<li>8.3.4.   <a href="#rfc.section.8.3.4">References to Possible Non-Schemas</a>
+</li>
+<li>8.3.5.   <a href="#rfc.section.8.3.5">Loading a referenced schema</a>
+</li>
+<li>8.3.6.   <a href="#rfc.section.8.3.6">Dereferencing</a>
+</li>
+</ul><li>8.4.   <a href="#rfc.section.8.4">Schema Re-Use With "$defs"</a>
+</li>
+</ul><li>9.   <a href="#rfc.section.9">Comments With "$comment"</a>
+</li>
+<li>10.   <a href="#rfc.section.10">Collecting Annotations</a>
+</li>
+<ul><li>10.1.   <a href="#rfc.section.10.1">Distinguishing Among Multiple Values</a>
+</li>
+<li>10.2.   <a href="#rfc.section.10.2">Annotations and Assertions</a>
+</li>
+<li>10.3.   <a href="#rfc.section.10.3">Annotations and Applicators</a>
+</li>
+</ul><li>11.   <a href="#rfc.section.11">A Vocabulary for Applying Subschemas</a>
+</li>
+<ul><li>11.1.   <a href="#rfc.section.11.1">Keyword Independence</a>
+</li>
+<li>11.2.   <a href="#rfc.section.11.2">Keywords for Applying Subschemas in Place</a>
+</li>
+<ul><li>11.2.1.   <a href="#rfc.section.11.2.1">Keywords for Applying Subschemas With Boolean Logic</a>
+</li>
+<li>11.2.2.   <a href="#rfc.section.11.2.2">Keywords for Applying Subschemas Conditionally</a>
+</li>
+</ul><li>11.3.   <a href="#rfc.section.11.3">Keywords for Applying Subschemas to Child Instances</a>
+</li>
+<ul><li>11.3.1.   <a href="#rfc.section.11.3.1">Keywords for Applying Subschemas to Arrays</a>
+</li>
+<li>11.3.2.   <a href="#rfc.section.11.3.2">Keywords for Applying Subschemas to Objects</a>
+</li>
+</ul></ul><li>12.   <a href="#rfc.section.12">Output Formatting</a>
+</li>
+<ul><li>12.1.   <a href="#rfc.section.12.1">Format</a>
+</li>
+<li>12.2.   <a href="#rfc.section.12.2">Output Formats</a>
+</li>
+<li>12.3.   <a href="#rfc.section.12.3">Minimum Information</a>
+</li>
+<ul><li>12.3.1.   <a href="#rfc.section.12.3.1">Keyword Relative Location</a>
+</li>
+<li>12.3.2.   <a href="#rfc.section.12.3.2">Keyword Absolute Location</a>
+</li>
+<li>12.3.3.   <a href="#rfc.section.12.3.3">Instance Location</a>
+</li>
+<li>12.3.4.   <a href="#rfc.section.12.3.4">Error or Annotation</a>
+</li>
+<li>12.3.5.   <a href="#rfc.section.12.3.5">Nested Results</a>
+</li>
+</ul><li>12.4.   <a href="#rfc.section.12.4">Output Structure</a>
+</li>
+<ul><li>12.4.1.   <a href="#rfc.section.12.4.1">Flag</a>
+</li>
+<li>12.4.2.   <a href="#rfc.section.12.4.2">Basic</a>
+</li>
+<li>12.4.3.   <a href="#rfc.section.12.4.3">Detailed</a>
+</li>
+<li>12.4.4.   <a href="#rfc.section.12.4.4">Verbose</a>
+</li>
+<li>12.4.5.   <a href="#rfc.section.12.4.5">Output validation schemas</a>
+</li>
+</ul></ul><li>13.   <a href="#rfc.section.13">Usage for Hypermedia</a>
+</li>
+<ul><li>13.1.   <a href="#rfc.section.13.1">Linking to a Schema</a>
+</li>
+<li>13.2.   <a href="#rfc.section.13.2">Identifying a Schema via a Media Type Parameter</a>
+</li>
+<li>13.3.   <a href="#rfc.section.13.3">Usage Over HTTP</a>
+</li>
+</ul><li>14.   <a href="#rfc.section.14">Security Considerations</a>
+</li>
+<li>15.   <a href="#rfc.section.15">IANA Considerations</a>
+</li>
+<ul><li>15.1.   <a href="#rfc.section.15.1">application/schema+json</a>
+</li>
+<li>15.2.   <a href="#rfc.section.15.2">application/schema-instance+json</a>
+</li>
+</ul><li>16.   <a href="#rfc.references">References</a>
+</li>
+<ul><li>16.1.   <a href="#rfc.references.1">Normative References</a>
+</li>
+<li>16.2.   <a href="#rfc.references.2">Informative References</a>
+</li>
+</ul><li>Appendix A.   <a href="#rfc.appendix.A">Acknowledgments</a>
+</li>
+<li>Appendix B.   <a href="#rfc.appendix.B">ChangeLog</a>
+</li>
+<li><a href="#rfc.authors">Authors' Addresses</a>
+</li>
+
+
+  </ul>
+
+  <h1 id="rfc.section.1">
+<a href="#rfc.section.1">1.</a> Introduction</h1>
+<p id="rfc.section.1.p.1">JSON Schema is a JSON media type for defining the structure of JSON data. JSON Schema is intended to define validation, documentation, hyperlink navigation, and interaction control of JSON data.  </p>
+<p id="rfc.section.1.p.2">This specification defines JSON Schema core terminology and mechanisms, including pointing to another JSON Schema by reference, dereferencing a JSON Schema reference, specifying the vocabulary being used, and defining the expected output.  </p>
+<p id="rfc.section.1.p.3">Other specifications define the vocabularies that perform assertions about validation, linking, annotation, navigation, and interaction.  </p>
+<h1 id="rfc.section.2">
+<a href="#rfc.section.2">2.</a> Conventions and Terminology</h1>
+<p id="rfc.section.2.p.1">The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in <a href="#RFC2119" class="xref">RFC 2119</a>.  </p>
+<p id="rfc.section.2.p.2">The terms "JSON", "JSON text", "JSON value", "member", "element", "object", "array", "number", "string", "boolean", "true", "false", and "null" in this document are to be interpreted as defined in <a href="#RFC8259" class="xref">RFC 8259</a>.  </p>
+<h1 id="rfc.section.3">
+<a href="#rfc.section.3">3.</a> Overview</h1>
+<p id="rfc.section.3.p.1">This document proposes a new media type "application/schema+json" to identify a JSON Schema for describing JSON data.  It also proposes a further optional media type, "application/schema-instance+json", to provide additional integration features.  JSON Schemas are themselves JSON documents.  This, and related specifications, define keywords allowing authors to describe JSON data in several ways.  </p>
+<h1 id="rfc.section.3.1">
+<a href="#rfc.section.3.1">3.1.</a> Keyword Behaviors</h1>
+<p id="rfc.section.3.1.p.1">JSON Schema keywords fall into several general behavior categories.  Assertions validate that an instance satisfies constraints, producing a boolean result.  Annotations attach information that applications may use in any way they see fit.  Applicators apply subschemas to parts of the instance and combine their results.  </p>
+<p id="rfc.section.3.1.p.2">Extension keywords SHOULD stay within these categories, keeping in mind that annotations in particular are extremely flexible.  Complex behavior is usually better delegated to applications on the basis of annotation data than implemented directly as schema keywords.  However, extension keywords MAY define other behaviors for specialized purposes.  </p>
+<p id="rfc.section.3.1.p.3">Evaluating an instance against a schema involves processing all of the keywords in the schema against the appropriate locations within the instance.  Typically, applicator keywords are processed until a schema object with no applicators (and therefore no subschemas) is reached.  The appropriate location in the instance is evaluated against the assertion and annotation keywords in the schema object, and their results are gathered into the parent schema according to the rules of the applicator.  </p>
+<p id="rfc.section.3.1.p.4">Evaluation of a parent schema object can complete once all of its subschemas have been evaluated, although in some circumstances evaluation may be short-circuited due to assertion results.  </p>
+<h1 id="rfc.section.3.1.1">
+<a href="#rfc.section.3.1.1">3.1.1.</a> Keyword Interactions</h1>
+<p id="rfc.section.3.1.1.p.1">Keyword behavior MAY be defined in terms of the annotation results of <a href="#root" class="xref">subschemas</a> and/or adjacent keywords.  Such keywords MUST NOT result in a circular dependency.  Keywords MAY modify their behavior based on the presence or absence of another keyword in the same <a href="#schema-document" class="xref">schema object</a>.  </p>
+<h1 id="rfc.section.3.1.2">
+<a href="#rfc.section.3.1.2">3.1.2.</a> Default Behaviors</h1>
+<p id="rfc.section.3.1.2.p.1">A missing keyword MUST NOT produce a false assertion result, MUST NOT produce annotation results, and MUST NOT cause any other schema to be evaluated as part of its own behavioral definition.  However, given that missing keywords do not contribute annotations, the lack of annotation results may indirectly change the behavior of other keywords.  </p>
+<p id="rfc.section.3.1.2.p.2">In some cases, the missing keyword assertion behavior of a keyword is identical to that produced by a certain value, and keyword definitions SHOULD note such values where known.  However, even if the value which produces the default behavior would produce annotation results if present, the default behavior still MUST NOT result in annotations.  </p>
+<p id="rfc.section.3.1.2.p.3">Because annotation collection can add significant cost in terms of both computation and memory, implementations MAY opt out of this feature.  Keywords known to an implementation to have assertion or applicator behavior that depend on annotation results MUST then be treated as errors, unless an alternate implementation producing the same behavior is available.  Keywords of this sort SHOULD describe reasonable alternate approaches when appropriate.  This approach is demonstrated by the "<a href="#additionalItems" class="xref">additionalItems</a>" and "<a href="#additionalProperties" class="xref">additionalProperties</a>" keywords in this document.  </p>
+<h1 id="rfc.section.3.1.3">
+<a href="#rfc.section.3.1.3">3.1.3.</a> <a href="#applicators" id="applicators">Applicators</a>
+</h1>
+<p id="rfc.section.3.1.3.p.1">Applicators allow for building more complex schemas than can be accomplished with a single schema object.  Evaluation of an instance against a <a href="#schema-document" class="xref">schema document</a> begins by applying the <a href="#root" class="xref">root schema</a> to the complete instance document.  From there, keywords known as applicators are used to determine which additional schemas are applied.  Such schemas may be applied in-place to the current location, or to a child location.  </p>
+<p id="rfc.section.3.1.3.p.2">The schemas to be applied may be present as subschemas comprising all or part of the keyword's value.  Alternatively, an applicator may refer to a schema elsewhere in the same schema document, or in a different one.  The mechanism for identifying such referenced schemas is defined by the keyword.  </p>
+<p id="rfc.section.3.1.3.p.3">Applicator keywords also define how subschema or referenced schema boolean <a href="#assertions" class="xref">assertion</a> results are modified and/or combined to produce the boolean result of the applicator.  Applicators may apply any boolean logic operation to the assertion results of subschemas, but MUST NOT introduce new assertion conditions of their own.  </p>
+<p><a href="#annotations" class="xref">Annotation</a> results are combined according to the rules specified by each annotation keyword.  </p>
+<h1 id="rfc.section.3.1.4">
+<a href="#rfc.section.3.1.4">3.1.4.</a> <a href="#assertions" id="assertions">Assertions</a>
+</h1>
+<p id="rfc.section.3.1.4.p.1">JSON Schema can be used to assert constraints on a JSON document, which either passes or fails the assertions.  This approach can be used to validate conformance with the constraints, or document what is needed to satisfy them.  </p>
+<p id="rfc.section.3.1.4.p.2">JSON Schema implementations produce a single boolean result when evaluating an instance against schema assertions.  </p>
+<p id="rfc.section.3.1.4.p.3">An instance can only fail an assertion that is present in the schema.  </p>
+<h1 id="rfc.section.3.1.4.1">
+<a href="#rfc.section.3.1.4.1">3.1.4.1.</a> Assertions and Instance Primitive Types</h1>
+<p id="rfc.section.3.1.4.1.p.1">Most assertions only constrain values within a certain primitive type.  When the type of the instance is not of the type targeted by the keyword, the instance is considered to conform to the assertion.  </p>
+<p id="rfc.section.3.1.4.1.p.2">For example, the "maxLength" keyword from the companion validation vocabulary will only restrict certain strings (that are too long) from being valid.  If the instance is a number, boolean, null, array, or object, then it is valid against this assertion.  </p>
+<h1 id="rfc.section.3.1.5">
+<a href="#rfc.section.3.1.5">3.1.5.</a> <a href="#annotations" id="annotations">Annotations</a>
+</h1>
+<p id="rfc.section.3.1.5.p.1">JSON Schema can annotate an instance with information, whenever the instance validates against the schema object containing the annotation, and all of its parent schema objects.  The information can be a simple value, or can be calculated based on the instance contents.  </p>
+<p id="rfc.section.3.1.5.p.2">Annotations are attached to specific locations in an instance.  Since many subschemas can be applied to any single location, annotation keywords need to specify any unusual handling of multiple applicable occurrences of the keyword with different values.  </p>
+<p id="rfc.section.3.1.5.p.3">The default behavior is simply to collect all values in a list in indeterminate order.  Given the extensibility of keywords, including applicators, it is not possible to define a universally predictable order of processing.  </p>
+<p id="rfc.section.3.1.5.p.4">Unlike assertion results, annotation data can take a wide variety of forms, which are provided to applications to use as they see fit.  JSON Schema implementations are not expected to make use of the collected information on behalf of applications.  </p>
+<p id="rfc.section.3.1.5.p.5">While "short-circuit" evaluation is possible for assertions, collecting annotations requires examining all schemas that apply to an instance location, even if they cannot change the overall assertion result.  </p>
+<h1 id="rfc.section.3.2">
+<a href="#rfc.section.3.2">3.2.</a> <a href="#vocabulary" id="vocabulary">Schema Vocabularies</a>
+</h1>
+<p id="rfc.section.3.2.p.1">A JSON Schema vocabulary is a set of keywords defined for a particular purpose.  The vocabulary specifies the meaning of its keywords as assertions, annotations, and/or any vocabulary-defined keyword category.  </p>
+<p id="rfc.section.3.2.p.2">Several vocabularies are provided as standards in this and closely related documents.  These vocabularies are used with the core keywords defined as fundamental to the "application/schema+json" media type.  </p>
+<p id="rfc.section.3.2.p.3">Schema authors are encouraged to define their own vocabularies for domain-specific concepts.  A vocabulary need not be a standard to be re-usable, although users of extension vocabularies MUST NOT assume that any JSON Schema implementation can support the vocabulary unless it specifically documents such support.  </p>
+<h1 id="rfc.section.3.2.1">
+<a href="#rfc.section.3.2.1">3.2.1.</a> Subschema Application</h1>
+<p id="rfc.section.3.2.1.p.1">This vocabulary provides keywords for applying subschemas to the instance in various ways.  It is defined in this document, and it is RECOMMENDED that all JSON Schema implementations support it.  All other vocabularies in this section are designed to be used alongside the subschema application vocabulary.  </p>
+<p id="rfc.section.3.2.1.p.2">Without this vocabulary or an equivalent one, JSON Schema can only be applied to a JSON document as a whole.  In most cases, schema keywords need to be applied to specific object properties or array items.  </p>
+<h1 id="rfc.section.3.2.2">
+<a href="#rfc.section.3.2.2">3.2.2.</a> Validation</h1>
+<p id="rfc.section.3.2.2.p.1">This vocabulary describes the structure of a JSON document (for instance, required properties and length limitations).  Applications can use this information to validate instances (check that constraints are met), or inform interfaces to collect user input such that the constraints are satisfied.  </p>
+<p id="rfc.section.3.2.2.p.2">Validation behaviour and keywords are specified in <a href="#json-schema-validation" class="xref">a separate document</a>.  </p>
+<h1 id="rfc.section.3.2.3">
+<a href="#rfc.section.3.2.3">3.2.3.</a> Basic Meta-Data</h1>
+<p id="rfc.section.3.2.3.p.1">A small set of annotation keywords are defined in <a href="#json-schema-validation" class="xref">the validation specification</a> to allow associating common kinds of meta-data with an instance.  </p>
+<h1 id="rfc.section.3.2.4">
+<a href="#rfc.section.3.2.4">3.2.4.</a> Hypermedia and Linking</h1>
+<p id="rfc.section.3.2.4.p.1">JSON Hyper-Schema produces hyperlinks as annotations available for use with a JSON document.  It supports resolving URI Templates and describing the resource and data submission formats required to use an API.  </p>
+<p id="rfc.section.3.2.4.p.2">Hyper-schema behaviour and keywords are specified in <a href="#json-hyper-schema" class="xref">a separate document</a>.  </p>
+<h1 id="rfc.section.4">
+<a href="#rfc.section.4">4.</a> Definitions</h1>
+<h1 id="rfc.section.4.1">
+<a href="#rfc.section.4.1">4.1.</a> JSON Document</h1>
+<p id="rfc.section.4.1.p.1">A JSON document is an information resource (series of octets) described by the application/json media type.  </p>
+<p id="rfc.section.4.1.p.2">In JSON Schema, the terms "JSON document", "JSON text", and "JSON value" are interchangeable because of the data model it defines.  </p>
+<p id="rfc.section.4.1.p.3">JSON Schema is only defined over JSON documents. However, any document or memory structure that can be parsed into or processed according to the JSON Schema data model can be interpreted against a JSON Schema, including media types like <a href="#RFC7049" class="xref">CBOR</a>.  </p>
+<h1 id="rfc.section.4.2">
+<a href="#rfc.section.4.2">4.2.</a> Instance</h1>
+<p id="rfc.section.4.2.p.1">A JSON document to which a schema is applied is known as an "instance".  </p>
+<h1 id="rfc.section.4.2.1">
+<a href="#rfc.section.4.2.1">4.2.1.</a> Instance Data Model</h1>
+<p id="rfc.section.4.2.1.p.1">JSON Schema interprets documents according to a data model. A JSON value interpreted according to this data model is called an "instance".  </p>
+<p id="rfc.section.4.2.1.p.2">An instance has one of six primitive types, and a range of possible values depending on the type: </p>
+
+<dl>
+<dt>null:</dt>
+<dd style="margin-left: 8">A JSON "null" production</dd>
+<dt>boolean:</dt>
+<dd style="margin-left: 8">A "true" or "false" value, from the JSON "true" or "false" productions</dd>
+<dt>object:</dt>
+<dd style="margin-left: 8">An unordered set of properties mapping a string to an instance, from the JSON "object" production</dd>
+<dt>array:</dt>
+<dd style="margin-left: 8">An ordered list of instances, from the JSON "array" production</dd>
+<dt>number:</dt>
+<dd style="margin-left: 8">An arbitrary-precision, base-10 decimal number value, from the JSON "number" production</dd>
+<dt>string:</dt>
+<dd style="margin-left: 8">A string of Unicode code points, from the JSON "string" production</dd>
+</dl>
+
+<p> </p>
+<p id="rfc.section.4.2.1.p.3">Whitespace and formatting concerns, including different lexical representations of numbers that are equal within the data model, are thus outside the scope of JSON Schema.  JSON Schema <a href="#vocabulary" class="xref">vocabularies</a> that wish to work with such differences in lexical representations SHOULD define keywords to precisely interpret formatted strings within the data model rather than relying on having the original JSON representation Unicode characters available.  </p>
+<p id="rfc.section.4.2.1.p.4">Since an object cannot have two properties with the same key, behavior for a JSON document that tries to define two properties (the "member" production) with the same key (the "string" production) in a single object is undefined.  </p>
+<p id="rfc.section.4.2.1.p.5">Note that JSON Schema vocabularies are free to define their own extended type system.  This should not be confused with the core data model types defined here.  As an example, "integer" is a reasonable type for a vocabulary to define as a value for a keyword, but the data model makes no distinction between integers and other numbers.  </p>
+<h1 id="rfc.section.4.2.2">
+<a href="#rfc.section.4.2.2">4.2.2.</a> Instance Media Types</h1>
+<p id="rfc.section.4.2.2.p.1">JSON Schema is designed to fully work with "application/json" documents, as well as media types using the "+json" structured syntax suffix.  </p>
+<p id="rfc.section.4.2.2.p.2">Some functionality that is useful for working with schemas is defined by each media type, namely media type parameters and URI fragment identifier syntax and semantics.  These features are useful in content negotiation and in calculating URIs for specific locations within an instance, respectively.  </p>
+<p id="rfc.section.4.2.2.p.3">This specification defines the "application/schema-instance+json" media type in order to allow instance authors to take full advantage of parameters and fragment identifiers for these purposes.  </p>
+<h1 id="rfc.section.4.2.3">
+<a href="#rfc.section.4.2.3">4.2.3.</a> Instance Equality</h1>
+<p id="rfc.section.4.2.3.p.1">Two JSON instances are said to be equal if and only if they are of the same type and have the same value according to the data model. Specifically, this means: </p>
+
+<ul class="empty">
+<li>both are null; or</li>
+<li>both are true; or</li>
+<li>both are false; or</li>
+<li>both are strings, and are the same codepoint-for-codepoint; or</li>
+<li>both are numbers, and have the same mathematical value; or</li>
+<li>both are arrays, and have an equal value item-for-item; or</li>
+<li>both are objects, and each property in one has exactly one property with a key equal to the other's, and that other property has an equal value.</li>
+</ul>
+
+<p> </p>
+<p id="rfc.section.4.2.3.p.2">Implied in this definition is that arrays must be the same length, objects must have the same number of members, properties in objects are unordered, there is no way to define multiple properties with the same key, and mere formatting differences (indentation, placement of commas, trailing zeros) are insignificant.  </p>
+<h1 id="rfc.section.4.3">
+<a href="#rfc.section.4.3">4.3.</a> <a href="#schema-document" id="schema-document">JSON Schema Documents</a>
+</h1>
+<p id="rfc.section.4.3.p.1">A JSON Schema document, or simply a schema, is a JSON document used to describe an instance.  A schema is itself interpreted as an instance, but SHOULD always be given the media type "application/schema+json" rather than "application/schema-instance+json".  The "application/schema+json" media type is defined to offer a superset of the media type parameter and fragment identifier syntax and semantics provided by "application/schema-instance+json".  </p>
+<p id="rfc.section.4.3.p.2">A JSON Schema MUST be an object or a boolean.  </p>
+<h1 id="rfc.section.4.3.1">
+<a href="#rfc.section.4.3.1">4.3.1.</a> JSON Schema Objects and Keywords</h1>
+<p id="rfc.section.4.3.1.p.1">Object properties that are applied to the instance are called keywords, or schema keywords.  Broadly speaking, keywords fall into one of three categories: </p>
+
+<dl>
+<dt>assertions:</dt>
+<dd style="margin-left: 8">produce a boolean result when applied to an instance </dd>
+<dt>annotations:</dt>
+<dd style="margin-left: 8">attach information to an instance for application use </dd>
+<dt>applicators:</dt>
+<dd style="margin-left: 8">apply one or more subschemas to a particular location in the instance, and combine or modify their results </dd>
+</dl>
+
+<p> </p>
+<p id="rfc.section.4.3.1.p.2">Keywords may fall into multiple categories, although applicators SHOULD only produce assertion results based on their subschemas' results.  They should not define additional constraints independent of their subschemas.  </p>
+<p id="rfc.section.4.3.1.p.3">Extension keywords, meaning those defined outside of this document and its companions, are free to define other behaviors as well.  </p>
+<p id="rfc.section.4.3.1.p.4">A JSON Schema MAY contain properties which are not schema keywords.  Unknown keywords SHOULD be ignored.  </p>
+<p id="rfc.section.4.3.1.p.5">An empty schema is a JSON Schema with no properties, or only unknown properties.  </p>
+<h1 id="rfc.section.4.3.2">
+<a href="#rfc.section.4.3.2">4.3.2.</a> Boolean JSON Schemas</h1>
+<p id="rfc.section.4.3.2.p.1">The boolean schema values "true" and "false" are trivial schemas that always produce themselves as assertions results, regardless of the instance value.  They never produce annotation results.  </p>
+<p id="rfc.section.4.3.2.p.2">These boolean schemas exist to clarify schema author intent and facilitate schema processing optimizations.  They behave identically to the following schema objects (where "not" is part of the subschema application vocabulary defined in this document).  </p>
+
+<dl>
+<dt>true:</dt>
+<dd style="margin-left: 8">Always passes validation, as if the empty schema {} </dd>
+<dt>false:</dt>
+<dd style="margin-left: 8">Always fails validation, as if the schema { "not":{} } </dd>
+</dl>
+
+<p> While the empty schema object is unambiguous, there are many possible equivalents to the "false" schema.  Using the boolean values ensures that the intent is clear to both human readers and implementations.  </p>
+<h1 id="rfc.section.4.3.3">
+<a href="#rfc.section.4.3.3">4.3.3.</a> <a href="#root" id="root">Root Schema and Subschemas</a>
+</h1>
+<p id="rfc.section.4.3.3.p.1">The root schema is the schema that comprises the entire JSON document in question.  </p>
+<p id="rfc.section.4.3.3.p.2">Some keywords take schemas themselves, allowing JSON Schemas to be nested: </p>
+<pre>
+
+{
+    "title": "root",
+    "items": {
+        "title": "array item"
+    }
+}
+
+                        </pre>
+<p id="rfc.section.4.3.3.p.3">In this example document, the schema titled "array item" is a subschema, and the schema titled "root" is the root schema.  </p>
+<p id="rfc.section.4.3.3.p.4">As with the root schema, a subschema is either an object or a boolean.  </p>
+<h1 id="rfc.section.4.3.4">
+<a href="#rfc.section.4.3.4">4.3.4.</a> Lexical Scope and Dynamic Scope</h1>
+<p id="rfc.section.4.3.4.p.1">While most JSON Schema keywords can be evaluated on their own, or at most need to take into account the values or results of adjacent keywords in the same schema object, a few have more complex behavior.  </p>
+<p id="rfc.section.4.3.4.p.2">The lexical scope of a keyword is determined by the nested JSON data structure of objects and arrays.  The largest such scope is an entire schema document.  The smallest scope is a single schema object with no subschemas.  </p>
+<p id="rfc.section.4.3.4.p.3">Keywords MAY be defined with a partial value, such as a URI-reference, which must be resolved against another value, such as another URI-reference or a full URI, which is found through the lexical structure of the JSON document.  The "$id" core keyword and the "base" JSON Hyper-Schema keyword are examples of this sort of behavior.  Additionally, "$ref" and "$recursiveRef" from this specification resolve their values in this way, although they do not change how further values are resolved.  </p>
+<p id="rfc.section.4.3.4.p.4">Note that some keywords, such as "$schema", apply to the lexical scope of the entire schema document, and therefore MUST only appear in the document's root schema.  </p>
+<p id="rfc.section.4.3.4.p.5">Other keywords may take into account the dynamic scope that exists during the evaluation of a schema, typically together with an instance document.  The outermost dynamic scope is the root schema of the schema document in which processing begins.  The path from this root schema to any particular keyword (that includes any "$ref" and "$recursiveRef" keywords that may have been resolved) is considered the keyword's "validation path." <a id="CREF1" class="info">[CREF1]<span class="info">Or should this be the schema object at which processing begins, even if it is not a root?  This has some implications for the case where "$recursiveAnchor" is only allowed in the root schema but processing begins in a subschema.  </span></a> </p>
+<p id="rfc.section.4.3.4.p.6">Lexical and dynamic scopes align until a reference keyword is encountered.  While following the reference keyword jumps from one lexical scope into a different one, from the perspective of dynamic scope, following reference is no different from descending into a subschema present as a value.  A keyword on the far side of that reference that resolves information through the dynamic scope will consider the originating side of the reference to be their dynamic parent, rather than examining the local lexically enclosing parent.  </p>
+<p id="rfc.section.4.3.4.p.7">The concept of dynamic scope is primarily used with "$recursiveRef", "$recursiveAnchor", and should be considered an advanced feature and used with caution when defining additional keywords.  </p>
+<h1 id="rfc.section.4.3.5">
+<a href="#rfc.section.4.3.5">4.3.5.</a> <a href="#referenced" id="referenced">Referenced and Referencing Schemas</a>
+</h1>
+<p id="rfc.section.4.3.5.p.1">As noted in <a href="#applicators" class="xref">Section 3.1.3</a>, an applicator keyword may refer to a schema to be applied, rather than including it as a subschema in the applicator's value.  In such situations, the schema being applied is known as the referenced schema, while the schema containing the applicator keyword is the referencing schema.  </p>
+<p id="rfc.section.4.3.5.p.2">While root schemas and subschemas are static concepts based on a schema's position within a schema document, referenced and referencing schemas are dynamic.  Different pairs of schemas may find themselves in various referenced and referencing arrangements during the evaluation of an instance against a schema.  </p>
+<p id="rfc.section.4.3.5.p.3">For some by-reference applicators, such as <a href="#ref" class="xref">"$ref"</a>, the referenced schema can be determined by static analysis of the schema document's lexical scope.  Others, such as "$recursiveRef" and "$recursiveAnchor",  may make use of dynamic scoping, and therefore only be resolvable in the process of evaluating the schema with an instance.  </p>
+<h1 id="rfc.section.5">
+<a href="#rfc.section.5">5.</a> <a href="#fragments" id="fragments">Fragment Identifiers</a>
+</h1>
+<p id="rfc.section.5.p.1">In accordance with section 3.1 of <a href="#RFC6839" class="xref">[RFC6839]</a>, the syntax and semantics of fragment identifiers specified for any +json media type SHOULD be as specified for "application/json".  (At publication of this document, there is no fragment identification syntax defined for "application/json".) </p>
+<p id="rfc.section.5.p.2">Additionally, the "application/schema+json" media type supports two fragment identifier structures: plain names and JSON Pointers.  The "application/schema-instance+json" media type supports one fragment identifier structure: JSON Pointers.  </p>
+<p id="rfc.section.5.p.3">The use of JSON Pointers as URI fragment identifiers is described in <a href="#RFC6901" class="xref">RFC 6901</a>.  For "application/schema+json", which supports two fragment identifier syntaxes, fragment identifiers matching the JSON Pointer syntax, including the empty string, MUST be interpreted as JSON Pointer fragment identifiers.  </p>
+<p id="rfc.section.5.p.4">Per the W3C's <a href="#W3C.WD-fragid-best-practices-20121025" class="xref">best practices for fragment identifiers</a>, plain name fragment identifiers in "application/schema+json" are reserved for referencing locally named schemas.  All fragment identifiers that do not match the JSON Pointer syntax MUST be interpreted as plain name fragment identifiers.  </p>
+<p id="rfc.section.5.p.5">Defining and referencing a plain name fragment identifier within an "application/schema+json" document are specified in the <a href="#id-keyword" class="xref">"$id" keyword</a> section.  </p>
+<p></p>
+<h1 id="rfc.section.6">
+<a href="#rfc.section.6">6.</a> General Considerations</h1>
+<h1 id="rfc.section.6.1">
+<a href="#rfc.section.6.1">6.1.</a> Range of JSON Values</h1>
+<p id="rfc.section.6.1.p.1">An instance may be any valid JSON value as defined by <a href="#RFC8259" class="xref">JSON</a>.  JSON Schema imposes no restrictions on type: JSON Schema can describe any JSON value, including, for example, null.  </p>
+<h1 id="rfc.section.6.2">
+<a href="#rfc.section.6.2">6.2.</a> <a href="#language" id="language">Programming Language Independence</a>
+</h1>
+<p id="rfc.section.6.2.p.1">JSON Schema is programming language agnostic, and supports the full range of values described in the data model.  Be aware, however, that some languages and JSON parsers may not be able to represent in memory the full range of values describable by JSON.  </p>
+<h1 id="rfc.section.6.3">
+<a href="#rfc.section.6.3">6.3.</a> <a href="#integers" id="integers">Mathematical Integers</a>
+</h1>
+<p id="rfc.section.6.3.p.1">Some programming languages and parsers use different internal representations for floating point numbers than they do for integers.  </p>
+<p id="rfc.section.6.3.p.2">For consistency, integer JSON numbers SHOULD NOT be encoded with a fractional part.  </p>
+<h1 id="rfc.section.6.4">
+<a href="#rfc.section.6.4">6.4.</a> <a href="#regex" id="regex">Regular Expressions</a>
+</h1>
+<p id="rfc.section.6.4.p.1">Keywords MAY use regular expressions to express constraints, or constrain the instance value to be a regular expression.  These regular expressions SHOULD be valid according to the <a href="#ecma262" class="xref">ECMA 262</a> regular expression dialect.  </p>
+<p id="rfc.section.6.4.p.2">Furthermore, given the high disparity in regular expression constructs support, schema authors SHOULD limit themselves to the following regular expression tokens: </p>
+
+<ul class="empty">
+<li>individual Unicode characters, as defined by the <a href="#RFC8259" class="xref">JSON specification</a>;</li>
+<li>simple character classes ([abc]), range character classes ([a-z]);</li>
+<li>complemented character classes ([^abc], [^a-z]);</li>
+<li>simple quantifiers: "+" (one or more), "*" (zero or more), "?" (zero or one), and their lazy versions ("+?", "*?", "??");</li>
+<li>range quantifiers: "{x}" (exactly x occurrences), "{x,y}" (at least x, at most y, occurrences), {x,} (x occurrences or more), and their lazy versions;</li>
+<li>the beginning-of-input ("^") and end-of-input ("$") anchors;</li>
+<li>simple grouping ("(...)") and alternation ("|").</li>
+</ul>
+
+<p> </p>
+<p id="rfc.section.6.4.p.3">Finally, implementations MUST NOT take regular expressions to be anchored, neither at the beginning nor at the end. This means, for instance, the pattern "es" matches "expression".  </p>
+<h1 id="rfc.section.6.5">
+<a href="#rfc.section.6.5">6.5.</a> Extending JSON Schema</h1>
+<p id="rfc.section.6.5.p.1">Additional schema keywords and schema vocabularies MAY be defined by any entity.  Save for explicit agreement, schema authors SHALL NOT expect these additional keywords and vocabularies to be supported by implementations that do not explicitly document such support.  Implementations SHOULD ignore keywords they do not support.  </p>
+<p id="rfc.section.6.5.p.2">Vocabulary authors SHOULD take care to avoid keyword name collisions if the vocabulary is intended for broad use, and potentially combined with other vocabularies.  JSON Schema does not provide any formal namespacing system, but also does not constrain keyword names, allowing for any number of namespacing approaches.  </p>
+<p id="rfc.section.6.5.p.3">Vocabularies may build on each other, such as by defining the behavior of their keywords with respect to the behavior of keywords from another vocabulary, or by using a keyword from another vocabulary with a restricted or expanded set of acceptable values.  Not all such vocabulary re-use will result in a new vocabulary that is compatible with the vocabulary on which it is built.  Vocabulary authors SHOULD clearly document what level of compatibility, if any, is expected.  </p>
+<p id="rfc.section.6.5.p.4">A schema that itself describes a schema is called a meta-schema.  Meta-schemas are used to validate JSON Schemas and specify which vocabulary they are using.  </p>
+<p id="rfc.section.6.5.p.5">Authors of extensions to JSON Schema are encouraged to write their own meta-schemas, which extend the existing meta-schemas using "allOf".  This extended meta-schema SHOULD be referenced using the "$schema" keyword, to allow tools to follow the correct behaviour.  </p>
+<p id="rfc.section.6.5.p.6">The recursive nature of meta-schemas makes the "$recursiveAnchor" and "$recursiveRef" keywords particularly useful for such extensions, as can be seen in the JSON Hyper-Schema meta-schema.  </p>
+<h1 id="rfc.section.7">
+<a href="#rfc.section.7">7.</a> Meta-Schemas and Vocabularies</h1>
+<p id="rfc.section.7.p.1">Two concepts, meta-schemas and vocabularies, are used to inform an implementation how to interpret a schema.  A schema S declares its meta-schema M with the "$schema" keyword, and meta-schemas declare vocabularies with the "$vocabulary" keyword.  The vocabularies declared in M are those that are expected to be used in S.  The meta-schema M may itself use a different set of vocabularies, which are declared in its own meta-schema, M'.  </p>
+<p id="rfc.section.7.p.2">The role of the meta-schema is to constrain the structure of conforming schemas, as well as simplify the process of composing multiple vocabularies into a usable feature set.  Schema authoring is expected to be a common activity, so schema authors need only understand how to reference a single meta-schema.  </p>
+<p id="rfc.section.7.p.3">Meta-schema authoring is an advanced usage of JSON Schema, so the design of meta-schema features emphasizes flexibility over simplicity.  </p>
+<p id="rfc.section.7.p.4">The role of a vocabulary is to declare which keywords (including sub-keywords such as those in JSON Hyper-Schema's Link Description Object) are in use, and with which semantics.  The semantics are indicated by the document that publicizes the vocabulary URI.  At this time, there is no machine-readable description of keywords other than validation rules, which appear in the meta-schema.  </p>
+<p id="rfc.section.7.p.5">Meta-schemas are separate from vocabularies to allow for the same sets of vocabularies to be combined in different ways, and for meta-schema authors to impose additional constraints such as forbidding certain keywords, or performing unusually strict syntactical validation, as might be done during a development and testing cycle.  </p>
+<h1 id="rfc.section.7.1">
+<a href="#rfc.section.7.1">7.1.</a> The "$schema" Keyword</h1>
+<p id="rfc.section.7.1.p.1">The "$schema" keyword is both used as a JSON Schema feature set identifier and the location of a resource which is itself a JSON Schema, which describes any schema written for this particular feature set.  </p>
+<p id="rfc.section.7.1.p.2">The value of this keyword MUST be a <a href="#RFC3986" class="xref">URI</a> (containing a scheme) and this URI MUST be normalized.  The current schema MUST be valid against the meta-schema identified by this URI.  </p>
+<p id="rfc.section.7.1.p.3">If this URI identifies a retrievable resource, that resource SHOULD be of media type "application/schema+json".  </p>
+<p id="rfc.section.7.1.p.4">The "$schema" keyword SHOULD be used in a root schema.  It MUST NOT appear in subschemas.  </p>
+<p><a id="CREF2" class="info">[CREF2]<span class="info">Using multiple "$schema" keywords in the same document would imply that the feature set and therefore behavior can change within a document.  This would necessitate resolving a number of implementation concerns that have not yet been clearly defined.  So, while the pattern of using "$schema" only in root schemas is likely to remain the best practice for schema authoring, implementation behavior is subject to be revised or liberalized in future drafts.  </span></a> </p>
+<p id="rfc.section.7.1.p.6">Values for this property are defined elsewhere in this and other documents, and by other parties.  </p>
+<h1 id="rfc.section.7.2">
+<a href="#rfc.section.7.2">7.2.</a> The "$vocabulary" Keyword</h1>
+<p id="rfc.section.7.2.p.1">The "$vocabulary" keyword, which appears in a meta-schema, identifies what sets of keywords are expected to be used in schemas described by that meta-schema, and with what semantics.  This is conceptually analogous to how most other keywords used in meta-schemas describe the syntax of keywords used in schemas described by that meta-schema.  </p>
+<p id="rfc.section.7.2.p.2">The value of this keyword MUST be an object.  The property names in the object MUST be URIs (containing a scheme) and this URI MUST be normalized.  Each URI that appears as a property name identifies a specific set of keywords and their semantics.  </p>
+<p id="rfc.section.7.2.p.3">The URI MAY be a URL, but the nature of the retrievable resources is currently undefined, and reserved for future use.  Vocabulary authors SHOULD NOT serve a document at that URL.  A server MAY respond with the relevant protocol's successful "no content" message, such as an HTTP 204 status.  <a id="CREF3" class="info">[CREF3]<span class="info">Vocabulary documents may be added shortly, or in the next draft.  For now, identifying the keyword set is deemed sufficient as that, along with meta-schema validation, is how the current "vocabularies" work today.  </span></a> </p>
+<p id="rfc.section.7.2.p.4">The values of the object properties MUST be booleans.  If the value is true, then implementations that do not recognize the vocabulary MUST refuse to process any schemas that declare this meta-schema with "$schema".  If the value is false, implementations that do not recognize the vocabulary MAY choose to proceed with processing such schemas.  </p>
+<p id="rfc.section.7.2.p.5">When processing a schema that uses unrecognized vocabularies, keywords declared by those vocabularies are treated like any other unrecognized keyword, and ignored.  </p>
+<p id="rfc.section.7.2.p.6">The "$vocabulary" keyword SHOULD be used in the root schema of any schema document intended for use as a meta-schema.  It MUST NOT appear in subschemas.  </p>
+<p id="rfc.section.7.2.p.7">The "$vocabulary" keyword MUST be ignored in schema documents that are not being processed as a meta-schema.  This allows validating a meta-schema M against its own meta-schema M' without requiring the validator to understand the vocabularies declared by M.  </p>
+<p id="rfc.section.7.2.p.8">Note that the processing restrictions on "$vocabulary" mean that meta-schemas that reference other meta-schemas using "$ref" or similar keywords do not automatically inherit the vocabulary declarations of those other meta-schemas.  All such declarations must be repeated in the root of each schema document intended for use as a meta-schema.  This is demonstrated in <a href="#example-meta-schema" class="xref">the example meta-schema</a>.  </p>
+<p id="rfc.section.7.2.p.9">If "$vocabulary" is absent, an implementation MAY determine behavior based on the meta-schema if it is recognized from the URI value of the referring schema's "$schema" keyword.  If the meta-schema, as referenced by the schema, is not recognized, then implementations MUST assume the use of the core vocabulary, and SHOULD assume the use of all vocabularies in this specification and the companion Validation specification.  </p>
+<h1 id="rfc.section.7.3">
+<a href="#rfc.section.7.3">7.3.</a> Detecting a Meta-Schema</h1>
+<p id="rfc.section.7.3.p.1">Implementations MUST recognize a schema as a meta-schema if it is being examined because it was identified as such by another schema's "$schema" keyword.  This means that a single schema document might sometimes be considered a regular schema, and other times be considered a meta-schema.  </p>
+<p id="rfc.section.7.3.p.2">In the case of examining a schema which is its own meta-schema, when an implementation begins processing it as a regular schema, it is processed under those rules.  However, when loaded a second time as a result of checking its own "$schema" value, it is treated as a meta-schema.  So the same document is processed both ways in the course of one session.  </p>
+<p id="rfc.section.7.3.p.3">Implementations MAY allow a schema to be passed as a meta-schema, for implementation-specific purposes, such as pre-loading a commonly used meta-schema and checking its vocabulary support requirements up front.  Meta-schema authors MUST NOT expect such features to be interoperable across implementations.  </p>
+<h1 id="rfc.section.7.4">
+<a href="#rfc.section.7.4">7.4.</a> Best Practices for Vocabulary and Meta-Schema Authors</h1>
+<p id="rfc.section.7.4.p.1">Meta-schema authors SHOULD NOT use "$vocabulary" to combine multiple vocabularies that define conflicting syntax or semantics for the same keyword.  As semantic conflicts are not generally detectable through schema validation, implementations are not expected to detect such conflicts.  If conflicting vocabularies are declared, the resulting behavior is undefined.  </p>
+<p id="rfc.section.7.4.p.2">Vocabulary authors SHOULD provide a meta-schema that validates the expected usage of the vocabulary's keywords.  Such meta-schemas SHOULD NOT forbid additional keywords, and MUST NOT forbid the "$id", "$schema", or "$vocabulary" keywords in the root schema.  </p>
+<p id="rfc.section.7.4.p.3">It is RECOMMENDED that meta-schema authors reference each vocabulary's meta-schema using the <a href="#allOf" class="xref">"allOf"</a> keyword, although other mechanisms for constructing the meta-schema may be appropriate for certain use cases.  </p>
+<p id="rfc.section.7.4.p.4">Meta-schemas MAY impose additional constraints, including describing keywords not present in any vocabulary, beyond what the meta-schemas associated with the declared vocabularies describe.  This allows for restricting usage to a subset of a vocabulary, and for validating locally defined keywords not intended for re-use.  </p>
+<p id="rfc.section.7.4.p.5">However, meta-schemas SHOULD NOT contradict any vocabularies that they declare, such as by requiring a different JSON type than the vocabulary expects.  The resulting behavior is undefined.  </p>
+<p id="rfc.section.7.4.p.6">Meta-schemas intended for local use, with no need to test for vocabulary support in arbitrary implementations, can safely omit "$vocabulary" entirely.  </p>
+<h1 id="rfc.section.7.5">
+<a href="#rfc.section.7.5">7.5.</a> The JSON Schema Core Vocabulary</h1>
+<p id="rfc.section.7.5.p.1">Keywords declared in in this specification that begin with "$" make up the JSON Schema Core vocabulary.  These keywords are either required in order process any schema or meta-schema, including those split across multiple documents, or exist to reserve keywords for purposes that require guaranteed interoperability.  </p>
+<p id="rfc.section.7.5.p.2">The Core vocabulary MUST be considered mandatory at all times, in order to bootstrap the processing of further vocabularies.  Meta-schemas that use "$vocabulary" MUST explicitly list the Core vocabulary, which MUST have a value of true indicating that it is required.  </p>
+<p id="rfc.section.7.5.p.3">The behavior of a false value for this vocabulary (and only this vocabulary) is undefined, as is the behavior when "$vocabulary" is present but the Core vocabulary is not included.  However, it is RECOMMENDED that implementations detect these cases and raise an error when they occur.  </p>
+<p id="rfc.section.7.5.p.4">Meta-schemas that do not use "$vocabulary" MUST be considered to require the Core vocabulary as if its URI were present with a value of true.  </p>
+<p id="rfc.section.7.5.p.5">The current URI for the Core vocabulary is: <span>&lt;</span><a href="https://json-schema.org/draft/2019-04/vocab/core">https://json-schema.org/draft/2019-04/vocab/core</a><span>&gt;</span>.  </p>
+<p id="rfc.section.7.5.p.6">The current URI for the corresponding meta-schema is: <span>&lt;</span><a href="https://json-schema.org/draft/2019-04/meta/core">https://json-schema.org/draft/2019-04/meta/core</a><span>&gt;</span>.  </p>
+<p id="rfc.section.7.5.p.7">Updated vocabulary and meta-schema URIs MAY be published between specification drafts in order to correct errors.  Implementations SHOULD consider URIs dated after this specification draft and before the next to indicate the same syntax and semantics as those listed here.  </p>
+<h1 id="rfc.section.7.6">
+<a href="#rfc.section.7.6">7.6.</a> <a href="#example-meta-schema" id="example-meta-schema">Example Meta-Schema With Vocabulary Declarations</a>
+</h1>
+<p>This meta-schema explicitly declares both the Core and Applicator vocabularies, and combines their meta-schemas with an "allOf".  It additionally restricts the usage of the Applicator vocabulary by forbidding the keyword prefixed with "unevaluated".  It also describes a keyword, "localKeyword", that is not part of either vocabulary.  Note that it is its own meta-schema, as it relies on both the Core vocabulary (as all schemas do) and the Applicator vocabulary (for "allOf").  </p>
+<pre>
+
+{
+  "$schema": "https://json-schema.org/draft/2019-04/core-app-example#",
+  "$id": "https://json-schema.org/draft/2019-04/core-app-example",
+  "$recursiveAnchor": true,
+  "$vocabulary": {
+    "https://json-schema.org/draft/2019-04/vocab/core": true,
+    "https://json-schema.org/draft/2019-04/vocab/applicator": true
+  },
+  "allOf": [
+    {"$ref": "https://json-schema.org/draft/2019-04/meta/core"},
+    {"$ref": "https://json-schema.org/draft/2019-04/meta/applicator"}
+  ],
+  "patternProperties": {
+    "^unevaluated.*$": false
+  },
+  "properties": {
+    "$comment": "Not in vocabulary, but validated if used",
+    "localKeyword": {
+      "type": "string"
+    }
+  }
+}
+
+                    </pre>
+<p>As shown above, even though each of the referenced standard meta-schemas declares its corresponding vocabulary, this new meta-schema must re-declare them for itself.  It would be valid to leave the core vocabulary out of the "$vocabulary" keyword, but it needs to be referenced through the "allOf" keyword in order for its terms to be validated.  There is no special case for validation of core keywords.  </p>
+<p id="rfc.section.7.6.p.1">The standard meta-schemas that combine all vocabularies defined by the Core and Validation specification, and that combine all vocabularies defined by those specifications as well as the Hyper-Schema specification, demonstrate additional complex combinations.  These URIs for these meta-schemas may be found in the Validation and Hyper-Schema specifications, respectively.  </p>
+<h1 id="rfc.section.8">
+<a href="#rfc.section.8">8.</a> Base URI and Dereferencing</h1>
+<p id="rfc.section.8.p.1">To differentiate between schemas in a vast ecosystem, schemas are identified by <a href="#RFC3986" class="xref">URI</a>, and can embed references to other schemas by specifying their URI.  </p>
+<h1 id="rfc.section.8.1">
+<a href="#rfc.section.8.1">8.1.</a> Initial Base URI</h1>
+<p><a href="#RFC3986" class="xref">RFC3986 Section 5.1</a> defines how to determine the default base URI of a document.  </p>
+<p id="rfc.section.8.1.p.2">Informatively, the initial base URI of a schema is the URI at which it was found, whether that was a network location, a local filesystem, or any other situation identifiable by a URI of any known scheme.  </p>
+<p id="rfc.section.8.1.p.3">If no source is known, or no URI scheme is known for the source, a suitable implementation-specific default URI MAY be used as described in <a href="#RFC3986" class="xref">RFC 3986 Section 5.1.4</a>.  It is RECOMMENDED that implementations document any default base URI that they assume.  </p>
+<h1 id="rfc.section.8.2">
+<a href="#rfc.section.8.2">8.2.</a> <a href="#id-keyword" id="id-keyword">The "$id" Keyword</a>
+</h1>
+<p id="rfc.section.8.2.p.1">The "$id" keyword defines a URI for the schema, and the base URI that other URI references within the schema are resolved against.  A subschema's "$id" is resolved against the base URI of its parent schema.  If no parent sets an explicit base with "$id", the base URI is that of the entire document, as determined per <a href="#RFC3986" class="xref">RFC 3986 section 5</a>.  </p>
+<p id="rfc.section.8.2.p.2">If present, the value for this keyword MUST be a string, and MUST represent a valid <a href="#RFC3986" class="xref">URI-reference</a>.  This value SHOULD be normalized, and SHOULD NOT be an empty fragment &lt;#&gt; or an empty string &lt;&gt;.  </p>
+<h1 id="rfc.section.8.2.1">
+<a href="#rfc.section.8.2.1">8.2.1.</a> Identifying the root schema</h1>
+<p id="rfc.section.8.2.1.p.1">The root schema of a JSON Schema document SHOULD contain an "$id" keyword with an <a href="#RFC3986" class="xref">absolute-URI</a> (containing a scheme, but no fragment), or this absolute URI but with an empty fragment.  </p>
+<h1 id="rfc.section.8.2.2">
+<a href="#rfc.section.8.2.2">8.2.2.</a> Changing the base URI within a schema file</h1>
+<p id="rfc.section.8.2.2.p.1">When an "$id" sets the base URI, the object containing that "$id" and all of its subschemas can be identified by using a JSON Pointer fragment starting from that location.  This is true even of subschemas that further change the base URI.  Therefore, a single subschema may be accessible by multiple URIs, each consisting of base URI declared in the subschema or a parent, along with a JSON Pointer fragment identifying the path from the schema object that declares the base to the subschema being identified.  Examples of this are shown in section <a href="#idExamples" class="xref">8.2.4</a>.  </p>
+<h1 id="rfc.section.8.2.3">
+<a href="#rfc.section.8.2.3">8.2.3.</a> Location-independent identifiers</h1>
+<p id="rfc.section.8.2.3.p.1">Using JSON Pointer fragments requires knowledge of the structure of the schema.  When writing schema documents with the intention to provide re-usable schemas, it may be preferable to use a plain name fragment that is not tied to any particular structural location.  This allows a subschema to be relocated without requiring JSON Pointer references to be updated.  </p>
+<p id="rfc.section.8.2.3.p.2">To specify such a subschema identifier, the "$id" keyword is set to a URI reference with a plain name fragment (not a JSON Pointer fragment).  This value MUST begin with the number sign that specifies a fragment ("#"), then a letter ([A-Za-z]), followed by any number of letters, digits ([0-9]), hyphens ("-"), underscores ("_"), colons (":"), or periods (".").  </p>
+<p id="rfc.section.8.2.3.p.3">The effect of using a fragment in "$id" that isn't blank or doesn't follow the plain name syntax is undefined.  <a id="CREF4" class="info">[CREF4]<span class="info">How should an "$id" URI reference containing a fragment with other components be interpreted?  There are two cases:  when the other components match the current base URI and when they change the base URI.  </span></a> </p>
+<h1 id="rfc.section.8.2.4">
+<a href="#rfc.section.8.2.4">8.2.4.</a> <a href="#idExamples" id="idExamples">Schema identification examples</a>
+</h1>
+<p>Consider the following schema, which shows "$id" being used to identify the root schema, change the base URI for subschemas, and assign plain name fragments to subschemas: </p>
+<pre>
+
+{
+    "$id": "http://example.com/root.json",
+    "$defs": {
+        "A": { "$id": "#foo" },
+        "B": {
+            "$id": "other.json",
+            "$defs": {
+                "X": { "$id": "#bar" },
+                "Y": { "$id": "t/inner.json" }
+            }
+        },
+        "C": {
+            "$id": "urn:uuid:ee564b8a-7a87-4125-8c96-e9f123d6766f"
+        }
+    }
+}
+
+                        </pre>
+<p id="rfc.section.8.2.4.p.1">The schemas at the following URI-encoded <a href="#RFC6901" class="xref">JSON Pointers</a> (relative to the root schema) have the following base URIs, and are identifiable by any listed URI in accordance with Section <a href="#fragments" class="xref">5</a> above: </p>
+<p></p>
+
+<dl>
+<dt># (document root)</dt>
+<dd style="margin-left: 8">
+<dl>
+<dt></dt>
+<dd style="margin-left: 8">http://example.com/root.json</dd>
+<dt></dt>
+<dd style="margin-left: 8">http://example.com/root.json#</dd>
+</dl>
+<p> </p>
+</dd>
+<dt>#/$defs/A</dt>
+<dd style="margin-left: 8">
+<dl>
+<dt></dt>
+<dd style="margin-left: 8">http://example.com/root.json#foo</dd>
+<dt></dt>
+<dd style="margin-left: 8">http://example.com/root.json#/$defs/A</dd>
+</dl>
+<p> </p>
+</dd>
+<dt>#/$defs/B</dt>
+<dd style="margin-left: 8">
+<dl>
+<dt></dt>
+<dd style="margin-left: 8">http://example.com/other.json</dd>
+<dt></dt>
+<dd style="margin-left: 8">http://example.com/other.json#</dd>
+<dt></dt>
+<dd style="margin-left: 8">http://example.com/root.json#/$defs/B</dd>
+</dl>
+<p> </p>
+</dd>
+<dt>#/$defs/B/$defs/X</dt>
+<dd style="margin-left: 8">
+<dl>
+<dt></dt>
+<dd style="margin-left: 8">http://example.com/other.json#bar</dd>
+<dt></dt>
+<dd style="margin-left: 8">http://example.com/other.json#/$defs/X</dd>
+<dt></dt>
+<dd style="margin-left: 8">http://example.com/root.json#/$defs/B/$defs/X</dd>
+</dl>
+<p> </p>
+</dd>
+<dt>#/$defs/B/$defs/Y</dt>
+<dd style="margin-left: 8">
+<dl>
+<dt></dt>
+<dd style="margin-left: 8">http://example.com/t/inner.json</dd>
+<dt></dt>
+<dd style="margin-left: 8">http://example.com/t/inner.json#</dd>
+<dt></dt>
+<dd style="margin-left: 8">http://example.com/other.json#/$defs/Y</dd>
+<dt></dt>
+<dd style="margin-left: 8">http://example.com/root.json#/$defs/B/$defs/Y</dd>
+</dl>
+<p> </p>
+</dd>
+<dt>#/$defs/C</dt>
+<dd style="margin-left: 8">
+<dl>
+<dt></dt>
+<dd style="margin-left: 8">urn:uuid:ee564b8a-7a87-4125-8c96-e9f123d6766f</dd>
+<dt></dt>
+<dd style="margin-left: 8">urn:uuid:ee564b8a-7a87-4125-8c96-e9f123d6766f#</dd>
+<dt></dt>
+<dd style="margin-left: 8">http://example.com/root.json#/$defs/C</dd>
+</dl>
+<p> </p>
+</dd>
+</dl>
+
+<p> </p>
+<h1 id="rfc.section.8.3">
+<a href="#rfc.section.8.3">8.3.</a> Schema References</h1>
+<p id="rfc.section.8.3.p.1">Several keywords can be used to reference a schema which is to be applied to the current instance location. "$ref" and "$recursiveRef" are applicator keywords, applying the referenced schema to the instance.  "$recursiveAnchor" is a helper keyword that controls how the referenced schema of "$recursiveRef" is determined.  </p>
+<p id="rfc.section.8.3.p.2">As the value of "$ref" and "$recursiveRef" are URI References, this allows the possibility to externalise or divide a schema across multiple files, and provides the ability to validate recursive structures through self-reference.  </p>
+<p id="rfc.section.8.3.p.3">The resolved URI produced by these keywords is not necessarily a network locator, only an identifier. A schema need not be downloadable from the address if it is a network-addressable URL, and implementations SHOULD NOT assume they should perform a network operation when they encounter a network-addressable URI.  </p>
+<h1 id="rfc.section.8.3.1">
+<a href="#rfc.section.8.3.1">8.3.1.</a> <a href="#ref" id="ref">Direct References with "$ref"</a>
+</h1>
+<p id="rfc.section.8.3.1.p.1">The "$ref" keyword is used to reference a statically identified schema.  </p>
+<p id="rfc.section.8.3.1.p.2">The value of the "$ref" property MUST be a string which is a URI Reference.  Resolved against the current URI base, it identifies the URI of a schema to use.  </p>
+<h1 id="rfc.section.8.3.2">
+<a href="#rfc.section.8.3.2">8.3.2.</a> Recursive References with "$recursiveRef" and "$recursiveAnchor"</h1>
+<p id="rfc.section.8.3.2.p.1">The "$recursiveRef" and "$recursiveAnchor" keywords are used to construct extensible recursive schemas.  A recursive schema is one that has a reference to its own root, identified by the empty fragment URI reference ("#").  </p>
+<p id="rfc.section.8.3.2.p.2">Extending a recursive schema with "$ref" alone involves redefining all recursive references in the source schema to point to the root of the extension.  This produces the correct recursive behavior in the extension, which is that all recursion should reference the root of the extension.  </p>
+<p>Consider the following two schemas.  The first schema, identified as "original" as it is the schema to be extended, describes an object with one string property and one recursive reference property, "r".  The second schema, identified as "extension", references the first, and describes an additional things" property, which is an array of recursive references.  It also repeats the description of "r" from the original schema.  </p>
+<pre>
+
+{
+    "$schema": "http://json-schema.org/draft/2019-04/schema#",
+    "$id": "https://example.com/original",
+
+    "properties": {
+        "name": {
+            "type": "string"
+        },
+        "r": {
+            "$ref": "#"
+        }
+    }
+}
+
+{
+    "$schema": "http://json-schema.org/draft/2019-04/schema#",
+    "$id": "https://example.com/extension",
+
+    "$ref": "original",
+    "properties": {
+        "r": {
+            "$ref": "#"
+        },
+        "things": {
+            "type": "array"
+            "items": {
+                "$ref": "#"
+            }
+        }
+    }
+}
+
+                        </pre>
+<p>This apparent duplication is important because it resolves to "https://example.com/extension#", meaning that for instance validated against the extension schema, the value of "r" must be valid according to the extension, and not just the original schema as "r" was described there.  </p>
+<p id="rfc.section.8.3.2.p.3">This approach is fine for a single recursive field, but the more complicated the original schema, the more redefinitions are necessary in the extension.  This leads to a verbose and error-prone extension, which must be kept synchronized with the original schema if the original changes its recursive fields.  This approach can be seen in the meta-schema for JSON Hyper-Schema in all prior drafts.  </p>
+<h1 id="rfc.section.8.3.2.1">
+<a href="#rfc.section.8.3.2.1">8.3.2.1.</a> Enabling Recursion with "$recursiveAnchor"</h1>
+<p id="rfc.section.8.3.2.1.p.1">The desired behavior is for the recursive reference, "r", in the original schema to resolve to the original schema when that is the only schema being used, but to resolve to the extension schema when using the extension.  Then there would be no need to redefine the "r" property, or others like it, in the extension.  </p>
+<p id="rfc.section.8.3.2.1.p.2">In order to create a recursive reference, we must do three things: </p>
+
+<ul class="empty">
+<li>In our original schema, indicate that the schema author intends for it to be extensible recursively.  </li>
+<li>In our extension schema, indicate that it is intended to be a recursive extension.  </li>
+<li>Use a reference keyword that explicitly activates the recursive behavior at the point of reference.  </li>
+</ul>
+
+<p> These three things together ensure that all schema authors are intentionally constructing a recursive extension, which in turn gives all uses of the regular "$ref" keyword confidence that it only behaves as it appears to, using lexical scoping.  </p>
+<p id="rfc.section.8.3.2.1.p.3">The "$recursiveAnchor" keyword is how schema authors indicate that a schema can be extended recursively, and be a recursive schema.  This keyword MAY appear in the root schema of a schema document, and MUST NOT appear in any subschema.  </p>
+<p id="rfc.section.8.3.2.1.p.4">The value of "$recursiveAnchor" MUST be of type boolean, and MUST be true.  The value false is reserved for possible future use.  </p>
+<h1 id="rfc.section.8.3.2.2">
+<a href="#rfc.section.8.3.2.2">8.3.2.2.</a> Dynamically recursive references with "$recursiveRef"</h1>
+<p id="rfc.section.8.3.2.2.p.1">The "$recursiveRef" keyword behaves identically to "$ref", except that if the referenced schema has "$recursiveAnchor" set to true, then the implementation MUST examine the dynamic scope for the outermost (first seen) schema document with "$recursiveAnchor" set to true.  If such a schema document exists, then the target of the "$recursiveRef" MUST be set to that document's URI, in place of the URI produced by the rules for "$ref".  </p>
+<p id="rfc.section.8.3.2.2.p.2">Note that if the schema referenced by "$recursiveRef" does not contain "$recursiveAnchor" set to true, or if there are no other "$recursiveAnchor" keywords set to true anywhere further back in the dynamic scope, then "$recursiveRef"'s behavior is identical to that of "$ref".  </p>
+<p>With this in mind, we can rewrite the previous example: </p>
+<pre>
+
+{
+    "$schema": "http://json-schema.org/draft/2019-04/schema#",
+    "$id": "https://example.com/original",
+    "$recursiveAnchor": true,
+
+    "properties": {
+        "name": {
+            "type": "string"
+        },
+        "r": {
+            "$recursiveRef": "#"
+        }
+    }
+}
+
+{
+    "$schema": "http://json-schema.org/draft/2019-04/schema#",
+    "$id": "https://example.com/extension",
+    "$recursiveAnchor": true,
+
+    "$ref": "original",
+    "properties": {
+        "things": {
+            "type": "array"
+            "items": {
+                "$recursiveRef": "#"
+            }
+        }
+    }
+}
+
+                            </pre>
+<p>Note that the "r" property no longer appears in the extension schema.  Instead, all "$ref"s have been changed to "$recursiveRef"s, and both schemas have "$recursiveAnchor" set to true in their root schema.  </p>
+<p id="rfc.section.8.3.2.2.p.3">When using the original schema on its own, there is no change in behavior.  The "$recursiveRef" does lead to a schema where "$recursiveAnchor" is set to true, but since the original schema is the only schema document in the dynamics scope (it references itself, and does not reference any other schema documents), the behavior is effectively the same as "$ref".  </p>
+<p id="rfc.section.8.3.2.2.p.4">When using the extension schema, the "$recursiveRef" within that schema (for the array items within "things") also effectively behaves like "$ref".  The extension schema is the outermost dynamic scope, so the reference target is not changed.  </p>
+<p id="rfc.section.8.3.2.2.p.5">In contrast, when using the extension schema, the "$recursiveRef" for "r" in the original schema now behaves differently.  Its initial target is the root schema of the original schema document, which has "$recursiveAnchor" set to true. In this case, the outermost dynamic scope that also has "$recursiveAnchor" set to true is the extension schema.  So when using the extensions schema, "r"'s reference in the original schema will resolve to "https://example.com/extension#", not "https://example.com/original#".  </p>
+<h1 id="rfc.section.8.3.3">
+<a href="#rfc.section.8.3.3">8.3.3.</a> Guarding Against Infinite Recursion</h1>
+<p id="rfc.section.8.3.3.p.1">A schema MUST NOT be run into an infinite loop against an instance. For example, if two schemas "#alice" and "#bob" both have an "allOf" property that refers to the other, a naive validator might get stuck in an infinite recursive loop trying to validate the instance.  Schemas SHOULD NOT make use of infinite recursive nesting like this; the behavior is undefined.  </p>
+<h1 id="rfc.section.8.3.4">
+<a href="#rfc.section.8.3.4">8.3.4.</a> References to Possible Non-Schemas</h1>
+<p id="rfc.section.8.3.4.p.1">Subschema objects (or booleans) are recognized by their use with known applicator keywords.  These keywords may be the standard applicators from this document, or extension keywords from a known vocabulary, or implementation-specific custom keywords.  </p>
+<p id="rfc.section.8.3.4.p.2">Multi-level structures of unknown keywords are capable of introducing nested subschemas, which would be subject to the processing rules for "$id".  Therefore, having a reference target in such an unrecognized structure cannot be reliably implemented, and the resulting behavior is undefined.  Similarly, a reference target under a known keyword, for which the value is known not to be a schema, results in undefined behavior in order to avoid burdening implementations with the need to detect such targets.  <a id="CREF5" class="info">[CREF5]<span class="info">These scenarios are analogous to fetching a schema over HTTP but receiving a response with a Content-Type other than application/schema+json.  An implementation can certainly try to interpret it as a schema, but the origin server offered no guarantee that it actually is any such thing.  Therefore, interpreting it as such has security implications and may produce unpredictable results.  </span></a> </p>
+<p id="rfc.section.8.3.4.p.3">Note that single-level custom keywords with identical syntax and semantics to "$defs" do not allow for any intervening "$id" keywords, and therefore will behave correctly under implementations that attempt to use any reference target as a schema.  However, this behavior is implementation-specific and MUST NOT be relied upon for interoperability.  </p>
+<h1 id="rfc.section.8.3.5">
+<a href="#rfc.section.8.3.5">8.3.5.</a> Loading a referenced schema</h1>
+<p id="rfc.section.8.3.5.p.1">The use of URIs to identify remote schemas does not necessarily mean anything is downloaded, but instead JSON Schema implementations SHOULD understand ahead of time which schemas they will be using, and the URIs that identify them.  </p>
+<p id="rfc.section.8.3.5.p.2">When schemas are downloaded, for example by a generic user-agent that doesn't know until runtime which schemas to download, see <a href="#hypermedia" class="xref">Usage for Hypermedia</a>.  </p>
+<p id="rfc.section.8.3.5.p.3">Implementations SHOULD be able to associate arbitrary URIs with an arbitrary schema and/or automatically associate a schema's "$id"-given URI, depending on the trust that the validator has in the schema.  Such URIs and schemas can be supplied to an implementation prior to processing instances, or may be noted within a schema document as it is processed, producing associations as shown in section <a href="#idExamples" class="xref">8.2.4</a>.  </p>
+<p id="rfc.section.8.3.5.p.4">A schema MAY (and likely will) have multiple URIs, but there is no way for a URI to identify more than one schema. When multiple schemas try to identify as the same URI, validators SHOULD raise an error condition.  </p>
+<h1 id="rfc.section.8.3.6">
+<a href="#rfc.section.8.3.6">8.3.6.</a> Dereferencing</h1>
+<p id="rfc.section.8.3.6.p.1">Schemas can be identified by any URI that has been given to them, including a JSON Pointer or their URI given directly by "$id".  In all cases, dereferencing a "$ref" reference involves first resolving its value as a URI reference against the current base URI per <a href="#RFC3986" class="xref">RFC 3986</a>.  </p>
+<p id="rfc.section.8.3.6.p.2">If the resulting URI identifies a schema within the current document, or within another schema document that has been made available to the implementation, then that schema SHOULD be used automatically.  </p>
+<p id="rfc.section.8.3.6.p.3">For example, consider this schema: </p>
+<pre>
+
+{
+    "$id": "http://example.net/root.json",
+    "items": {
+        "type": "array",
+        "items": { "$ref": "#item" }
+    },
+    "$defs": {
+        "single": {
+            "$id": "#item",
+            "type": "object",
+            "additionalProperties": { "$ref": "other.json" }
+        }
+    }
+}
+
+                        </pre>
+<p id="rfc.section.8.3.6.p.4">When an implementation encounters the &lt;#/$defs/single&gt; schema, it resolves the "$id" URI reference against the current base URI to form &lt;http://example.net/root.json#item&gt;.  </p>
+<p id="rfc.section.8.3.6.p.5">When an implementation then looks inside the &lt;#/items&gt; schema, it encounters the &lt;#item&gt; reference, and resolves this to &lt;http://example.net/root.json#item&gt;, which it has seen defined in this same document and can therefore use automatically.  </p>
+<p id="rfc.section.8.3.6.p.6">When an implementation encounters the reference to "other.json", it resolves this to &lt;http://example.net/other.json&gt;, which is not defined in this document.  If a schema with that identifier has otherwise been supplied to the implementation, it can also be used automatically.  <a id="CREF6" class="info">[CREF6]<span class="info">What should implementations do when the referenced schema is not known? Are there circumstances in which automatic network dereferencing is allowed?  A same origin policy?  A user-configurable option?  In the case of an evolving API described by Hyper-Schema, it is expected that new schemas will be added to the system dynamically, so placing an absolute requirement of pre-loading schema documents is not feasible.  </span></a> </p>
+<h1 id="rfc.section.8.4">
+<a href="#rfc.section.8.4">8.4.</a> Schema Re-Use With "$defs"</h1>
+<p id="rfc.section.8.4.p.1">The "$defs" keyword provides a standardized location for schema authors to inline re-usable JSON Schemas into a more general schema.  The keyword does not directly affect the validation result.  </p>
+<p id="rfc.section.8.4.p.2">This keyword's value MUST be an object.  Each member value of this object MUST be a valid JSON Schema.  </p>
+<pre>
+
+{
+    "type": "array",
+    "items": { "$ref": "#/$defs/positiveInteger" },
+    "$defs": {
+        "positiveInteger": {
+            "type": "integer",
+            "exclusiveMinimum": 0
+        }
+    }
+}
+
+                        </pre>
+<p id="rfc.section.8.4.p.3">As an example, here is a schema describing an array of positive integers, where the positive integer constraint is a subschema in "$defs": </p>
+<h1 id="rfc.section.9">
+<a href="#rfc.section.9">9.</a> Comments With "$comment"</h1>
+<p id="rfc.section.9.p.1">This keyword is reserved for comments from schema authors to readers or maintainers of the schema.  The value of this keyword MUST be a string. Implementations MUST NOT present this string to end users.  Tools for editing schemas SHOULD support displaying and editing this keyword.  The value of this keyword MAY be used in debug or error output which is intended for developers making use of schemas.  Schema vocabularies SHOULD allow "$comment" within any object containing vocabulary keywords.  Implementations MAY assume "$comment" is allowed unless the vocabulary specifically forbids it.  Vocabularies MUST NOT specify any effect of "$comment" beyond what is described in this specification.  Tools that translate other media types or programming languages to and from application/schema+json MAY choose to convert that media type or programming language's native comments to or from "$comment" values.  The behavior of such translation when both native comments and "$comment" properties are present is implementation-dependent.  Implementations SHOULD treat "$comment" identically to an unknown extension keyword.  They MAY strip "$comment" values at any point during processing.  In particular, this allows for shortening schemas when the size of deployed schemas is a concern.  Implementations MUST NOT take any other action based on the presence, absence, or contents of "$comment" properties.  In particular, the value of "$comment" MUST NOT be collected as an annotation result.  </p>
+<h1 id="rfc.section.10">
+<a href="#rfc.section.10">10.</a> Collecting Annotations</h1>
+<p id="rfc.section.10.p.1">Annotations are collected by keywords that explicitly define annotation-collecting behavior.  Note that boolean schemas cannot produce annotations as they do not make use of keywords.  </p>
+<p id="rfc.section.10.p.2">A collected annotation MUST include the following information: </p>
+
+<ul class="empty">
+<li>The name of the keyword that produces the annotation </li>
+<li>The instance location to which it is attached, as a JSON Pointer </li>
+<li>The schema location path, indicating how reference keywords such as "$ref" were followed to reach the absolute schema location.  </li>
+<li>The absolute schema location of the attaching keyword, as a URI.  This MAY be omitted if it is the same as the schema location path from above.  </li>
+<li>The attached value(s) </li>
+</ul>
+
+<p> </p>
+<p id="rfc.section.10.p.3">If the same keyword attaches values from multiple schema locations to the same instance location, and the annotation defines a process for combining such values, then the combined value MUST also be associated with the instance location.  </p>
+<h1 id="rfc.section.10.1">
+<a href="#rfc.section.10.1">10.1.</a> Distinguishing Among Multiple Values</h1>
+<p id="rfc.section.10.1.p.1">Applications MAY make decisions on which of multiple annotation values to use based on the schema location that contributed the value.  This is intended to allow flexible usage.  Collecting the schema location facilitates such usage.  </p>
+<p id="rfc.section.10.1.p.2">For example, consider this schema, which uses annotations and assertions from the <a href="#json-schema-validation" class="xref">Validation specification</a>: </p>
+<p>Note that some lines are wrapped for clarity.  </p>
+<pre>
+
+{
+    "title": "Feature list",
+    "type": "array",
+        "items": [
+            {
+                "title": "Feature A",
+                "properties": {
+                    "enabled": {
+                        "$ref": "#/$defs/enabledToggle",
+                        "default": true
+                    }
+                }
+            },
+            {
+                "title": "Feature B",
+                "properties": {
+                    "enabled": {
+                        "description": "If set to null, Feature B
+                                        inherits the enabled
+                                        value from Feature A",
+                        "$ref": "#/$defs/enabledToggle"
+                    }
+                }
+            }
+        ]
+    },
+    "$defs": {
+        "enabledToggle": {
+            "title": "Enabled",
+            "description": "Whether the feature is enabled (true),
+                            disabled (false), or under
+                            automatic control (null)",
+            "type": ["boolean", "null"],
+            "default": null
+        }
+    }
+}
+
+                    </pre>
+<p id="rfc.section.10.1.p.3">In this example, both Feature A and Feature B make use of the re-usable "enabledToggle" schema.  That schema uses the "title", "description", and "default" annotations, none of which define special behavior for handling multiple values.  Therefore the application has to decide how to handle the additional "default" value for Feature A, and the additional "description" value for Feature B.  </p>
+<p id="rfc.section.10.1.p.4">The application programmer and the schema author need to agree on the usage.  For this example, let's assume that they agree that the most specific "default" value will be used, and any additional, more generic "default" values will be silently ignored.  Let's also assume that they agree that all "description" text is to be used, starting with the most generic, and ending with the most specific.  This requires the schema author to write descriptions that work when combined in this way.  </p>
+<p id="rfc.section.10.1.p.5">The application can use the schema location path to determine which values are which.  The values in the feature's immediate "enabled" property schema are more specific, while the values under the re-usable schema that is referenced to with "$ref" are more generic.  The schema location path will show whether each value was found by crossing a "$ref" or not.  </p>
+<p id="rfc.section.10.1.p.6">Feature A will therefore use a default value of true, while Feature B will use the generic default value of null.  Feature A will only have the generic description from the "enabledToggle" schema, while Feature B will use that description, and also append its locally defined description that explains how to interpret a null value.  </p>
+<p id="rfc.section.10.1.p.7">Note that there are other reasonable approaches that a different application might take.  For example, an application may consider the presence of two different values for "default" to be an error, regardless of their schema locations.  </p>
+<h1 id="rfc.section.10.2">
+<a href="#rfc.section.10.2">10.2.</a> Annotations and Assertions</h1>
+<p id="rfc.section.10.2.p.1">Schema objects that produce a false assertion result MUST NOT produce any annotation results, whether from their own keywords or from keywords in subschemas.  </p>
+<p id="rfc.section.10.2.p.2">Note that the overall schema results may still include annotations collected from other schema locations.  Given this schema: </p>
+<pre>
+
+{
+    "oneOf": [
+        {
+            "title": "Integer Value",
+            "type": "integer"
+        },
+        {
+            "title": "String Value",
+            "type": "string"
+        }
+    ]
+}
+
+                    </pre>
+<p id="rfc.section.10.2.p.3">And the instance <samp>"This is a string"</samp>, the title annotation "Integer Value" is discarded because the type assertion in that schema object fails.  The title annotation "String Value" is kept, as the instance passes the string type assertions.  </p>
+<h1 id="rfc.section.10.3">
+<a href="#rfc.section.10.3">10.3.</a> Annotations and Applicators</h1>
+<p id="rfc.section.10.3.p.1">In addition to possibly defining annotation results of their own, applicator keywords aggregate the annotations collected in their subschema(s) or referenced schema(s).  The rules for aggregating annotation values are defined by each annotation keyword, and are not directly affected by the logic used for combining assertion results.  </p>
+<h1 id="rfc.section.11">
+<a href="#rfc.section.11">11.</a> A Vocabulary for Applying Subschemas</h1>
+<p id="rfc.section.11.p.1">This section defines a vocabulary of applicator keywords that are RECOMMENDED for use as the basis of other vocabularies.  </p>
+<p id="rfc.section.11.p.2">Meta-schemas that do not use "$vocabulary" SHOULD be considered to require this vocabulary as if its URI were present with a value of true.  </p>
+<p id="rfc.section.11.p.3">The current URI for this vocabulary, known as the Applicator vocabulary, is: <span>&lt;</span><a href="https://json-schema.org/draft/2019-04/vocab/applicator">https://json-schema.org/draft/2019-04/vocab/applicator</a><span>&gt;</span>.  </p>
+<p id="rfc.section.11.p.4">The current URI for the corresponding meta-schema is: <span>&lt;</span><a href="https://json-schema.org/draft/2019-04/meta/applicator">https://json-schema.org/draft/2019-04/meta/applicator</a><span>&gt;</span>.  </p>
+<p id="rfc.section.11.p.5">Updated vocabulary and meta-schema URIs MAY be published between specification drafts in order to correct errors.  Implementations SHOULD consider URIs dated after this specification draft and before the next to indicate the same syntax and semantics as those listed here.  </p>
+<h1 id="rfc.section.11.1">
+<a href="#rfc.section.11.1">11.1.</a> Keyword Independence</h1>
+<p id="rfc.section.11.1.p.1">Schema keywords typically operate independently, without affecting each other's outcomes.  </p>
+<p id="rfc.section.11.1.p.2">For schema author convenience, there are some exceptions among the keywords in this vocabulary: </p>
+
+<ul class="empty">
+<li>"additionalProperties", whose behavior is defined in terms of "properties" and "patternProperties" </li>
+<li>"unevaluatedProperties", whose behavior is defined in terms of annotations from "properties", "patternProperties", "additionalProperties" and itself </li>
+<li>"additionalItems", whose behavior is defined in terms of "items" </li>
+<li>"unevaluatedItems", whose behavior is defined in terms of annotations from "items", "additionalItems" and itself </li>
+</ul>
+
+<p> </p>
+<h1 id="rfc.section.11.2">
+<a href="#rfc.section.11.2">11.2.</a> <a href="#in-place" id="in-place">Keywords for Applying Subschemas in Place</a>
+</h1>
+<p id="rfc.section.11.2.p.1">These keywords apply subschemas to the same location in the instance as the parent schema is being applied.  They allow combining or modifying the subschema results in various ways.  </p>
+<h1 id="rfc.section.11.2.1">
+<a href="#rfc.section.11.2.1">11.2.1.</a> <a href="#logic" id="logic">Keywords for Applying Subschemas With Boolean Logic</a>
+</h1>
+<p id="rfc.section.11.2.1.p.1">These keywords correspond to logical operators for combining or modifying the boolean assertion results of the subschemas.  They have no direct impact on annotation collection, although they enable the same annotation keyword to be applied to an instance location with different values.  Annotation keywords define their own rules for combining such values.  </p>
+<h1 id="rfc.section.11.2.1.1">
+<a href="#rfc.section.11.2.1.1">11.2.1.1.</a> <a href="#allOf" id="allOf">allOf</a>
+</h1>
+<p id="rfc.section.11.2.1.1.p.1">This keyword's value MUST be a non-empty array.  Each item of the array MUST be a valid JSON Schema.  </p>
+<p id="rfc.section.11.2.1.1.p.2">An instance validates successfully against this keyword if it validates successfully against all schemas defined by this keyword's value.  </p>
+<h1 id="rfc.section.11.2.1.2">
+<a href="#rfc.section.11.2.1.2">11.2.1.2.</a> anyOf</h1>
+<p id="rfc.section.11.2.1.2.p.1">This keyword's value MUST be a non-empty array.  Each item of the array MUST be a valid JSON Schema.  </p>
+<p id="rfc.section.11.2.1.2.p.2">An instance validates successfully against this keyword if it validates successfully against at least one schema defined by this keyword's value.  </p>
+<h1 id="rfc.section.11.2.1.3">
+<a href="#rfc.section.11.2.1.3">11.2.1.3.</a> oneOf</h1>
+<p id="rfc.section.11.2.1.3.p.1">This keyword's value MUST be a non-empty array.  Each item of the array MUST be a valid JSON Schema.  </p>
+<p id="rfc.section.11.2.1.3.p.2">An instance validates successfully against this keyword if it validates successfully against exactly one schema defined by this keyword's value.  </p>
+<h1 id="rfc.section.11.2.1.4">
+<a href="#rfc.section.11.2.1.4">11.2.1.4.</a> <a href="#not" id="not">not</a>
+</h1>
+<p id="rfc.section.11.2.1.4.p.1">This keyword's value MUST be a valid JSON Schema.  </p>
+<p id="rfc.section.11.2.1.4.p.2">An instance is valid against this keyword if it fails to validate successfully against the schema defined by this keyword.  </p>
+<h1 id="rfc.section.11.2.2">
+<a href="#rfc.section.11.2.2">11.2.2.</a> <a href="#conditional" id="conditional">Keywords for Applying Subschemas Conditionally</a>
+</h1>
+<p id="rfc.section.11.2.2.p.1">Three of these keywords work together to implement conditional application of a subschema based on the outcome of another subschema.  The fourth is a shortcut for a specific conditional case.  </p>
+<p id="rfc.section.11.2.2.p.2">"if", "then", and "else" MUST NOT interact with each other across subschema boundaries.  In other words, an "if" in one branch of an "allOf" MUST NOT have an impact on a "then" or "else" in another branch.  </p>
+<p id="rfc.section.11.2.2.p.3">There is no default behavior for "if", "then", or "else" when they are not present.  In particular, they MUST NOT be treated as if present with an empty schema, and when "if" is not present, both "then" and "else" MUST be entirely ignored.  </p>
+<h1 id="rfc.section.11.2.2.1">
+<a href="#rfc.section.11.2.2.1">11.2.2.1.</a> if</h1>
+<p id="rfc.section.11.2.2.1.p.1">This keyword's value MUST be a valid JSON Schema.  </p>
+<p id="rfc.section.11.2.2.1.p.2">This validation outcome of this keyword's subschema has no direct effect on the overall validation result.  Rather, it controls which of the "then" or "else" keywords are evaluated.  </p>
+<p id="rfc.section.11.2.2.1.p.3">Instances that successfully validate against this keyword's subschema MUST also be valid against the subschema value of the "then" keyword, if present.  </p>
+<p id="rfc.section.11.2.2.1.p.4">Instances that fail to validate against this keyword's subschema MUST also be valid against the subschema value of the "else" keyword, if present.  </p>
+<p id="rfc.section.11.2.2.1.p.5">If <a href="#annotations" class="xref">annotations</a> are being collected, they are collected from this keyword's subschema in the usual way, including when the keyword is present without either "then" or "else".  </p>
+<h1 id="rfc.section.11.2.2.2">
+<a href="#rfc.section.11.2.2.2">11.2.2.2.</a> then</h1>
+<p id="rfc.section.11.2.2.2.p.1">This keyword's value MUST be a valid JSON Schema.  </p>
+<p id="rfc.section.11.2.2.2.p.2">When "if" is present, and the instance successfully validates against its subschema, then validation succeeds against this keyword if the instance also successfully validates against this keyword's subschema.  </p>
+<p id="rfc.section.11.2.2.2.p.3">This keyword has no effect when "if" is absent, or when the instance fails to validate against its subschema.  Implementations MUST NOT evaluate the instance against this keyword, for either validation or annotation collection purposes, in such cases.  </p>
+<h1 id="rfc.section.11.2.2.3">
+<a href="#rfc.section.11.2.2.3">11.2.2.3.</a> else</h1>
+<p id="rfc.section.11.2.2.3.p.1">This keyword's value MUST be a valid JSON Schema.  </p>
+<p id="rfc.section.11.2.2.3.p.2">When "if" is present, and the instance fails to validate against its subschema, then validation succeeds against this keyword if the instance successfully validates against this keyword's subschema.  </p>
+<p id="rfc.section.11.2.2.3.p.3">This keyword has no effect when "if" is absent, or when the instance successfully validates against its subschema.  Implementations MUST NOT evaluate the instance against this keyword, for either validation or annotation collection purposes, in such cases.  </p>
+<h1 id="rfc.section.11.2.2.4">
+<a href="#rfc.section.11.2.2.4">11.2.2.4.</a> dependentSchemas</h1>
+<p id="rfc.section.11.2.2.4.p.1">This keyword specifies subschemas that are evaluated if the instance is an object and contains a certain property.  </p>
+<p id="rfc.section.11.2.2.4.p.2">This keyword's value MUST be an object.  Each value in the object MUST be a valid JSON Schema.  </p>
+<p id="rfc.section.11.2.2.4.p.3">If the object key is a property in the instance, the entire instance must validate against the subschema.  Its use is dependent on the presence of the property.  </p>
+<p id="rfc.section.11.2.2.4.p.4">Omitting this keyword has the same behavior as an empty object.  </p>
+<h1 id="rfc.section.11.3">
+<a href="#rfc.section.11.3">11.3.</a> Keywords for Applying Subschemas to Child Instances</h1>
+<p id="rfc.section.11.3.p.1">Each of these keywords defines a rule for applying its subschema(s) to child instances, specifically object properties and array items, and combining their results.  </p>
+<h1 id="rfc.section.11.3.1">
+<a href="#rfc.section.11.3.1">11.3.1.</a> Keywords for Applying Subschemas to Arrays</h1>
+<h1 id="rfc.section.11.3.1.1">
+<a href="#rfc.section.11.3.1.1">11.3.1.1.</a> items</h1>
+<p id="rfc.section.11.3.1.1.p.1">The value of "items" MUST be either a valid JSON Schema or an array of valid JSON Schemas.  </p>
+<p id="rfc.section.11.3.1.1.p.2">If "items" is a schema, validation succeeds if all elements in the array successfully validate against that schema.  </p>
+<p id="rfc.section.11.3.1.1.p.3">If "items" is an array of schemas, validation succeeds if each element of the instance validates against the schema at the same position, if any.  </p>
+<p id="rfc.section.11.3.1.1.p.4">This keyword produces an annotation value which is the largest index to which this keyword applied a subschema.  The value MAY be a boolean true if a subschema was applied to every index of the instance, such as when "items" is a schema.  </p>
+<p id="rfc.section.11.3.1.1.p.5">Annotation results for "items" keywords from multiple schemas applied to the same instance location are combined by setting the combined result to true if any of the values are true, and otherwise retaining the largest numerical value.  </p>
+<p id="rfc.section.11.3.1.1.p.6">Omitting this keyword has the same assertion behavior as an empty schema.  </p>
+<h1 id="rfc.section.11.3.1.2">
+<a href="#rfc.section.11.3.1.2">11.3.1.2.</a> <a href="#additionalItems" id="additionalItems">additionalItems</a>
+</h1>
+<p id="rfc.section.11.3.1.2.p.1">The value of "additionalItems" MUST be a valid JSON Schema.  </p>
+<p id="rfc.section.11.3.1.2.p.2">The behavior of this keyword depends on the presence and annotation result of "items" within the same schema object.  If "items" is present, and its annotation result is a number, validation succeeds if every instance element at an index greater than that number validates against "additionalItems".  </p>
+<p id="rfc.section.11.3.1.2.p.3">Otherwise, if "items" is absent or its annotation result is the boolean true, "additionalItems" MUST be ignored.  </p>
+<p id="rfc.section.11.3.1.2.p.4">If the "additionalItems" subschema is applied to any positions within the instance array, it produces an annotation result of boolean true, analogous to the single schema behavior of "items".  If any "additionalItems" keyword from any subschema applied to the same instance location produces an annotation value of true, then the combined result from these keywords is also true.  </p>
+<p id="rfc.section.11.3.1.2.p.5">Omitting this keyword has the same assertion behavior as an empty schema.  </p>
+<p id="rfc.section.11.3.1.2.p.6">Implementations MAY choose to implement or optimize this keyword in another way that produces the same effect, such as by directly checking for the presence and size of an "items" array.  Implementations that do not support annotation collection MUST do so.  </p>
+<h1 id="rfc.section.11.3.1.3">
+<a href="#rfc.section.11.3.1.3">11.3.1.3.</a> <a href="#unevaluatedItems" id="unevaluatedItems">unevaluatedItems</a>
+</h1>
+<p id="rfc.section.11.3.1.3.p.1">The value of "unevaluatedItems" MUST be a valid JSON Schema.  </p>
+<p id="rfc.section.11.3.1.3.p.2">The behavior of this keyword depends on the annotation results of adjacent keywords that apply to the instance location being validated.  Specifically, the annotations from "items" and  "additionalItems", which can come from those keywords when they are adjacent to the "unevaluatedItems" keyword.  Those two annotations, as well as "unevaluatedItems", can also result from any and all adjacent <a href="#in-place" class="xref">in-place applicator</a> keywords.  This includes but is not limited to the in-place applicators defined in this document.  </p>
+<p id="rfc.section.11.3.1.3.p.3">If an "items" annotation is present, and its annotation result is a number, and no "additionalItems" or "unevaluatedItems" annotation is present, then validation succeeds if every instance element at an index greater than the "items" annotation validates against "unevaluatedItems".  </p>
+<p id="rfc.section.11.3.1.3.p.4">Otherwise, if any "items", "additionalItems", or "unevaluatedItems" annotations are present with a value of boolean true, then "unevaluatedItems" MUST be ignored.  However, if none of these annotations are present, "unevaluatedItems" MUST be applied to all locations in the array.  </p>
+<p id="rfc.section.11.3.1.3.p.5">This means that "items", "additionalItems", and all in-place applicators MUST be evaluated before this keyword can be evaluated.  Authors of extension keywords MUST NOT define an in-place applicator that would need to be evaluated before this keyword.  </p>
+<p id="rfc.section.11.3.1.3.p.6">If the "unevaluatedItems" subschema is applied to any positions within the instance array, it produces an annotation result of boolean true, analogous to the single schema behavior of "items".  If any "unevaluatedItems" keyword from any subschema applied to the same instance location produces an annotation value of true, then the combined result from these keywords is also true.  </p>
+<p id="rfc.section.11.3.1.3.p.7">Omitting this keyword has the same assertion behavior as an empty schema.  </p>
+<p id="rfc.section.11.3.1.3.p.8">Implementations that do not collect annotations MUST raise an error upon encountering this keyword.  </p>
+<h1 id="rfc.section.11.3.1.4">
+<a href="#rfc.section.11.3.1.4">11.3.1.4.</a> contains</h1>
+<p id="rfc.section.11.3.1.4.p.1">The value of this keyword MUST be a valid JSON Schema.  </p>
+<p id="rfc.section.11.3.1.4.p.2">An array instance is valid against "contains" if at least one of its elements is valid against the given schema.  This keyword does not produce annotation results.  <a id="CREF7" class="info">[CREF7]<span class="info">Should it produce a set of the indices for which the array element is valid against the subschema?  "contains" does not affect "additionalItems" or any other current or proposed keyword, but the information could be useful, and implementation that collect annotations need to apply "contains" to every element anyway.  </span></a> </p>
+<h1 id="rfc.section.11.3.2">
+<a href="#rfc.section.11.3.2">11.3.2.</a> Keywords for Applying Subschemas to Objects</h1>
+<h1 id="rfc.section.11.3.2.1">
+<a href="#rfc.section.11.3.2.1">11.3.2.1.</a> properties</h1>
+<p id="rfc.section.11.3.2.1.p.1">The value of "properties" MUST be an object.  Each value of this object MUST be a valid JSON Schema.  </p>
+<p id="rfc.section.11.3.2.1.p.2">Validation succeeds if, for each name that appears in both the instance and as a name within this keyword's value, the child instance for that name successfully validates against the corresponding schema.  </p>
+<p id="rfc.section.11.3.2.1.p.3">The annotation result of this keyword is the set of instance property names matched by this keyword.  Annotation results for "properties" keywords from multiple schemas applied to the same instance location are combined by taking the union of the sets.  </p>
+<p id="rfc.section.11.3.2.1.p.4">Omitting this keyword has the same assertion behavior as an empty object.  </p>
+<h1 id="rfc.section.11.3.2.2">
+<a href="#rfc.section.11.3.2.2">11.3.2.2.</a> patternProperties</h1>
+<p id="rfc.section.11.3.2.2.p.1">The value of "patternProperties" MUST be an object. Each property name of this object SHOULD be a valid regular expression, according to the ECMA 262 regular expression dialect. Each property value of this object MUST be a valid JSON Schema.  </p>
+<p id="rfc.section.11.3.2.2.p.2">Validation succeeds if, for each instance name that matches any regular expressions that appear as a property name in this keyword's value, the child instance for that name successfully validates against each schema that corresponds to a matching regular expression.  </p>
+<p id="rfc.section.11.3.2.2.p.3">The annotation result of this keyword is the set of instance property names matched by this keyword.  Annotation results for "patternProperties" keywords from multiple schemas applied to the same instance location are combined by taking the union of the sets.  </p>
+<p id="rfc.section.11.3.2.2.p.4">Omitting this keyword has the same assertion behavior as an empty object.  </p>
+<h1 id="rfc.section.11.3.2.3">
+<a href="#rfc.section.11.3.2.3">11.3.2.3.</a> <a href="#additionalProperties" id="additionalProperties">additionalProperties</a>
+</h1>
+<p id="rfc.section.11.3.2.3.p.1">The value of "additionalProperties" MUST be a valid JSON Schema.  </p>
+<p id="rfc.section.11.3.2.3.p.2">The behavior of this keyword depends on the presence and annotation results of "properties" and "patternProperties" within the same schema object.  Validation with "additionalProperties" applies only to the child values of instance names that do not appear in the annotation results of either "properties" or "patternProperties".  </p>
+<p id="rfc.section.11.3.2.3.p.3">For all such properties, validation succeeds if the child instance validates against the "additionalProperties" schema.  </p>
+<p id="rfc.section.11.3.2.3.p.4">The annotation result of this keyword is the set of instance property names validated by this keyword's subschema.  Annotation results for "additionalProperties" keywords from multiple schemas applied to the same instance location are combined by taking the union of the sets.  </p>
+<p id="rfc.section.11.3.2.3.p.5">Omitting this keyword has the same assertion behavior as an empty schema.  </p>
+<p id="rfc.section.11.3.2.3.p.6">Implementations MAY choose to implement or optimize this keyword in another way that produces the same effect, such as by directly checking the names in "properties" and the patterns in "patternProperties" against the instance property set.  Implementations that do not support annotation collection MUST do so.  </p>
+<h1 id="rfc.section.11.3.2.4">
+<a href="#rfc.section.11.3.2.4">11.3.2.4.</a> <a href="#unevaluatedProperties" id="unevaluatedProperties">unevaluatedProperties</a>
+</h1>
+<p id="rfc.section.11.3.2.4.p.1">The value of "unevaluatedProperties" MUST be a valid JSON Schema.  </p>
+<p id="rfc.section.11.3.2.4.p.2">The behavior of this keyword depends on the annotation results of adjacent keywords that apply to the instance location being validated.  Specifically, the annotations from "properties", "patternProperties", and "additionalProperties", which can come from those keywords when they are adjacent to the "unevaluatedProperties" keyword.  Those three annotations, as well as "unevaluatedProperties", can also result from any and all adjacent <a href="#in-place" class="xref">in-place applicator</a> keywords.  This includes but is not limited to the in-place applicators defined in this document.  </p>
+<p id="rfc.section.11.3.2.4.p.3">Validation with "unevaluatedProperties" applies only to the child values of instance names that do not appear in the "properties", "patternProperties", "additionalProperties", or "unevaluatedProperties" annotation results that apply to the instance location being validated.  </p>
+<p id="rfc.section.11.3.2.4.p.4">For all such properties, validation succeeds if the child instance validates against the "unevaluatedProperties" schema.  </p>
+<p id="rfc.section.11.3.2.4.p.5">This means that "properties", "patternProperties", "additionalProperties", and all in-place applicators MUST be evaluated before this keyword can be evaluated.  Authors of extension keywords MUST NOT define an in-place applicator that would need to be evaluated before this keyword.  </p>
+<p id="rfc.section.11.3.2.4.p.6">The annotation result of this keyword is the set of instance property names validated by this keyword's subschema.  Annotation results for "unevaluatedProperties" keywords from multiple schemas applied to the same instance location are combined by taking the union of the sets.  </p>
+<p id="rfc.section.11.3.2.4.p.7">Omitting this keyword has the same assertion behavior as an empty schema.  </p>
+<p id="rfc.section.11.3.2.4.p.8">Implementations that do not collect annotations MUST raise an error upon encountering this keyword.  </p>
+<h1 id="rfc.section.11.3.2.5">
+<a href="#rfc.section.11.3.2.5">11.3.2.5.</a> propertyNames</h1>
+<p id="rfc.section.11.3.2.5.p.1">The value of "propertyNames" MUST be a valid JSON Schema.  </p>
+<p id="rfc.section.11.3.2.5.p.2">If the instance is an object, this keyword validates if every property name in the instance validates against the provided schema.  Note the property name that the schema is testing will always be a string.  </p>
+<p id="rfc.section.11.3.2.5.p.3">Omitting this keyword has the same behavior as an empty schema.  </p>
+<h1 id="rfc.section.12">
+<a href="#rfc.section.12">12.</a> <a href="#output" id="output">Output Formatting</a>
+</h1>
+<p id="rfc.section.12.p.1">JSON Schema is defined to be platform-independent.  As such, to increase compatibility across platforms, implementations SHOULD conform to a standard validation output format.  This section describes the minimum requirements that consumers will need to properly interpret validation results.  </p>
+<h1 id="rfc.section.12.1">
+<a href="#rfc.section.12.1">12.1.</a> Format</h1>
+<p id="rfc.section.12.1.p.1">JSON Schema output is defined using the JSON Schema data instance model as described in section 4.2.1.  Implementations MAY deviate from this as supported by their specific languages and platforms, however it is RECOMMENDED that the output be convertible to the JSON format defined herein via serialization or other means.  </p>
+<h1 id="rfc.section.12.2">
+<a href="#rfc.section.12.2">12.2.</a> Output Formats</h1>
+<p id="rfc.section.12.2.p.1">This specification defines four output formats.  See the "Output Structure" section for the requirements of each format.  </p>
+
+<ul class="empty">
+<li>Flag - A boolean which simply indicates the overall validation result with no further details.  </li>
+<li>Basic - Provides validation information in a flat list structure.  </li>
+<li>Detailed - Provides validation information in a condensed hierarchical structure based on the structure of the schema.  </li>
+<li>Verbose - Provides validation information in an uncondensed hierarchical structure that matches the exact structure of the schema.  </li>
+</ul>
+
+<p> An implementation SHOULD provide at least the "flag", "basic", or "detailed" format and MAY provide the "verbose" format.  If it provides one or more of the complex formats, it MUST also provide the "flag" format. Implementations SHOULD specify in their documentation which formats they support.  </p>
+<h1 id="rfc.section.12.3">
+<a href="#rfc.section.12.3">12.3.</a> Minimum Information</h1>
+<p id="rfc.section.12.3.p.1">Beyond the simplistic "flag" output, additional information is useful to aid in debugging a schema or instance.  Each sub-result SHOULD contain the information contained within this section at a minimum.  </p>
+<p id="rfc.section.12.3.p.2">A single object that contains all of these components is considered an output unit.  </p>
+<p id="rfc.section.12.3.p.3">Implementations MAY elect to provide additional information.  </p>
+<h1 id="rfc.section.12.3.1">
+<a href="#rfc.section.12.3.1">12.3.1.</a> Keyword Relative Location</h1>
+<p id="rfc.section.12.3.1.p.1">The relative location of the validating keyword that follows the validation path.  The value MUST be expressed as a JSON Pointer, and it MUST include any by-reference applicators such as "$ref" or "$recursiveRef".  </p>
+<pre>
+
+#/properties/minLength/$ref/minimum
+
+                        </pre>
+<p id="rfc.section.12.3.1.p.2">Note that this pointer may not be resolvable due to the inclusion of these applicator keywords.  </p>
+<p id="rfc.section.12.3.1.p.3">The JSON key for this information is "keywordLocation".  </p>
+<h1 id="rfc.section.12.3.2">
+<a href="#rfc.section.12.3.2">12.3.2.</a> Keyword Absolute Location</h1>
+<p id="rfc.section.12.3.2.p.1">The absolute, dereferenced location of the validating keyword.  The value MUST be expressed as an absolute URI, and it MUST NOT include by-reference applicators such as "$ref" or "$recursiveRef".  </p>
+<pre>
+
+http://json-schema.org/draft/2019-04/schema#/$defs/nonNegativeInteger/minimum
+
+                        </pre>
+<p id="rfc.section.12.3.2.p.2">This information MAY be omitted only if either the relative location contains no references or if the schema does not declare an absolute URI as its "$id".  </p>
+<p id="rfc.section.12.3.2.p.3">The JSON key for this information is "absoluteKeywordLocation".  </p>
+<h1 id="rfc.section.12.3.3">
+<a href="#rfc.section.12.3.3">12.3.3.</a> Instance Location</h1>
+<p id="rfc.section.12.3.3.p.1">The location of the JSON value within the instance being validated.  The value MUST be expressed as a JSON Pointer.  </p>
+<p id="rfc.section.12.3.3.p.2">The JSON key for this information is "instanceLocation".  </p>
+<h1 id="rfc.section.12.3.4">
+<a href="#rfc.section.12.3.4">12.3.4.</a> Error or Annotation</h1>
+<p id="rfc.section.12.3.4.p.1">The error or annotation that is produced by the validation.  </p>
+<p id="rfc.section.12.3.4.p.2">For errors, the specific wording for the message is not defined by this specification.  Implementations will need to provide this.  </p>
+<p id="rfc.section.12.3.4.p.3">The JSON key for failed validations is "error"; for successful validations it is "annotation".  </p>
+<h1 id="rfc.section.12.3.5">
+<a href="#rfc.section.12.3.5">12.3.5.</a> Nested Results</h1>
+<p id="rfc.section.12.3.5.p.1">For the two hierarchical structures, this property will hold nested errors and annotations.  </p>
+<p id="rfc.section.12.3.5.p.2">The JSON key for nested results in failed validations is "errors"; for successful validations it is "annotations".  </p>
+<h1 id="rfc.section.12.4">
+<a href="#rfc.section.12.4">12.4.</a> Output Structure</h1>
+<p id="rfc.section.12.4.p.1">The output MUST be an object containing a boolean property named "valid".  When additional information about the result is required, the output MUST also contain "errors" or "annotations" as described below.  </p>
+
+<ul class="empty">
+<li>"valid" - a boolean value indicating the overall validation success or failure </li>
+<li>"errors" - the collection of errors or annotations produced by a failed validation </li>
+<li>"annotations" - the collection of errors or annotations produced by a successful validation </li>
+</ul>
+
+<p> For these examples, the following schema and instance will be used.  </p>
+<pre>
+
+{
+  "$id": "http://example.com/polygon#",
+  "$schema": "http://json-schema.org/draft/2019-04/schema#",
+  "$defs": {
+    "point": {
+      "type": "object",
+      "properties": {
+        "x": { "type": "number" },
+        "y": { "type": "number" }
+      },
+      "additionalProperties": false,
+      "required": [ "x", "y" ]
+    }
+  },
+  "type": "array",
+  "items": { "$ref": "#/$defs/point" },
+  "minItems": 3
+}
+
+[
+  {
+    "x": 2.5,
+    "y": 1.3,
+  },
+  {
+    "x": 1,
+    "z": 6.7
+  }
+]
+
+                    </pre>
+<p id="rfc.section.12.4.p.2">This instance will fail validation and produce errors, but it's trivial to deduce examples for passing schemas that produce annotations.  </p>
+<p id="rfc.section.12.4.p.3">Specifically, the errors it will produce are: </p>
+
+<ul class="empty">
+<li>The second element in the "vertices" property is missing a "y" property.  </li>
+<li>The second element in the "vertices" property has a disallowed "z" property.  </li>
+<li>There are only two vertices, but three are required.  </li>
+</ul>
+
+<p> Note that neither the error message property nor its wording as depicted in these examples is not a requirement of this specification.  Implementations SHOULD craft error messages tailored for their audience.  </p>
+<h1 id="rfc.section.12.4.1">
+<a href="#rfc.section.12.4.1">12.4.1.</a> Flag</h1>
+<p id="rfc.section.12.4.1.p.1">In the simplest case, merely the boolean result for the "valid" valid property needs to be fulfilled.  </p>
+<pre>
+
+{
+  "valid": false
+}
+
+                        </pre>
+<p id="rfc.section.12.4.1.p.2">Because no errors or annotations are returned with this format, it is RECOMMENDED that implementations use short-circuiting logic to return failure or success as soon as the outcome can be determined.  For example, if an "anyOf" keyword contains five sub-schemas, and the second one passes, there is no need to check the other three.  The logic can simply return with success.  </p>
+<h1 id="rfc.section.12.4.2">
+<a href="#rfc.section.12.4.2">12.4.2.</a> Basic</h1>
+<p id="rfc.section.12.4.2.p.1">The "Basic" structure is a flat list of output units.  </p>
+<pre>
+
+{
+  "valid": false,
+  "errors": [
+    {
+      "keywordLocation": "#",
+      "instanceLocation": "#",
+      "error": "A subschema had errors."
+    },
+    {
+      "keywordLocation": "#/items/$ref",
+      "absoluteKeywordLocation":
+        "http://example.com/polygon#/definitions/point",
+      "instanceLocation": "#/1",
+      "error": "A subschema had errors."
+    },
+    {
+      "keywordLocation": "#/items/$ref/required",
+      "absoluteKeywordLocation":
+        "http://example.com/polygon#/definitions/point/required",
+      "instanceLocation": "#/1",
+      "error": "Required property 'y' not found."
+    },
+    {
+      "keywordLocation": "#/items/$ref/additionalProperties",
+      "absoluteKeywordLocation":
+        "http://example.com/polygon#/definitions/point/additionalProperties",
+      "instanceLocation": "#/1/z",
+      "error": "Additional property 'z' found but was invalid."
+    },
+    {
+      "keywordLocation": "#/minItems",
+      "instanceLocation": "#",
+      "error": "Expected at least 3 items but found 2"
+    }
+  ]
+}
+
+                        </pre>
+<h1 id="rfc.section.12.4.3">
+<a href="#rfc.section.12.4.3">12.4.3.</a> Detailed</h1>
+<p id="rfc.section.12.4.3.p.1">The "Detailed" structure is based on the schema and can be more readable for both humans and machines.  Having the structure organized this way makes associations between the errors more apparent.  For example, the fact that the missing "y" property and the extra "z" property both stem from the same location in the instance is not immediately obvious in the "Basic" structure.  In a hierarchy, the correllation is more easily identified.  </p>
+<p id="rfc.section.12.4.3.p.2">The following rules govern the construction of the results object: </p>
+
+<ul class="empty">
+<li>All applicator keywords ("*Of", "$ref", "if"/"then"/"else", etc.) require a node.  </li>
+<li>Nodes that have no children are removed.  </li>
+<li>Nodes that have a single child are replaced by the child.  </li>
+</ul>
+
+<p> Branch nodes do not require an error message or an annotation.  </p>
+<pre>
+
+{
+  "valid": false,
+  "keywordLocation": "#",
+  "instanceLocation": "#",
+  "errors": [
+    {
+      "valid": false,
+      "keywordLocation": "#/items/$ref",
+      "absoluteKeywordLocation":
+        "http://example.com/polygon#/definitions/point",
+      "instanceLocation": "#/1",
+      "errors": [
+        {
+          "valid": false,
+          "keywordLocation": "#/items/$ref/required",
+          "absoluteKeywordLocation":
+            "http://example.com/polygon#/definitions/point/required",
+          "instanceLocation": "#/1",
+          "error": "Required property 'y' not found."
+        },
+        {
+          "valid": false,
+          "keywordLocation": "#/items/$ref/additionalProperties",
+          "absoluteKeywordLocation":
+            "http://example.com/polygon#/definitions/point/additionalProperties",
+          "instanceLocation": "#/1/z",
+          "error": "Additional property 'z' found but was invalid."
+        }
+      ]
+    },
+    {
+      "valid": false,
+      "keywordLocation": "#/minItems",
+      "instanceLocation": "#",
+      "error": "Expected at least 3 items but found 2"
+    }
+  ]
+}
+
+                        </pre>
+<h1 id="rfc.section.12.4.4">
+<a href="#rfc.section.12.4.4">12.4.4.</a> Verbose</h1>
+<p id="rfc.section.12.4.4.p.1">The "Verbose" structure is a fully realized hierarchy that exactly matches that of the schema.  This structure has applications in form generation and validation where the error's location is important.  </p>
+<p id="rfc.section.12.4.4.p.2">The primary difference between this and the "Detailed" structure is that all results are returned.  This includes sub-schema validation results that would otherwise be removed (e.g. annotations for failed validations, successful validations inside a `not` keyword, etc.).  Because of this, it is RECOMMENDED that each node also carry a `valid` property to indicate the validation result for that node.  </p>
+<p id="rfc.section.12.4.4.p.3">Because this output structure can be quite large, a smaller example is given here for brevity.  The URI of the full output structure of the example above is: <span>&lt;</span><a href="https://json-schema.org/draft/2019-04/output/verbose-example">https://json-schema.org/draft/2019-04/output/verbose-example</a><span>&gt;</span>.  </p>
+<pre>
+
+// schema
+{
+  "$id": "http://example.com/polygon#",
+  "$schema": "http://json-schema.org/draft/2019-04/schema#",
+  "type": "object",
+  "properties": {
+    "validProp": true,
+  },
+  "additionalProperties": false
+}
+
+// instance
+{
+  "validProp": 5,
+  "disallowedProp": "value"
+}
+
+// result
+{
+  "valid": false,
+  "keywordLocation": "#",
+  "instanceLocation": "#",
+  "errors": [
+    {
+      "valid": true,
+      "keywordLocation": "#/type",
+      "instanceLocation": "#"
+    },
+    {
+      "valid": true,
+      "keywordLocation": "#/properties",
+      "instanceLocation": "#"
+    },
+    {
+      "valid": false,
+      "keywordLocation": "#/additionalProperties",
+      "instanceLocation": "#",
+      "errors": [
+        {
+          "valid": false,
+          "keywordLocation": "#/additionalProperties",
+          "instanceLocation": "#/disallowedProp",
+          "error": "Additional property 'disallowedProp' found but was invalid."
+        }
+      ]
+    }
+  ]
+}
+
+                        </pre>
+<h1 id="rfc.section.12.4.5">
+<a href="#rfc.section.12.4.5">12.4.5.</a> Output validation schemas</h1>
+<p id="rfc.section.12.4.5.p.1">For convenience, JSON Schema has been provided to validate output generated by implementations.  Its URI is: <span>&lt;</span><a href="https://json-schema.org/draft/2019-04/output/schema">https://json-schema.org/draft/2019-04/output/schema</a><span>&gt;</span>.  </p>
+<h1 id="rfc.section.13">
+<a href="#rfc.section.13">13.</a> <a href="#hypermedia" id="hypermedia">Usage for Hypermedia</a>
+</h1>
+<p id="rfc.section.13.p.1">JSON has been adopted widely by HTTP servers for automated APIs and robots. This section describes how to enhance processing of JSON documents in a more RESTful manner when used with protocols that support media types and <a href="#RFC8288" class="xref">Web linking</a>.  </p>
+<h1 id="rfc.section.13.1">
+<a href="#rfc.section.13.1">13.1.</a> Linking to a Schema</h1>
+<p id="rfc.section.13.1.p.1">It is RECOMMENDED that instances described by a schema provide a link to a downloadable JSON Schema using the link relation "describedby", as defined by <a href="#W3C.REC-ldp-20150226" class="xref">Linked Data Protocol 1.0, section 8.1</a>.  </p>
+<p id="rfc.section.13.1.p.2">In HTTP, such links can be attached to any response using the <a href="#RFC8288" class="xref">Link header</a>. An example of such a header would be: </p>
+<pre>
+
+Link: &lt;http://example.com/my-hyper-schema#&gt;; rel="describedby"
+
+                    </pre>
+<h1 id="rfc.section.13.2">
+<a href="#rfc.section.13.2">13.2.</a> <a href="#parameter" id="parameter">Identifying a Schema via a Media Type Parameter</a>
+</h1>
+<p id="rfc.section.13.2.p.1">Media types MAY allow for a "schema" media type parameter, which gives HTTP servers the ability to perform Content-Type Negotiation based on schema.  The media-type parameter MUST be a whitespace-separated list of URIs (i.e. relative references are invalid).  </p>
+<p id="rfc.section.13.2.p.2">When using the media type application/schema-instance+json, the "schema" parameter MUST be supplied.  </p>
+<p id="rfc.section.13.2.p.3">When using the media type application/schema+json, the "schema" parameter MAY be supplied. If supplied, it SHOULD contain the same URI as identified by the "$schema" keyword, and MAY contain additional URIs.  The "$schema" URI MUST be considered the schema's canonical meta-schema, regardless of the presence of alternative or additional meta-schemas as a media type parameter.  </p>
+<p id="rfc.section.13.2.p.4">The schema URI is opaque and SHOULD NOT automatically be dereferenced.  If the implementation does not understand the semantics of the provided schema, the implementation can instead follow the "describedby" links, if any, which may provide information on how to handle the schema.  Since "schema" doesn't necessarily point to a network location, the "describedby" relation is used for linking to a downloadable schema.  However, for simplicity, schema authors should make these URIs point to the same resource when possible.  </p>
+<p id="rfc.section.13.2.p.5">In HTTP, the media-type parameter would be sent inside the Content-Type header: </p>
+<pre>
+
+Content-Type: application/json;
+          schema="http://example.com/my-hyper-schema#"
+
+                    </pre>
+<p id="rfc.section.13.2.p.6">Multiple schemas are whitespace separated, and indicate that the instance conforms to all of the listed schemas: </p>
+<pre>
+
+Content-Type: application/json;
+          schema="http://example.com/alice http://example.com/bob"
+
+                    </pre>
+<p id="rfc.section.13.2.p.7">Media type parameters are also used in HTTP's Accept request header: </p>
+<pre>
+
+Accept: application/json;
+          schema="http://example.com/qiang http://example.com/li",
+        application/json;
+          schema="http://example.com/kumar"
+
+                    </pre>
+<p id="rfc.section.13.2.p.8">As with Content-Type, multiple schema parameters in the same string requests an instance that conforms to all of the listed schemas.  </p>
+<p id="rfc.section.13.2.p.9">Unlike Content-Type, Accept can contain multiple values to indicate that the client can accept several media types.  In the above example, note that the two media types differ only by their schema parameter values.  This requests an application/json representation that conforms to at least one of the identified schemas.  </p>
+<p><a id="CREF8" class="info">[CREF8]<span class="info">This paragraph assumes that we can register a "schema" link relation.  Should we instead specify something like "tag:json-schema.org,2017:schema" for now? </span></a> HTTP can also send the "schema" in a Link, though this may impact media-type semantics and Content-Type negotiation if this replaces the media-type parameter entirely: </p>
+<pre>
+
+Link: &lt;/alice&gt;;rel="schema", &lt;/bob&gt;;rel="schema"
+
+                    </pre>
+<h1 id="rfc.section.13.3">
+<a href="#rfc.section.13.3">13.3.</a> Usage Over HTTP</h1>
+<p id="rfc.section.13.3.p.1">When used for hypermedia systems over a network, <a href="#RFC7231" class="xref">HTTP</a> is frequently the protocol of choice for distributing schemas. Misbehaving clients can pose problems for server maintainers if they pull a schema over the network more frequently than necessary, when it's instead possible to cache a schema for a long period of time.  </p>
+<p id="rfc.section.13.3.p.2">HTTP servers SHOULD set long-lived caching headers on JSON Schemas.  HTTP clients SHOULD observe caching headers and not re-request documents within their freshness period.  Distributed systems SHOULD make use of a shared cache and/or caching proxy.  </p>
+<pre>
+
+User-Agent: product-name/5.4.1 so-cool-json-schema/1.0.2 curl/7.43.0
+
+                        </pre>
+<p id="rfc.section.13.3.p.3">Clients SHOULD set or prepend a User-Agent header specific to the JSON Schema implementation or software product. Since symbols are listed in decreasing order of significance, the JSON Schema library name/version should precede the more generic HTTP library name (if any). For example: </p>
+<p id="rfc.section.13.3.p.4">Clients SHOULD be able to make requests with a "From" header so that server operators can contact the owner of a potentially misbehaving script.  </p>
+<h1 id="rfc.section.14">
+<a href="#rfc.section.14">14.</a> <a href="#security" id="security">Security Considerations</a>
+</h1>
+<p id="rfc.section.14.p.1">Both schemas and instances are JSON values. As such, all security considerations defined in <a href="#RFC8259" class="xref">RFC 8259</a> apply.  </p>
+<p id="rfc.section.14.p.2">Instances and schemas are both frequently written by untrusted third parties, to be deployed on public Internet servers.  Validators should take care that the parsing and validating against schemas doesn't consume excessive system resources.  Validators MUST NOT fall into an infinite loop.  </p>
+<p id="rfc.section.14.p.3">Servers MUST ensure that malicious parties can't change the functionality of existing schemas by uploading a schema with a pre-existing or very similar "$id".  </p>
+<p id="rfc.section.14.p.4">Individual JSON Schema vocabularies are liable to also have their own security considerations. Consult the respective specifications for more information.  </p>
+<p id="rfc.section.14.p.5">Schema authors should take care with "$comment" contents, as a malicious implementation can display them to end-users in violation of a spec, or fail to strip them if such behavior is expected.  </p>
+<p id="rfc.section.14.p.6">A malicious schema author could place executable code or other dangerous material within a "$comment".  Implementations MUST NOT parse or otherwise take action based on "$comment" contents.  </p>
+<h1 id="rfc.section.15">
+<a href="#rfc.section.15">15.</a> IANA Considerations</h1>
+<h1 id="rfc.section.15.1">
+<a href="#rfc.section.15.1">15.1.</a> application/schema+json</h1>
+<p id="rfc.section.15.1.p.1">The proposed MIME media type for JSON Schema is defined as follows: </p>
+
+<ul class="empty">
+<li>Type name: application</li>
+<li>Subtype name: schema+json</li>
+<li>Required parameters: N/A</li>
+<li>Optional parameters: <dl>
+<dt>schema:</dt>
+<dd style="margin-left: 8">A non-empty list of space-separated URIs, each identifying a JSON Schema resource.  The instance SHOULD successfully validate against at least one of these meta-schemas.  Non-validating meta-schemas MAY be included for purposes such as allowing clients to make use of older versions of a meta-schema as long as the runtime instance validates against that older version.  </dd>
+</dl>
+<p> </p>
+</li>
+<li>Encoding considerations: Encoding considerations are identical to those specified for the "application/json" media type.  See <a href="#RFC8259" class="xref">JSON</a>.  </li>
+<li>Security considerations: See Section <a href="#security" class="xref">14</a> above.  </li>
+<li>Interoperability considerations: See Sections <a href="#language" class="xref">6.2</a>, <a href="#integers" class="xref">6.3</a>, and <a href="#regex" class="xref">6.4</a> above.  </li>
+<li>Fragment identifier considerations: See Section <a href="#fragments" class="xref">5</a> </li>
+</ul>
+
+<p> </p>
+<h1 id="rfc.section.15.2">
+<a href="#rfc.section.15.2">15.2.</a> application/schema-instance+json</h1>
+<p id="rfc.section.15.2.p.1">The proposed MIME media type for JSON Schema Instances that require a JSON Schema-specific media type is defined as follows: </p>
+
+<ul class="empty">
+<li>Type name: application</li>
+<li>Subtype name: schema-instance+json</li>
+<li>Required parameters: <dl>
+<dt>schema:</dt>
+<dd style="margin-left: 8">A non-empty list of space-separated URIs, each identifying a JSON Schema resource.  The instance SHOULD successfully validate against at least one of these schemas.  Non-validating schemas MAY be included for purposes such as allowing clients to make use of older versions of a schema as long as the runtime instance validates against that older version.  </dd>
+</dl>
+<p> </p>
+</li>
+<li>Encoding considerations: Encoding considerations are identical to those specified for the "application/json" media type.  See <a href="#RFC8259" class="xref">JSON</a>.  </li>
+<li>Security considerations: See Section <a href="#security" class="xref">14</a> above.  </li>
+<li>Interoperability considerations: See Sections <a href="#language" class="xref">6.2</a>, <a href="#integers" class="xref">6.3</a>, and <a href="#regex" class="xref">6.4</a> above.  </li>
+<li>Fragment identifier considerations: See Section <a href="#fragments" class="xref">5</a> </li>
+</ul>
+
+<p> </p>
+<h1 id="rfc.references">
+<a href="#rfc.references">16.</a> References</h1>
+<h1 id="rfc.references.1">
+<a href="#rfc.references.1">16.1.</a> Normative References</h1>
+<table><tbody>
+<tr>
+<td class="reference"><b id="ecma262">[ecma262]</b></td>
+<td class="top">"<a href="http://www.ecma-international.org/publications/files/ECMA-ST/Ecma-262.pdf">ECMA 262 specification</a>"</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC2119">[RFC2119]</b></td>
+<td class="top">
+<a>Bradner, S.</a>, "<a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>", BCP 14, RFC 2119, DOI 10.17487/RFC2119, March 1997.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC3986">[RFC3986]</b></td>
+<td class="top">
+<a>Berners-Lee, T.</a>, <a>Fielding, R.</a> and <a>L. Masinter</a>, "<a href="https://tools.ietf.org/html/rfc3986">Uniform Resource Identifier (URI): Generic Syntax</a>", STD 66, RFC 3986, DOI 10.17487/RFC3986, January 2005.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC6839">[RFC6839]</b></td>
+<td class="top">
+<a>Hansen, T.</a> and <a>A. Melnikov</a>, "<a href="https://tools.ietf.org/html/rfc6839">Additional Media Type Structured Syntax Suffixes</a>", RFC 6839, DOI 10.17487/RFC6839, January 2013.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC6901">[RFC6901]</b></td>
+<td class="top">
+<a>Bryan, P.</a>, <a>Zyp, K.</a> and <a>M. Nottingham</a>, "<a href="https://tools.ietf.org/html/rfc6901">JavaScript Object Notation (JSON) Pointer</a>", RFC 6901, DOI 10.17487/RFC6901, April 2013.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC8259">[RFC8259]</b></td>
+<td class="top">
+<a>Bray, T.</a>, "<a href="https://tools.ietf.org/html/rfc8259">The JavaScript Object Notation (JSON) Data Interchange Format</a>", STD 90, RFC 8259, DOI 10.17487/RFC8259, December 2017.</td>
+</tr>
+<tr>
+<td class="reference"><b id="W3C.REC-ldp-20150226">[W3C.REC-ldp-20150226]</b></td>
+<td class="top">
+<a>Speicher, S.</a>, <a>Arwe, J.</a> and <a>A. Malhotra</a>, "<a href="http://www.w3.org/TR/2015/REC-ldp-20150226">Linked Data Platform 1.0</a>", World Wide Web Consortium Recommendation REC-ldp-20150226, February 2015.</td>
+</tr>
+</tbody></table>
+<h1 id="rfc.references.2">
+<a href="#rfc.references.2">16.2.</a> Informative References</h1>
+<table><tbody>
+<tr>
+<td class="reference"><b id="json-hyper-schema">[json-hyper-schema]</b></td>
+<td class="top">
+<a>Andrews, H.</a> and <a>A. Wright</a>, "<a href="https://tools.ietf.org/html/draft-handrews-json-schema-hyperschema-02">JSON Hyper-Schema: A Vocabulary for Hypermedia Annotation of JSON</a>", Internet-Draft draft-handrews-json-schema-hyperschema-02, November 2017.</td>
+</tr>
+<tr>
+<td class="reference"><b id="json-schema-validation">[json-schema-validation]</b></td>
+<td class="top">
+<a>Wright, A.</a>, <a>Andrews, H.</a> and <a>G. Luff</a>, "<a href="https://tools.ietf.org/html/draft-handrews-json-schema-validation-02">JSON Schema Validation: A Vocabulary for Structural Validation of JSON</a>", Internet-Draft draft-handrews-json-schema-validation-02, November 2017.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC7049">[RFC7049]</b></td>
+<td class="top">
+<a>Bormann, C.</a> and <a>P. Hoffman</a>, "<a href="https://tools.ietf.org/html/rfc7049">Concise Binary Object Representation (CBOR)</a>", RFC 7049, DOI 10.17487/RFC7049, October 2013.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC7231">[RFC7231]</b></td>
+<td class="top">
+<a>Fielding, R.</a> and <a>J. Reschke</a>, "<a href="https://tools.ietf.org/html/rfc7231">Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</a>", RFC 7231, DOI 10.17487/RFC7231, June 2014.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC8288">[RFC8288]</b></td>
+<td class="top">
+<a>Nottingham, M.</a>, "<a href="https://tools.ietf.org/html/rfc8288">Web Linking</a>", RFC 8288, DOI 10.17487/RFC8288, October 2017.</td>
+</tr>
+<tr>
+<td class="reference"><b id="W3C.WD-fragid-best-practices-20121025">[W3C.WD-fragid-best-practices-20121025]</b></td>
+<td class="top">
+<a>Tennison, J.</a>, "<a href="http://www.w3.org/TR/2012/WD-fragid-best-practices-20121025">Best Practices for Fragment Identifiers and Media Type Definitions</a>", World Wide Web Consortium WD WD-fragid-best-practices-20121025, October 2012.</td>
+</tr>
+</tbody></table>
+<h1 id="rfc.appendix.A">
+<a href="#rfc.appendix.A">Appendix A.</a> Acknowledgments</h1>
+<p id="rfc.section.A.p.1">Thanks to Gary Court, Francis Galiegue, Kris Zyp, and Geraint Luff for their work on the initial drafts of JSON Schema.  </p>
+<p id="rfc.section.A.p.2">Thanks to Jason Desrosiers, Daniel Perrett, Erik Wilde, Ben Hutton, Evgeny Poberezkin, Brad Bowman, Gowry Sankar, Donald Pipowitch, and Dave Finlay for their submissions and patches to the document.  </p>
+<h1 id="rfc.appendix.B">
+<a href="#rfc.appendix.B">Appendix B.</a> ChangeLog</h1>
+<p><a id="CREF9" class="info">[CREF9]<span class="info">This section to be removed before leaving Internet-Draft status.</span></a> </p>
+<p></p>
+
+<dl>
+<dt>draft-handrews-json-schema-02</dt>
+<dd style="margin-left: 8">
+<ul>
+<li>Update to RFC 8359 for JSON specification</li>
+<li>Moved "definitions" from the Validation specification here as "$defs"</li>
+<li>Moved applicator keywords from the Validation specification as their own vocabulary</li>
+<li>Moved the schema form of "dependencies" from the Validation specification as "dependentSchemas"</li>
+<li>Formalized annotation collection</li>
+<li>Specified recommended output formats</li>
+<li>Defined keyword interactions in terms of annotation and assertion results</li>
+<li>Added "unevaluatedProperties" and "unevaluatedItems"</li>
+<li>Define "$ref" behavior in terms of the assertion, applicator, and annotation model</li>
+<li>Allow keywords adjacent to "$ref"</li>
+<li>Note undefined behavior for "$ref" targets involving unknown keywords</li>
+<li>Add recursive referencing, primarily for meta-schema extension</li>
+<li>Add the concept of formal vocabularies, and how they can be recognized through meta-schemas</li>
+<li>Additional guidance on initial base URIs beyond network retrieval</li>
+<li>Allow "schema" media type parameter for "application/schema+json"</li>
+<li>Better explanation of media type parameters and the HTTP Accept header</li>
+</ul>
+<p> </p>
+</dd>
+<dt>draft-handrews-json-schema-01</dt>
+<dd style="margin-left: 8">
+<ul>
+<li>This draft is purely a clarification with no functional changes</li>
+<li>Emphasized annotations as a primary usage of JSON Schema</li>
+<li>Clarified $id by use cases</li>
+<li>Exhaustive schema identification examples</li>
+<li>Replaced "external referencing" with how and when an implementation might know of a schema from another document</li>
+<li>Replaced "internal referencing" with how an implementation should recognized schema identifiers during parsing</li>
+<li>Dereferencing the former "internal" or "external" references is always the same process</li>
+<li>Minor formatting improvements</li>
+</ul>
+<p> </p>
+</dd>
+<dt>draft-handrews-json-schema-00</dt>
+<dd style="margin-left: 8">
+<ul>
+<li>Make the concept of a schema keyword vocabulary more clear</li>
+<li>Note that the concept of "integer" is from a vocabulary, not the data model</li>
+<li>Classify keywords as assertions or annotations and describe their general behavior</li>
+<li>Explain the boolean schemas in terms of generalized assertions</li>
+<li>Reserve "$comment" for non-user-visible notes about the schema</li>
+<li>Wording improvements around "$id" and fragments</li>
+<li>Note the challenges of extending meta-schemas with recursive references</li>
+<li>Add "application/schema-instance+json" media type</li>
+<li>Recommend a "schema" link relation / parameter instead of "profile"</li>
+</ul>
+<p> </p>
+</dd>
+<dt>draft-wright-json-schema-01</dt>
+<dd style="margin-left: 8">
+<ul>
+<li>Updated intro</li>
+<li>Allowed for any schema to be a boolean</li>
+<li>"$schema" SHOULD NOT appear in subschemas, although that may change</li>
+<li>Changed "id" to "$id"; all core keywords prefixed with "$"</li>
+<li>Clarify and formalize fragments for application/schema+json</li>
+<li>Note applicability to formats such as CBOR that can be represented in the JSON data model</li>
+</ul>
+<p> </p>
+</dd>
+<dt>draft-wright-json-schema-00</dt>
+<dd style="margin-left: 8">
+<ul>
+<li>Updated references to JSON</li>
+<li>Updated references to HTTP</li>
+<li>Updated references to JSON Pointer</li>
+<li>Behavior for "id" is now specified in terms of RFC3986</li>
+<li>Aligned vocabulary usage for URIs with RFC3986</li>
+<li>Removed reference to draft-pbryan-zyp-json-ref-03</li>
+<li>Limited use of "$ref" to wherever a schema is expected</li>
+<li>Added definition of the "JSON Schema data model"</li>
+<li>Added additional security considerations</li>
+<li>Defined use of subschema identifiers for "id"</li>
+<li>Rewrote section on usage with HTTP</li>
+<li>Rewrote section on usage with rel="describedBy" and rel="profile"</li>
+<li>Fixed numerous invalid examples</li>
+</ul>
+<p> </p>
+</dd>
+<dt>draft-zyp-json-schema-04</dt>
+<dd style="margin-left: 8">
+<ul>
+<li>Salvaged from draft v3.</li>
+<li>Split validation keywords into separate document.</li>
+<li>Split hypermedia keywords into separate document.</li>
+<li>Initial post-split draft.</li>
+<li>Mandate the use of JSON Reference, JSON Pointer.</li>
+<li>Define the role of "id". Define URI resolution scope.</li>
+<li>Add interoperability considerations.</li>
+</ul>
+<p> </p>
+</dd>
+<dt>draft-zyp-json-schema-00</dt>
+<dd style="margin-left: 8">
+<ul><li>Initial draft.</li></ul>
+<p> </p>
+</dd>
+</dl>
+
+<p> </p>
+<h1 id="rfc.authors"><a href="#rfc.authors">Authors' Addresses</a></h1>
+<div class="avoidbreak">
+  <address class="vcard">
+	<span class="vcardline">
+	  <span class="fn">Austin Wright</span> (editor)
+	  <span class="n hidden">
+		<span class="family-name">Wright</span>
+	  </span>
+	</span>
+	<span class="org vcardline"></span>
+	<span class="adr">
+	  
+	  <span class="vcardline">
+		<span class="locality"></span> 
+		<span class="region"></span>
+		<span class="code"></span>
+	  </span>
+	  <span class="country-name vcardline"></span>
+	</span>
+	<span class="vcardline">EMail: <a href="mailto:aaa@bzfx.net">aaa@bzfx.net</a></span>
+
+  </address>
+</div><div class="avoidbreak">
+  <address class="vcard">
+	<span class="vcardline">
+	  <span class="fn">Henry Andrews</span> (editor)
+	  <span class="n hidden">
+		<span class="family-name">Andrews</span>
+	  </span>
+	</span>
+	<span class="org vcardline">Riverbed Technology</span>
+	<span class="adr">
+	  <span class="vcardline">680 Folsom St.</span>
+
+	  <span class="vcardline">
+		<span class="locality">San Francisco</span>,  
+		<span class="region">CA</span> 
+		<span class="code"></span>
+	  </span>
+	  <span class="country-name vcardline">USA</span>
+	</span>
+	<span class="vcardline">EMail: <a href="mailto:handrews@riverbed.com">handrews@riverbed.com</a></span>
+
+  </address>
+</div><div class="avoidbreak">
+  <address class="vcard">
+	<span class="vcardline">
+	  <span class="fn">Ben Hutton</span> (editor)
+	  <span class="n hidden">
+		<span class="family-name">Hutton</span>
+	  </span>
+	</span>
+	<span class="org vcardline">Wellcome Sanger Institute</span>
+	<span class="adr">
+	  
+	  <span class="vcardline">
+		<span class="locality"></span> 
+		<span class="region"></span>
+		<span class="code"></span>
+	  </span>
+	  <span class="country-name vcardline"></span>
+	</span>
+	<span class="vcardline">EMail: <a href="mailto:bh7@sanger.ac.uk">bh7@sanger.ac.uk</a></span>
+
+  </address>
+</div><div class="avoidbreak">
+  <address class="vcard">
+	<span class="vcardline">
+	  <span class="fn">Greg Dennis</span> 
+	  <span class="n hidden">
+		<span class="family-name">Dennis</span>
+	  </span>
+	</span>
+	<span class="org vcardline"></span>
+	<span class="adr">
+	  
+	  <span class="vcardline">
+		<span class="locality">Auckland</span>,  
+		<span class="region"></span>
+		<span class="code"></span>
+	  </span>
+	  <span class="country-name vcardline">NZ</span>
+	</span>
+	<span class="vcardline">EMail: <a href="mailto:gregsdennis@yahoo.com">gregsdennis@yahoo.com</a></span>
+
+  </address>
+</div>
+
+</body>
+</html>

--- a/work-in-progress/WIP-jsonschema-core.txt
+++ b/work-in-progress/WIP-jsonschema-core.txt
@@ -13,7 +13,7 @@ Expires: November 26, 2019                           Riverbed Technology
 
 
         JSON Schema: A Media Type for Describing JSON Documents
-                     draft-handrews-json-schema-02
+                     draft-handrews-json-schema-WIP
 
 Abstract
 
@@ -3404,7 +3404,7 @@ Internet-Draft                 JSON Schema                      May 2019
    [json-schema-validation]
               Wright, A., Andrews, H., and G. Luff, "JSON Schema
               Validation: A Vocabulary for Structural Validation of
-              JSON", draft-handrews-json-schema-validation-02 (work in
+              JSON", draft-handrews-json-schema-validation-WIP (work in
               progress), November 2017.
 
    [RFC7049]  Bormann, C. and P. Hoffman, "Concise Binary Object
@@ -3488,7 +3488,7 @@ Appendix B.  ChangeLog
    [[CREF9: This section to be removed before leaving Internet-Draft
    status.]]
 
-   draft-handrews-json-schema-02
+   draft-handrews-json-schema-WIP
 
       *  Update to RFC 8359 for JSON specification
 

--- a/work-in-progress/WIP-jsonschema-core.txt
+++ b/work-in-progress/WIP-jsonschema-core.txt
@@ -1,0 +1,3752 @@
+
+
+
+
+Internet Engineering Task Force                           A. Wright, Ed.
+Internet-Draft
+Intended status: Informational                           H. Andrews, Ed.
+Expires: November 26, 2019                           Riverbed Technology
+                                                          B. Hutton, Ed.
+                                               Wellcome Sanger Institute
+                                                               G. Dennis
+                                                            May 25, 2019
+
+
+        JSON Schema: A Media Type for Describing JSON Documents
+                     draft-handrews-json-schema-02
+
+Abstract
+
+   JSON Schema defines the media type "application/schema+json", a JSON-
+   based format for describing the structure of JSON data.  JSON Schema
+   asserts what a JSON document must look like, ways to extract
+   information from it, and how to interact with it.  The "application/
+   schema-instance+json" media type provides additional feature-rich
+   integration with "application/schema+json" beyond what can be offered
+   for "application/json" documents.
+
+Note to Readers
+
+   The issues list for this draft can be found at <https://github.com/
+   json-schema-org/json-schema-spec/issues>.
+
+   For additional information, see <http://json-schema.org/>.
+
+   To provide feedback, use this issue tracker, the communication
+   methods listed on the homepage, or email the document editors.
+
+Status of This Memo
+
+   This Internet-Draft is submitted in full conformance with the
+   provisions of BCP 78 and BCP 79.
+
+   Internet-Drafts are working documents of the Internet Engineering
+   Task Force (IETF).  Note that other groups may also distribute
+   working documents as Internet-Drafts.  The list of current Internet-
+   Drafts is at https://datatracker.ietf.org/drafts/current/.
+
+   Internet-Drafts are draft documents valid for a maximum of six months
+   and may be updated, replaced, or obsoleted by other documents at any
+   time.  It is inappropriate to use Internet-Drafts as reference
+   material or to cite them other than as "work in progress."
+
+
+
+
+Wright, et al.          Expires November 26, 2019               [Page 1]
+
+Internet-Draft                 JSON Schema                      May 2019
+
+
+   This Internet-Draft will expire on November 26, 2019.
+
+Copyright Notice
+
+   Copyright (c) 2019 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (https://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+Table of Contents
+
+   1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   4
+   2.  Conventions and Terminology . . . . . . . . . . . . . . . . .   4
+   3.  Overview  . . . . . . . . . . . . . . . . . . . . . . . . . .   5
+     3.1.  Keyword Behaviors . . . . . . . . . . . . . . . . . . . .   5
+       3.1.1.  Keyword Interactions  . . . . . . . . . . . . . . . .   5
+       3.1.2.  Default Behaviors . . . . . . . . . . . . . . . . . .   6
+       3.1.3.  Applicators . . . . . . . . . . . . . . . . . . . . .   6
+       3.1.4.  Assertions  . . . . . . . . . . . . . . . . . . . . .   7
+       3.1.5.  Annotations . . . . . . . . . . . . . . . . . . . . .   7
+     3.2.  Schema Vocabularies . . . . . . . . . . . . . . . . . . .   8
+       3.2.1.  Subschema Application . . . . . . . . . . . . . . . .   8
+       3.2.2.  Validation  . . . . . . . . . . . . . . . . . . . . .   8
+       3.2.3.  Basic Meta-Data . . . . . . . . . . . . . . . . . . .   9
+       3.2.4.  Hypermedia and Linking  . . . . . . . . . . . . . . .   9
+   4.  Definitions . . . . . . . . . . . . . . . . . . . . . . . . .   9
+     4.1.  JSON Document . . . . . . . . . . . . . . . . . . . . . .   9
+     4.2.  Instance  . . . . . . . . . . . . . . . . . . . . . . . .   9
+       4.2.1.  Instance Data Model . . . . . . . . . . . . . . . . .   9
+       4.2.2.  Instance Media Types  . . . . . . . . . . . . . . . .  10
+       4.2.3.  Instance Equality . . . . . . . . . . . . . . . . . .  11
+     4.3.  JSON Schema Documents . . . . . . . . . . . . . . . . . .  11
+       4.3.1.  JSON Schema Objects and Keywords  . . . . . . . . . .  12
+       4.3.2.  Boolean JSON Schemas  . . . . . . . . . . . . . . . .  12
+       4.3.3.  Root Schema and Subschemas  . . . . . . . . . . . . .  13
+       4.3.4.  Lexical Scope and Dynamic Scope . . . . . . . . . . .  13
+       4.3.5.  Referenced and Referencing Schemas  . . . . . . . . .  14
+   5.  Fragment Identifiers  . . . . . . . . . . . . . . . . . . . .  15
+   6.  General Considerations  . . . . . . . . . . . . . . . . . . .  15
+     6.1.  Range of JSON Values  . . . . . . . . . . . . . . . . . .  15
+
+
+
+Wright, et al.          Expires November 26, 2019               [Page 2]
+
+Internet-Draft                 JSON Schema                      May 2019
+
+
+     6.2.  Programming Language Independence . . . . . . . . . . . .  15
+     6.3.  Mathematical Integers . . . . . . . . . . . . . . . . . .  16
+     6.4.  Regular Expressions . . . . . . . . . . . . . . . . . . .  16
+     6.5.  Extending JSON Schema . . . . . . . . . . . . . . . . . .  16
+   7.  Meta-Schemas and Vocabularies . . . . . . . . . . . . . . . .  17
+     7.1.  The "$schema" Keyword . . . . . . . . . . . . . . . . . .  18
+     7.2.  The "$vocabulary" Keyword . . . . . . . . . . . . . . . .  18
+     7.3.  Detecting a Meta-Schema . . . . . . . . . . . . . . . . .  20
+     7.4.  Best Practices for Vocabulary and Meta-Schema Authors . .  20
+     7.5.  The JSON Schema Core Vocabulary . . . . . . . . . . . . .  21
+     7.6.  Example Meta-Schema With Vocabulary Declarations  . . . .  22
+   8.  Base URI and Dereferencing  . . . . . . . . . . . . . . . . .  23
+     8.1.  Initial Base URI  . . . . . . . . . . . . . . . . . . . .  23
+     8.2.  The "$id" Keyword . . . . . . . . . . . . . . . . . . . .  23
+       8.2.1.  Identifying the root schema . . . . . . . . . . . . .  23
+       8.2.2.  Changing the base URI within a schema file  . . . . .  24
+       8.2.3.  Location-independent identifiers  . . . . . . . . . .  24
+       8.2.4.  Schema identification examples  . . . . . . . . . . .  24
+     8.3.  Schema References . . . . . . . . . . . . . . . . . . . .  26
+       8.3.1.  Direct References with "$ref" . . . . . . . . . . . .  26
+       8.3.2.  Recursive References with "$recursiveRef" and
+               "$recursiveAnchor"  . . . . . . . . . . . . . . . . .  27
+       8.3.3.  Guarding Against Infinite Recursion . . . . . . . . .  31
+       8.3.4.  References to Possible Non-Schemas  . . . . . . . . .  31
+       8.3.5.  Loading a referenced schema . . . . . . . . . . . . .  32
+       8.3.6.  Dereferencing . . . . . . . . . . . . . . . . . . . .  32
+     8.4.  Schema Re-Use With "$defs"  . . . . . . . . . . . . . . .  33
+   9.  Comments With "$comment"  . . . . . . . . . . . . . . . . . .  34
+   10. Collecting Annotations  . . . . . . . . . . . . . . . . . . .  34
+     10.1.  Distinguishing Among Multiple Values . . . . . . . . . .  35
+     10.2.  Annotations and Assertions . . . . . . . . . . . . . . .  37
+     10.3.  Annotations and Applicators  . . . . . . . . . . . . . .  38
+   11. A Vocabulary for Applying Subschemas  . . . . . . . . . . . .  38
+     11.1.  Keyword Independence . . . . . . . . . . . . . . . . . .  39
+     11.2.  Keywords for Applying Subschemas in Place  . . . . . . .  39
+       11.2.1.  Keywords for Applying Subschemas With Boolean Logic   39
+       11.2.2.  Keywords for Applying Subschemas Conditionally . . .  40
+     11.3.  Keywords for Applying Subschemas to Child Instances  . .  42
+       11.3.1.  Keywords for Applying Subschemas to Arrays . . . . .  42
+       11.3.2.  Keywords for Applying Subschemas to Objects  . . . .  44
+   12. Output Formatting . . . . . . . . . . . . . . . . . . . . . .  47
+     12.1.  Format . . . . . . . . . . . . . . . . . . . . . . . . .  47
+     12.2.  Output Formats . . . . . . . . . . . . . . . . . . . . .  47
+     12.3.  Minimum Information  . . . . . . . . . . . . . . . . . .  47
+       12.3.1.  Keyword Relative Location  . . . . . . . . . . . . .  48
+       12.3.2.  Keyword Absolute Location  . . . . . . . . . . . . .  48
+       12.3.3.  Instance Location  . . . . . . . . . . . . . . . . .  48
+       12.3.4.  Error or Annotation  . . . . . . . . . . . . . . . .  49
+
+
+
+Wright, et al.          Expires November 26, 2019               [Page 3]
+
+Internet-Draft                 JSON Schema                      May 2019
+
+
+       12.3.5.  Nested Results . . . . . . . . . . . . . . . . . . .  49
+     12.4.  Output Structure . . . . . . . . . . . . . . . . . . . .  49
+       12.4.1.  Flag . . . . . . . . . . . . . . . . . . . . . . . .  51
+       12.4.2.  Basic  . . . . . . . . . . . . . . . . . . . . . . .  51
+       12.4.3.  Detailed . . . . . . . . . . . . . . . . . . . . . .  52
+       12.4.4.  Verbose  . . . . . . . . . . . . . . . . . . . . . .  54
+       12.4.5.  Output validation schemas  . . . . . . . . . . . . .  56
+   13. Usage for Hypermedia  . . . . . . . . . . . . . . . . . . . .  56
+     13.1.  Linking to a Schema  . . . . . . . . . . . . . . . . . .  56
+     13.2.  Identifying a Schema via a Media Type Parameter  . . . .  56
+     13.3.  Usage Over HTTP  . . . . . . . . . . . . . . . . . . . .  58
+   14. Security Considerations . . . . . . . . . . . . . . . . . . .  58
+   15. IANA Considerations . . . . . . . . . . . . . . . . . . . . .  59
+     15.1.  application/schema+json  . . . . . . . . . . . . . . . .  59
+     15.2.  application/schema-instance+json . . . . . . . . . . . .  60
+   16. References  . . . . . . . . . . . . . . . . . . . . . . . . .  60
+     16.1.  Normative References . . . . . . . . . . . . . . . . . .  60
+     16.2.  Informative References . . . . . . . . . . . . . . . . .  61
+   Appendix A.  Acknowledgments  . . . . . . . . . . . . . . . . . .  63
+   Appendix B.  ChangeLog  . . . . . . . . . . . . . . . . . . . . .  63
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  66
+
+1.  Introduction
+
+   JSON Schema is a JSON media type for defining the structure of JSON
+   data.  JSON Schema is intended to define validation, documentation,
+   hyperlink navigation, and interaction control of JSON data.
+
+   This specification defines JSON Schema core terminology and
+   mechanisms, including pointing to another JSON Schema by reference,
+   dereferencing a JSON Schema reference, specifying the vocabulary
+   being used, and defining the expected output.
+
+   Other specifications define the vocabularies that perform assertions
+   about validation, linking, annotation, navigation, and interaction.
+
+2.  Conventions and Terminology
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in RFC 2119 [RFC2119].
+
+   The terms "JSON", "JSON text", "JSON value", "member", "element",
+   "object", "array", "number", "string", "boolean", "true", "false",
+   and "null" in this document are to be interpreted as defined in RFC
+   8259 [RFC8259].
+
+
+
+
+
+Wright, et al.          Expires November 26, 2019               [Page 4]
+
+Internet-Draft                 JSON Schema                      May 2019
+
+
+3.  Overview
+
+   This document proposes a new media type "application/schema+json" to
+   identify a JSON Schema for describing JSON data.  It also proposes a
+   further optional media type, "application/schema-instance+json", to
+   provide additional integration features.  JSON Schemas are themselves
+   JSON documents.  This, and related specifications, define keywords
+   allowing authors to describe JSON data in several ways.
+
+3.1.  Keyword Behaviors
+
+   JSON Schema keywords fall into several general behavior categories.
+   Assertions validate that an instance satisfies constraints, producing
+   a boolean result.  Annotations attach information that applications
+   may use in any way they see fit.  Applicators apply subschemas to
+   parts of the instance and combine their results.
+
+   Extension keywords SHOULD stay within these categories, keeping in
+   mind that annotations in particular are extremely flexible.  Complex
+   behavior is usually better delegated to applications on the basis of
+   annotation data than implemented directly as schema keywords.
+   However, extension keywords MAY define other behaviors for
+   specialized purposes.
+
+   Evaluating an instance against a schema involves processing all of
+   the keywords in the schema against the appropriate locations within
+   the instance.  Typically, applicator keywords are processed until a
+   schema object with no applicators (and therefore no subschemas) is
+   reached.  The appropriate location in the instance is evaluated
+   against the assertion and annotation keywords in the schema object,
+   and their results are gathered into the parent schema according to
+   the rules of the applicator.
+
+   Evaluation of a parent schema object can complete once all of its
+   subschemas have been evaluated, although in some circumstances
+   evaluation may be short-circuited due to assertion results.
+
+3.1.1.  Keyword Interactions
+
+   Keyword behavior MAY be defined in terms of the annotation results of
+   subschemas (Section 4.3.3) and/or adjacent keywords.  Such keywords
+   MUST NOT result in a circular dependency.  Keywords MAY modify their
+   behavior based on the presence or absence of another keyword in the
+   same schema object (Section 4.3).
+
+
+
+
+
+
+
+Wright, et al.          Expires November 26, 2019               [Page 5]
+
+Internet-Draft                 JSON Schema                      May 2019
+
+
+3.1.2.  Default Behaviors
+
+   A missing keyword MUST NOT produce a false assertion result, MUST NOT
+   produce annotation results, and MUST NOT cause any other schema to be
+   evaluated as part of its own behavioral definition.  However, given
+   that missing keywords do not contribute annotations, the lack of
+   annotation results may indirectly change the behavior of other
+   keywords.
+
+   In some cases, the missing keyword assertion behavior of a keyword is
+   identical to that produced by a certain value, and keyword
+   definitions SHOULD note such values where known.  However, even if
+   the value which produces the default behavior would produce
+   annotation results if present, the default behavior still MUST NOT
+   result in annotations.
+
+   Because annotation collection can add significant cost in terms of
+   both computation and memory, implementations MAY opt out of this
+   feature.  Keywords known to an implementation to have assertion or
+   applicator behavior that depend on annotation results MUST then be
+   treated as errors, unless an alternate implementation producing the
+   same behavior is available.  Keywords of this sort SHOULD describe
+   reasonable alternate approaches when appropriate.  This approach is
+   demonstrated by the "additionalItems" and "additionalProperties"
+   keywords in this document.
+
+3.1.3.  Applicators
+
+   Applicators allow for building more complex schemas than can be
+   accomplished with a single schema object.  Evaluation of an instance
+   against a schema document (Section 4.3) begins by applying the root
+   schema (Section 4.3.3) to the complete instance document.  From
+   there, keywords known as applicators are used to determine which
+   additional schemas are applied.  Such schemas may be applied in-place
+   to the current location, or to a child location.
+
+   The schemas to be applied may be present as subschemas comprising all
+   or part of the keyword's value.  Alternatively, an applicator may
+   refer to a schema elsewhere in the same schema document, or in a
+   different one.  The mechanism for identifying such referenced schemas
+   is defined by the keyword.
+
+   Applicator keywords also define how subschema or referenced schema
+   boolean assertion (Section 3.1.4) results are modified and/or
+   combined to produce the boolean result of the applicator.
+   Applicators may apply any boolean logic operation to the assertion
+   results of subschemas, but MUST NOT introduce new assertion
+   conditions of their own.
+
+
+
+Wright, et al.          Expires November 26, 2019               [Page 6]
+
+Internet-Draft                 JSON Schema                      May 2019
+
+
+   Annotation (Section 3.1.5) results are combined according to the
+   rules specified by each annotation keyword.
+
+3.1.4.  Assertions
+
+   JSON Schema can be used to assert constraints on a JSON document,
+   which either passes or fails the assertions.  This approach can be
+   used to validate conformance with the constraints, or document what
+   is needed to satisfy them.
+
+   JSON Schema implementations produce a single boolean result when
+   evaluating an instance against schema assertions.
+
+   An instance can only fail an assertion that is present in the schema.
+
+3.1.4.1.  Assertions and Instance Primitive Types
+
+   Most assertions only constrain values within a certain primitive
+   type.  When the type of the instance is not of the type targeted by
+   the keyword, the instance is considered to conform to the assertion.
+
+   For example, the "maxLength" keyword from the companion validation
+   vocabulary will only restrict certain strings (that are too long)
+   from being valid.  If the instance is a number, boolean, null, array,
+   or object, then it is valid against this assertion.
+
+3.1.5.  Annotations
+
+   JSON Schema can annotate an instance with information, whenever the
+   instance validates against the schema object containing the
+   annotation, and all of its parent schema objects.  The information
+   can be a simple value, or can be calculated based on the instance
+   contents.
+
+   Annotations are attached to specific locations in an instance.  Since
+   many subschemas can be applied to any single location, annotation
+   keywords need to specify any unusual handling of multiple applicable
+   occurrences of the keyword with different values.
+
+   The default behavior is simply to collect all values in a list in
+   indeterminate order.  Given the extensibility of keywords, including
+   applicators, it is not possible to define a universally predictable
+   order of processing.
+
+   Unlike assertion results, annotation data can take a wide variety of
+   forms, which are provided to applications to use as they see fit.
+   JSON Schema implementations are not expected to make use of the
+   collected information on behalf of applications.
+
+
+
+Wright, et al.          Expires November 26, 2019               [Page 7]
+
+Internet-Draft                 JSON Schema                      May 2019
+
+
+   While "short-circuit" evaluation is possible for assertions,
+   collecting annotations requires examining all schemas that apply to
+   an instance location, even if they cannot change the overall
+   assertion result.
+
+3.2.  Schema Vocabularies
+
+   A JSON Schema vocabulary is a set of keywords defined for a
+   particular purpose.  The vocabulary specifies the meaning of its
+   keywords as assertions, annotations, and/or any vocabulary-defined
+   keyword category.
+
+   Several vocabularies are provided as standards in this and closely
+   related documents.  These vocabularies are used with the core
+   keywords defined as fundamental to the "application/schema+json"
+   media type.
+
+   Schema authors are encouraged to define their own vocabularies for
+   domain-specific concepts.  A vocabulary need not be a standard to be
+   re-usable, although users of extension vocabularies MUST NOT assume
+   that any JSON Schema implementation can support the vocabulary unless
+   it specifically documents such support.
+
+3.2.1.  Subschema Application
+
+   This vocabulary provides keywords for applying subschemas to the
+   instance in various ways.  It is defined in this document, and it is
+   RECOMMENDED that all JSON Schema implementations support it.  All
+   other vocabularies in this section are designed to be used alongside
+   the subschema application vocabulary.
+
+   Without this vocabulary or an equivalent one, JSON Schema can only be
+   applied to a JSON document as a whole.  In most cases, schema
+   keywords need to be applied to specific object properties or array
+   items.
+
+3.2.2.  Validation
+
+   This vocabulary describes the structure of a JSON document (for
+   instance, required properties and length limitations).  Applications
+   can use this information to validate instances (check that
+   constraints are met), or inform interfaces to collect user input such
+   that the constraints are satisfied.
+
+   Validation behaviour and keywords are specified in a separate
+   document [json-schema-validation].
+
+
+
+
+
+Wright, et al.          Expires November 26, 2019               [Page 8]
+
+Internet-Draft                 JSON Schema                      May 2019
+
+
+3.2.3.  Basic Meta-Data
+
+   A small set of annotation keywords are defined in the validation
+   specification [json-schema-validation] to allow associating common
+   kinds of meta-data with an instance.
+
+3.2.4.  Hypermedia and Linking
+
+   JSON Hyper-Schema produces hyperlinks as annotations available for
+   use with a JSON document.  It supports resolving URI Templates and
+   describing the resource and data submission formats required to use
+   an API.
+
+   Hyper-schema behaviour and keywords are specified in a separate
+   document [json-hyper-schema].
+
+4.  Definitions
+
+4.1.  JSON Document
+
+   A JSON document is an information resource (series of octets)
+   described by the application/json media type.
+
+   In JSON Schema, the terms "JSON document", "JSON text", and "JSON
+   value" are interchangeable because of the data model it defines.
+
+   JSON Schema is only defined over JSON documents.  However, any
+   document or memory structure that can be parsed into or processed
+   according to the JSON Schema data model can be interpreted against a
+   JSON Schema, including media types like CBOR [RFC7049].
+
+4.2.  Instance
+
+   A JSON document to which a schema is applied is known as an
+   "instance".
+
+4.2.1.  Instance Data Model
+
+   JSON Schema interprets documents according to a data model.  A JSON
+   value interpreted according to this data model is called an
+   "instance".
+
+   An instance has one of six primitive types, and a range of possible
+   values depending on the type:
+
+   null:  A JSON "null" production
+
+
+
+
+
+Wright, et al.          Expires November 26, 2019               [Page 9]
+
+Internet-Draft                 JSON Schema                      May 2019
+
+
+   boolean:  A "true" or "false" value, from the JSON "true" or "false"
+      productions
+
+   object:  An unordered set of properties mapping a string to an
+      instance, from the JSON "object" production
+
+   array:  An ordered list of instances, from the JSON "array"
+      production
+
+   number:  An arbitrary-precision, base-10 decimal number value, from
+      the JSON "number" production
+
+   string:  A string of Unicode code points, from the JSON "string"
+      production
+
+   Whitespace and formatting concerns, including different lexical
+   representations of numbers that are equal within the data model, are
+   thus outside the scope of JSON Schema.  JSON Schema vocabularies
+   (Section 3.2) that wish to work with such differences in lexical
+   representations SHOULD define keywords to precisely interpret
+   formatted strings within the data model rather than relying on having
+   the original JSON representation Unicode characters available.
+
+   Since an object cannot have two properties with the same key,
+   behavior for a JSON document that tries to define two properties (the
+   "member" production) with the same key (the "string" production) in a
+   single object is undefined.
+
+   Note that JSON Schema vocabularies are free to define their own
+   extended type system.  This should not be confused with the core data
+   model types defined here.  As an example, "integer" is a reasonable
+   type for a vocabulary to define as a value for a keyword, but the
+   data model makes no distinction between integers and other numbers.
+
+4.2.2.  Instance Media Types
+
+   JSON Schema is designed to fully work with "application/json"
+   documents, as well as media types using the "+json" structured syntax
+   suffix.
+
+   Some functionality that is useful for working with schemas is defined
+   by each media type, namely media type parameters and URI fragment
+   identifier syntax and semantics.  These features are useful in
+   content negotiation and in calculating URIs for specific locations
+   within an instance, respectively.
+
+
+
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 10]
+
+Internet-Draft                 JSON Schema                      May 2019
+
+
+   This specification defines the "application/schema-instance+json"
+   media type in order to allow instance authors to take full advantage
+   of parameters and fragment identifiers for these purposes.
+
+4.2.3.  Instance Equality
+
+   Two JSON instances are said to be equal if and only if they are of
+   the same type and have the same value according to the data model.
+   Specifically, this means:
+
+      both are null; or
+
+      both are true; or
+
+      both are false; or
+
+      both are strings, and are the same codepoint-for-codepoint; or
+
+      both are numbers, and have the same mathematical value; or
+
+      both are arrays, and have an equal value item-for-item; or
+
+      both are objects, and each property in one has exactly one
+      property with a key equal to the other's, and that other property
+      has an equal value.
+
+   Implied in this definition is that arrays must be the same length,
+   objects must have the same number of members, properties in objects
+   are unordered, there is no way to define multiple properties with the
+   same key, and mere formatting differences (indentation, placement of
+   commas, trailing zeros) are insignificant.
+
+4.3.  JSON Schema Documents
+
+   A JSON Schema document, or simply a schema, is a JSON document used
+   to describe an instance.  A schema is itself interpreted as an
+   instance, but SHOULD always be given the media type "application/
+   schema+json" rather than "application/schema-instance+json".  The
+   "application/schema+json" media type is defined to offer a superset
+   of the media type parameter and fragment identifier syntax and
+   semantics provided by "application/schema-instance+json".
+
+   A JSON Schema MUST be an object or a boolean.
+
+
+
+
+
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 11]
+
+Internet-Draft                 JSON Schema                      May 2019
+
+
+4.3.1.  JSON Schema Objects and Keywords
+
+   Object properties that are applied to the instance are called
+   keywords, or schema keywords.  Broadly speaking, keywords fall into
+   one of three categories:
+
+   assertions:  produce a boolean result when applied to an instance
+
+   annotations:  attach information to an instance for application use
+
+   applicators:  apply one or more subschemas to a particular location
+      in the instance, and combine or modify their results
+
+   Keywords may fall into multiple categories, although applicators
+   SHOULD only produce assertion results based on their subschemas'
+   results.  They should not define additional constraints independent
+   of their subschemas.
+
+   Extension keywords, meaning those defined outside of this document
+   and its companions, are free to define other behaviors as well.
+
+   A JSON Schema MAY contain properties which are not schema keywords.
+   Unknown keywords SHOULD be ignored.
+
+   An empty schema is a JSON Schema with no properties, or only unknown
+   properties.
+
+4.3.2.  Boolean JSON Schemas
+
+   The boolean schema values "true" and "false" are trivial schemas that
+   always produce themselves as assertions results, regardless of the
+   instance value.  They never produce annotation results.
+
+   These boolean schemas exist to clarify schema author intent and
+   facilitate schema processing optimizations.  They behave identically
+   to the following schema objects (where "not" is part of the subschema
+   application vocabulary defined in this document).
+
+   true:  Always passes validation, as if the empty schema {}
+
+   false:  Always fails validation, as if the schema { "not":{} }
+
+   While the empty schema object is unambiguous, there are many possible
+   equivalents to the "false" schema.  Using the boolean values ensures
+   that the intent is clear to both human readers and implementations.
+
+
+
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 12]
+
+Internet-Draft                 JSON Schema                      May 2019
+
+
+4.3.3.  Root Schema and Subschemas
+
+   The root schema is the schema that comprises the entire JSON document
+   in question.
+
+   Some keywords take schemas themselves, allowing JSON Schemas to be
+   nested:
+
+
+   {
+       "title": "root",
+       "items": {
+           "title": "array item"
+       }
+   }
+
+
+   In this example document, the schema titled "array item" is a
+   subschema, and the schema titled "root" is the root schema.
+
+   As with the root schema, a subschema is either an object or a
+   boolean.
+
+4.3.4.  Lexical Scope and Dynamic Scope
+
+   While most JSON Schema keywords can be evaluated on their own, or at
+   most need to take into account the values or results of adjacent
+   keywords in the same schema object, a few have more complex behavior.
+
+   The lexical scope of a keyword is determined by the nested JSON data
+   structure of objects and arrays.  The largest such scope is an entire
+   schema document.  The smallest scope is a single schema object with
+   no subschemas.
+
+   Keywords MAY be defined with a partial value, such as a URI-
+   reference, which must be resolved against another value, such as
+   another URI-reference or a full URI, which is found through the
+   lexical structure of the JSON document.  The "$id" core keyword and
+   the "base" JSON Hyper-Schema keyword are examples of this sort of
+   behavior.  Additionally, "$ref" and "$recursiveRef" from this
+   specification resolve their values in this way, although they do not
+   change how further values are resolved.
+
+   Note that some keywords, such as "$schema", apply to the lexical
+   scope of the entire schema document, and therefore MUST only appear
+   in the document's root schema.
+
+
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 13]
+
+Internet-Draft                 JSON Schema                      May 2019
+
+
+   Other keywords may take into account the dynamic scope that exists
+   during the evaluation of a schema, typically together with an
+   instance document.  The outermost dynamic scope is the root schema of
+   the schema document in which processing begins.  The path from this
+   root schema to any particular keyword (that includes any "$ref" and
+   "$recursiveRef" keywords that may have been resolved) is considered
+   the keyword's "validation path."  [[CREF1: Or should this be the
+   schema object at which processing begins, even if it is not a root?
+   This has some implications for the case where "$recursiveAnchor" is
+   only allowed in the root schema but processing begins in a subschema.
+   ]]
+
+   Lexical and dynamic scopes align until a reference keyword is
+   encountered.  While following the reference keyword jumps from one
+   lexical scope into a different one, from the perspective of dynamic
+   scope, following reference is no different from descending into a
+   subschema present as a value.  A keyword on the far side of that
+   reference that resolves information through the dynamic scope will
+   consider the originating side of the reference to be their dynamic
+   parent, rather than examining the local lexically enclosing parent.
+
+   The concept of dynamic scope is primarily used with "$recursiveRef",
+   "$recursiveAnchor", and should be considered an advanced feature and
+   used with caution when defining additional keywords.
+
+4.3.5.  Referenced and Referencing Schemas
+
+   As noted in Section 3.1.3, an applicator keyword may refer to a
+   schema to be applied, rather than including it as a subschema in the
+   applicator's value.  In such situations, the schema being applied is
+   known as the referenced schema, while the schema containing the
+   applicator keyword is the referencing schema.
+
+   While root schemas and subschemas are static concepts based on a
+   schema's position within a schema document, referenced and
+   referencing schemas are dynamic.  Different pairs of schemas may find
+   themselves in various referenced and referencing arrangements during
+   the evaluation of an instance against a schema.
+
+   For some by-reference applicators, such as "$ref" (Section 8.3.1),
+   the referenced schema can be determined by static analysis of the
+   schema document's lexical scope.  Others, such as "$recursiveRef" and
+   "$recursiveAnchor", may make use of dynamic scoping, and therefore
+   only be resolvable in the process of evaluating the schema with an
+   instance.
+
+
+
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 14]
+
+Internet-Draft                 JSON Schema                      May 2019
+
+
+5.  Fragment Identifiers
+
+   In accordance with section 3.1 of [RFC6839], the syntax and semantics
+   of fragment identifiers specified for any +json media type SHOULD be
+   as specified for "application/json".  (At publication of this
+   document, there is no fragment identification syntax defined for
+   "application/json".)
+
+   Additionally, the "application/schema+json" media type supports two
+   fragment identifier structures: plain names and JSON Pointers.  The
+   "application/schema-instance+json" media type supports one fragment
+   identifier structure: JSON Pointers.
+
+   The use of JSON Pointers as URI fragment identifiers is described in
+   RFC 6901 [RFC6901].  For "application/schema+json", which supports
+   two fragment identifier syntaxes, fragment identifiers matching the
+   JSON Pointer syntax, including the empty string, MUST be interpreted
+   as JSON Pointer fragment identifiers.
+
+   Per the W3C's best practices for fragment identifiers
+   [W3C.WD-fragid-best-practices-20121025], plain name fragment
+   identifiers in "application/schema+json" are reserved for referencing
+   locally named schemas.  All fragment identifiers that do not match
+   the JSON Pointer syntax MUST be interpreted as plain name fragment
+   identifiers.
+
+   Defining and referencing a plain name fragment identifier within an
+   "application/schema+json" document are specified in the "$id" keyword
+   (Section 8.2) section.
+
+6.  General Considerations
+
+6.1.  Range of JSON Values
+
+   An instance may be any valid JSON value as defined by JSON [RFC8259].
+   JSON Schema imposes no restrictions on type: JSON Schema can describe
+   any JSON value, including, for example, null.
+
+6.2.  Programming Language Independence
+
+   JSON Schema is programming language agnostic, and supports the full
+   range of values described in the data model.  Be aware, however, that
+   some languages and JSON parsers may not be able to represent in
+   memory the full range of values describable by JSON.
+
+
+
+
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 15]
+
+Internet-Draft                 JSON Schema                      May 2019
+
+
+6.3.  Mathematical Integers
+
+   Some programming languages and parsers use different internal
+   representations for floating point numbers than they do for integers.
+
+   For consistency, integer JSON numbers SHOULD NOT be encoded with a
+   fractional part.
+
+6.4.  Regular Expressions
+
+   Keywords MAY use regular expressions to express constraints, or
+   constrain the instance value to be a regular expression.  These
+   regular expressions SHOULD be valid according to the ECMA 262
+   [ecma262] regular expression dialect.
+
+   Furthermore, given the high disparity in regular expression
+   constructs support, schema authors SHOULD limit themselves to the
+   following regular expression tokens:
+
+      individual Unicode characters, as defined by the JSON
+      specification [RFC8259];
+
+      simple character classes ([abc]), range character classes ([a-z]);
+
+      complemented character classes ([^abc], [^a-z]);
+
+      simple quantifiers: "+" (one or more), "*" (zero or more), "?"
+      (zero or one), and their lazy versions ("+?", "*?", "??");
+
+      range quantifiers: "{x}" (exactly x occurrences), "{x,y}" (at
+      least x, at most y, occurrences), {x,} (x occurrences or more),
+      and their lazy versions;
+
+      the beginning-of-input ("^") and end-of-input ("$") anchors;
+
+      simple grouping ("(...)") and alternation ("|").
+
+   Finally, implementations MUST NOT take regular expressions to be
+   anchored, neither at the beginning nor at the end.  This means, for
+   instance, the pattern "es" matches "expression".
+
+6.5.  Extending JSON Schema
+
+   Additional schema keywords and schema vocabularies MAY be defined by
+   any entity.  Save for explicit agreement, schema authors SHALL NOT
+   expect these additional keywords and vocabularies to be supported by
+   implementations that do not explicitly document such support.
+   Implementations SHOULD ignore keywords they do not support.
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 16]
+
+Internet-Draft                 JSON Schema                      May 2019
+
+
+   Vocabulary authors SHOULD take care to avoid keyword name collisions
+   if the vocabulary is intended for broad use, and potentially combined
+   with other vocabularies.  JSON Schema does not provide any formal
+   namespacing system, but also does not constrain keyword names,
+   allowing for any number of namespacing approaches.
+
+   Vocabularies may build on each other, such as by defining the
+   behavior of their keywords with respect to the behavior of keywords
+   from another vocabulary, or by using a keyword from another
+   vocabulary with a restricted or expanded set of acceptable values.
+   Not all such vocabulary re-use will result in a new vocabulary that
+   is compatible with the vocabulary on which it is built.  Vocabulary
+   authors SHOULD clearly document what level of compatibility, if any,
+   is expected.
+
+   A schema that itself describes a schema is called a meta-schema.
+   Meta-schemas are used to validate JSON Schemas and specify which
+   vocabulary they are using.
+
+   Authors of extensions to JSON Schema are encouraged to write their
+   own meta-schemas, which extend the existing meta-schemas using
+   "allOf".  This extended meta-schema SHOULD be referenced using the
+   "$schema" keyword, to allow tools to follow the correct behaviour.
+
+   The recursive nature of meta-schemas makes the "$recursiveAnchor" and
+   "$recursiveRef" keywords particularly useful for such extensions, as
+   can be seen in the JSON Hyper-Schema meta-schema.
+
+7.  Meta-Schemas and Vocabularies
+
+   Two concepts, meta-schemas and vocabularies, are used to inform an
+   implementation how to interpret a schema.  A schema S declares its
+   meta-schema M with the "$schema" keyword, and meta-schemas declare
+   vocabularies with the "$vocabulary" keyword.  The vocabularies
+   declared in M are those that are expected to be used in S.  The meta-
+   schema M may itself use a different set of vocabularies, which are
+   declared in its own meta-schema, M'.
+
+   The role of the meta-schema is to constrain the structure of
+   conforming schemas, as well as simplify the process of composing
+   multiple vocabularies into a usable feature set.  Schema authoring is
+   expected to be a common activity, so schema authors need only
+   understand how to reference a single meta-schema.
+
+   Meta-schema authoring is an advanced usage of JSON Schema, so the
+   design of meta-schema features emphasizes flexibility over
+   simplicity.
+
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 17]
+
+Internet-Draft                 JSON Schema                      May 2019
+
+
+   The role of a vocabulary is to declare which keywords (including sub-
+   keywords such as those in JSON Hyper-Schema's Link Description
+   Object) are in use, and with which semantics.  The semantics are
+   indicated by the document that publicizes the vocabulary URI.  At
+   this time, there is no machine-readable description of keywords other
+   than validation rules, which appear in the meta-schema.
+
+   Meta-schemas are separate from vocabularies to allow for the same
+   sets of vocabularies to be combined in different ways, and for meta-
+   schema authors to impose additional constraints such as forbidding
+   certain keywords, or performing unusually strict syntactical
+   validation, as might be done during a development and testing cycle.
+
+7.1.  The "$schema" Keyword
+
+   The "$schema" keyword is both used as a JSON Schema feature set
+   identifier and the location of a resource which is itself a JSON
+   Schema, which describes any schema written for this particular
+   feature set.
+
+   The value of this keyword MUST be a URI [RFC3986] (containing a
+   scheme) and this URI MUST be normalized.  The current schema MUST be
+   valid against the meta-schema identified by this URI.
+
+   If this URI identifies a retrievable resource, that resource SHOULD
+   be of media type "application/schema+json".
+
+   The "$schema" keyword SHOULD be used in a root schema.  It MUST NOT
+   appear in subschemas.
+
+   [[CREF2: Using multiple "$schema" keywords in the same document would
+   imply that the feature set and therefore behavior can change within a
+   document.  This would necessitate resolving a number of
+   implementation concerns that have not yet been clearly defined.  So,
+   while the pattern of using "$schema" only in root schemas is likely
+   to remain the best practice for schema authoring, implementation
+   behavior is subject to be revised or liberalized in future drafts.
+   ]]
+
+   Values for this property are defined elsewhere in this and other
+   documents, and by other parties.
+
+7.2.  The "$vocabulary" Keyword
+
+   The "$vocabulary" keyword, which appears in a meta-schema, identifies
+   what sets of keywords are expected to be used in schemas described by
+   that meta-schema, and with what semantics.  This is conceptually
+
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 18]
+
+Internet-Draft                 JSON Schema                      May 2019
+
+
+   analogous to how most other keywords used in meta-schemas describe
+   the syntax of keywords used in schemas described by that meta-schema.
+
+   The value of this keyword MUST be an object.  The property names in
+   the object MUST be URIs (containing a scheme) and this URI MUST be
+   normalized.  Each URI that appears as a property name identifies a
+   specific set of keywords and their semantics.
+
+   The URI MAY be a URL, but the nature of the retrievable resources is
+   currently undefined, and reserved for future use.  Vocabulary authors
+   SHOULD NOT serve a document at that URL.  A server MAY respond with
+   the relevant protocol's successful "no content" message, such as an
+   HTTP 204 status.  [[CREF3: Vocabulary documents may be added shortly,
+   or in the next draft.  For now, identifying the keyword set is deemed
+   sufficient as that, along with meta-schema validation, is how the
+   current "vocabularies" work today.  ]]
+
+   The values of the object properties MUST be booleans.  If the value
+   is true, then implementations that do not recognize the vocabulary
+   MUST refuse to process any schemas that declare this meta-schema with
+   "$schema".  If the value is false, implementations that do not
+   recognize the vocabulary MAY choose to proceed with processing such
+   schemas.
+
+   When processing a schema that uses unrecognized vocabularies,
+   keywords declared by those vocabularies are treated like any other
+   unrecognized keyword, and ignored.
+
+   The "$vocabulary" keyword SHOULD be used in the root schema of any
+   schema document intended for use as a meta-schema.  It MUST NOT
+   appear in subschemas.
+
+   The "$vocabulary" keyword MUST be ignored in schema documents that
+   are not being processed as a meta-schema.  This allows validating a
+   meta-schema M against its own meta-schema M' without requiring the
+   validator to understand the vocabularies declared by M.
+
+   Note that the processing restrictions on "$vocabulary" mean that
+   meta-schemas that reference other meta-schemas using "$ref" or
+   similar keywords do not automatically inherit the vocabulary
+   declarations of those other meta-schemas.  All such declarations must
+   be repeated in the root of each schema document intended for use as a
+   meta-schema.  This is demonstrated in the example meta-schema
+   (Section 7.6).
+
+   If "$vocabulary" is absent, an implementation MAY determine behavior
+   based on the meta-schema if it is recognized from the URI value of
+   the referring schema's "$schema" keyword.  If the meta-schema, as
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 19]
+
+Internet-Draft                 JSON Schema                      May 2019
+
+
+   referenced by the schema, is not recognized, then implementations
+   MUST assume the use of the core vocabulary, and SHOULD assume the use
+   of all vocabularies in this specification and the companion
+   Validation specification.
+
+7.3.  Detecting a Meta-Schema
+
+   Implementations MUST recognize a schema as a meta-schema if it is
+   being examined because it was identified as such by another schema's
+   "$schema" keyword.  This means that a single schema document might
+   sometimes be considered a regular schema, and other times be
+   considered a meta-schema.
+
+   In the case of examining a schema which is its own meta-schema, when
+   an implementation begins processing it as a regular schema, it is
+   processed under those rules.  However, when loaded a second time as a
+   result of checking its own "$schema" value, it is treated as a meta-
+   schema.  So the same document is processed both ways in the course of
+   one session.
+
+   Implementations MAY allow a schema to be passed as a meta-schema, for
+   implementation-specific purposes, such as pre-loading a commonly used
+   meta-schema and checking its vocabulary support requirements up
+   front.  Meta-schema authors MUST NOT expect such features to be
+   interoperable across implementations.
+
+7.4.  Best Practices for Vocabulary and Meta-Schema Authors
+
+   Meta-schema authors SHOULD NOT use "$vocabulary" to combine multiple
+   vocabularies that define conflicting syntax or semantics for the same
+   keyword.  As semantic conflicts are not generally detectable through
+   schema validation, implementations are not expected to detect such
+   conflicts.  If conflicting vocabularies are declared, the resulting
+   behavior is undefined.
+
+   Vocabulary authors SHOULD provide a meta-schema that validates the
+   expected usage of the vocabulary's keywords.  Such meta-schemas
+   SHOULD NOT forbid additional keywords, and MUST NOT forbid the "$id",
+   "$schema", or "$vocabulary" keywords in the root schema.
+
+   It is RECOMMENDED that meta-schema authors reference each
+   vocabulary's meta-schema using the "allOf" (Section 11.2.1.1)
+   keyword, although other mechanisms for constructing the meta-schema
+   may be appropriate for certain use cases.
+
+   Meta-schemas MAY impose additional constraints, including describing
+   keywords not present in any vocabulary, beyond what the meta-schemas
+   associated with the declared vocabularies describe.  This allows for
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 20]
+
+Internet-Draft                 JSON Schema                      May 2019
+
+
+   restricting usage to a subset of a vocabulary, and for validating
+   locally defined keywords not intended for re-use.
+
+   However, meta-schemas SHOULD NOT contradict any vocabularies that
+   they declare, such as by requiring a different JSON type than the
+   vocabulary expects.  The resulting behavior is undefined.
+
+   Meta-schemas intended for local use, with no need to test for
+   vocabulary support in arbitrary implementations, can safely omit
+   "$vocabulary" entirely.
+
+7.5.  The JSON Schema Core Vocabulary
+
+   Keywords declared in in this specification that begin with "$" make
+   up the JSON Schema Core vocabulary.  These keywords are either
+   required in order process any schema or meta-schema, including those
+   split across multiple documents, or exist to reserve keywords for
+   purposes that require guaranteed interoperability.
+
+   The Core vocabulary MUST be considered mandatory at all times, in
+   order to bootstrap the processing of further vocabularies.  Meta-
+   schemas that use "$vocabulary" MUST explicitly list the Core
+   vocabulary, which MUST have a value of true indicating that it is
+   required.
+
+   The behavior of a false value for this vocabulary (and only this
+   vocabulary) is undefined, as is the behavior when "$vocabulary" is
+   present but the Core vocabulary is not included.  However, it is
+   RECOMMENDED that implementations detect these cases and raise an
+   error when they occur.
+
+   Meta-schemas that do not use "$vocabulary" MUST be considered to
+   require the Core vocabulary as if its URI were present with a value
+   of true.
+
+   The current URI for the Core vocabulary is: <https://json-schema.org/
+   draft/2019-04/vocab/core>.
+
+   The current URI for the corresponding meta-schema is: <https://json-
+   schema.org/draft/2019-04/meta/core>.
+
+   Updated vocabulary and meta-schema URIs MAY be published between
+   specification drafts in order to correct errors.  Implementations
+   SHOULD consider URIs dated after this specification draft and before
+   the next to indicate the same syntax and semantics as those listed
+   here.
+
+
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 21]
+
+Internet-Draft                 JSON Schema                      May 2019
+
+
+7.6.  Example Meta-Schema With Vocabulary Declarations
+
+   This meta-schema explicitly declares both the Core and Applicator
+   vocabularies, and combines their meta-schemas with an "allOf".  It
+   additionally restricts the usage of the Applicator vocabulary by
+   forbidding the keyword prefixed with "unevaluated".  It also
+   describes a keyword, "localKeyword", that is not part of either
+   vocabulary.  Note that it is its own meta-schema, as it relies on
+   both the Core vocabulary (as all schemas do) and the Applicator
+   vocabulary (for "allOf").
+
+
+ {
+   "$schema": "https://json-schema.org/draft/2019-04/core-app-example#",
+   "$id": "https://json-schema.org/draft/2019-04/core-app-example",
+   "$recursiveAnchor": true,
+   "$vocabulary": {
+     "https://json-schema.org/draft/2019-04/vocab/core": true,
+     "https://json-schema.org/draft/2019-04/vocab/applicator": true
+   },
+   "allOf": [
+     {"$ref": "https://json-schema.org/draft/2019-04/meta/core"},
+     {"$ref": "https://json-schema.org/draft/2019-04/meta/applicator"}
+   ],
+   "patternProperties": {
+     "^unevaluated.*$": false
+   },
+   "properties": {
+     "$comment": "Not in vocabulary, but validated if used",
+     "localKeyword": {
+       "type": "string"
+     }
+   }
+ }
+
+
+   As shown above, even though each of the referenced standard meta-
+   schemas declares its corresponding vocabulary, this new meta-schema
+   must re-declare them for itself.  It would be valid to leave the core
+   vocabulary out of the "$vocabulary" keyword, but it needs to be
+   referenced through the "allOf" keyword in order for its terms to be
+   validated.  There is no special case for validation of core keywords.
+
+   The standard meta-schemas that combine all vocabularies defined by
+   the Core and Validation specification, and that combine all
+   vocabularies defined by those specifications as well as the Hyper-
+   Schema specification, demonstrate additional complex combinations.
+
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 22]
+
+Internet-Draft                 JSON Schema                      May 2019
+
+
+   These URIs for these meta-schemas may be found in the Validation and
+   Hyper-Schema specifications, respectively.
+
+8.  Base URI and Dereferencing
+
+   To differentiate between schemas in a vast ecosystem, schemas are
+   identified by URI [RFC3986], and can embed references to other
+   schemas by specifying their URI.
+
+8.1.  Initial Base URI
+
+   RFC3986 Section 5.1 [RFC3986] defines how to determine the default
+   base URI of a document.
+
+   Informatively, the initial base URI of a schema is the URI at which
+   it was found, whether that was a network location, a local
+   filesystem, or any other situation identifiable by a URI of any known
+   scheme.
+
+   If no source is known, or no URI scheme is known for the source, a
+   suitable implementation-specific default URI MAY be used as described
+   in RFC 3986 Section 5.1.4 [RFC3986].  It is RECOMMENDED that
+   implementations document any default base URI that they assume.
+
+8.2.  The "$id" Keyword
+
+   The "$id" keyword defines a URI for the schema, and the base URI that
+   other URI references within the schema are resolved against.  A
+   subschema's "$id" is resolved against the base URI of its parent
+   schema.  If no parent sets an explicit base with "$id", the base URI
+   is that of the entire document, as determined per RFC 3986 section 5
+   [RFC3986].
+
+   If present, the value for this keyword MUST be a string, and MUST
+   represent a valid URI-reference [RFC3986].  This value SHOULD be
+   normalized, and SHOULD NOT be an empty fragment <#> or an empty
+   string <>.
+
+8.2.1.  Identifying the root schema
+
+   The root schema of a JSON Schema document SHOULD contain an "$id"
+   keyword with an absolute-URI [RFC3986] (containing a scheme, but no
+   fragment), or this absolute URI but with an empty fragment.
+
+
+
+
+
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 23]
+
+Internet-Draft                 JSON Schema                      May 2019
+
+
+8.2.2.  Changing the base URI within a schema file
+
+   When an "$id" sets the base URI, the object containing that "$id" and
+   all of its subschemas can be identified by using a JSON Pointer
+   fragment starting from that location.  This is true even of
+   subschemas that further change the base URI.  Therefore, a single
+   subschema may be accessible by multiple URIs, each consisting of base
+   URI declared in the subschema or a parent, along with a JSON Pointer
+   fragment identifying the path from the schema object that declares
+   the base to the subschema being identified.  Examples of this are
+   shown in section 8.2.4.
+
+8.2.3.  Location-independent identifiers
+
+   Using JSON Pointer fragments requires knowledge of the structure of
+   the schema.  When writing schema documents with the intention to
+   provide re-usable schemas, it may be preferable to use a plain name
+   fragment that is not tied to any particular structural location.
+   This allows a subschema to be relocated without requiring JSON
+   Pointer references to be updated.
+
+   To specify such a subschema identifier, the "$id" keyword is set to a
+   URI reference with a plain name fragment (not a JSON Pointer
+   fragment).  This value MUST begin with the number sign that specifies
+   a fragment ("#"), then a letter ([A-Za-z]), followed by any number of
+   letters, digits ([0-9]), hyphens ("-"), underscores ("_"), colons
+   (":"), or periods (".").
+
+   The effect of using a fragment in "$id" that isn't blank or doesn't
+   follow the plain name syntax is undefined.  [[CREF4: How should an
+   "$id" URI reference containing a fragment with other components be
+   interpreted?  There are two cases: when the other components match
+   the current base URI and when they change the base URI.  ]]
+
+8.2.4.  Schema identification examples
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 24]
+
+Internet-Draft                 JSON Schema                      May 2019
+
+
+   Consider the following schema, which shows "$id" being used to
+   identify the root schema, change the base URI for subschemas, and
+   assign plain name fragments to subschemas:
+
+
+   {
+       "$id": "http://example.com/root.json",
+       "$defs": {
+           "A": { "$id": "#foo" },
+           "B": {
+               "$id": "other.json",
+               "$defs": {
+                   "X": { "$id": "#bar" },
+                   "Y": { "$id": "t/inner.json" }
+               }
+           },
+           "C": {
+               "$id": "urn:uuid:ee564b8a-7a87-4125-8c96-e9f123d6766f"
+           }
+       }
+   }
+
+
+   The schemas at the following URI-encoded JSON Pointers [RFC6901]
+   (relative to the root schema) have the following base URIs, and are
+   identifiable by any listed URI in accordance with Section 5 above:
+
+   # (document root)
+
+         http://example.com/root.json
+
+         http://example.com/root.json#
+
+   #/$defs/A
+
+         http://example.com/root.json#foo
+
+         http://example.com/root.json#/$defs/A
+
+   #/$defs/B
+
+         http://example.com/other.json
+
+         http://example.com/other.json#
+
+         http://example.com/root.json#/$defs/B
+
+   #/$defs/B/$defs/X
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 25]
+
+Internet-Draft                 JSON Schema                      May 2019
+
+
+         http://example.com/other.json#bar
+
+         http://example.com/other.json#/$defs/X
+
+         http://example.com/root.json#/$defs/B/$defs/X
+
+   #/$defs/B/$defs/Y
+
+         http://example.com/t/inner.json
+
+         http://example.com/t/inner.json#
+
+         http://example.com/other.json#/$defs/Y
+
+         http://example.com/root.json#/$defs/B/$defs/Y
+
+   #/$defs/C
+
+         urn:uuid:ee564b8a-7a87-4125-8c96-e9f123d6766f
+
+         urn:uuid:ee564b8a-7a87-4125-8c96-e9f123d6766f#
+
+         http://example.com/root.json#/$defs/C
+
+8.3.  Schema References
+
+   Several keywords can be used to reference a schema which is to be
+   applied to the current instance location. "$ref" and "$recursiveRef"
+   are applicator keywords, applying the referenced schema to the
+   instance.  "$recursiveAnchor" is a helper keyword that controls how
+   the referenced schema of "$recursiveRef" is determined.
+
+   As the value of "$ref" and "$recursiveRef" are URI References, this
+   allows the possibility to externalise or divide a schema across
+   multiple files, and provides the ability to validate recursive
+   structures through self-reference.
+
+   The resolved URI produced by these keywords is not necessarily a
+   network locator, only an identifier.  A schema need not be
+   downloadable from the address if it is a network-addressable URL, and
+   implementations SHOULD NOT assume they should perform a network
+   operation when they encounter a network-addressable URI.
+
+8.3.1.  Direct References with "$ref"
+
+   The "$ref" keyword is used to reference a statically identified
+   schema.
+
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 26]
+
+Internet-Draft                 JSON Schema                      May 2019
+
+
+   The value of the "$ref" property MUST be a string which is a URI
+   Reference.  Resolved against the current URI base, it identifies the
+   URI of a schema to use.
+
+8.3.2.  Recursive References with "$recursiveRef" and "$recursiveAnchor"
+
+   The "$recursiveRef" and "$recursiveAnchor" keywords are used to
+   construct extensible recursive schemas.  A recursive schema is one
+   that has a reference to its own root, identified by the empty
+   fragment URI reference ("#").
+
+   Extending a recursive schema with "$ref" alone involves redefining
+   all recursive references in the source schema to point to the root of
+   the extension.  This produces the correct recursive behavior in the
+   extension, which is that all recursion should reference the root of
+   the extension.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 27]
+
+Internet-Draft                 JSON Schema                      May 2019
+
+
+   Consider the following two schemas.  The first schema, identified as
+   "original" as it is the schema to be extended, describes an object
+   with one string property and one recursive reference property, "r".
+   The second schema, identified as "extension", references the first,
+   and describes an additional things" property, which is an array of
+   recursive references.  It also repeats the description of "r" from
+   the original schema.
+
+
+   {
+       "$schema": "http://json-schema.org/draft/2019-04/schema#",
+       "$id": "https://example.com/original",
+
+       "properties": {
+           "name": {
+               "type": "string"
+           },
+           "r": {
+               "$ref": "#"
+           }
+       }
+   }
+
+   {
+       "$schema": "http://json-schema.org/draft/2019-04/schema#",
+       "$id": "https://example.com/extension",
+
+       "$ref": "original",
+       "properties": {
+           "r": {
+               "$ref": "#"
+           },
+           "things": {
+               "type": "array"
+               "items": {
+                   "$ref": "#"
+               }
+           }
+       }
+   }
+
+
+   This apparent duplication is important because it resolves to
+   "https://example.com/extension#", meaning that for instance validated
+   against the extension schema, the value of "r" must be valid
+   according to the extension, and not just the original schema as "r"
+   was described there.
+
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 28]
+
+Internet-Draft                 JSON Schema                      May 2019
+
+
+   This approach is fine for a single recursive field, but the more
+   complicated the original schema, the more redefinitions are necessary
+   in the extension.  This leads to a verbose and error-prone extension,
+   which must be kept synchronized with the original schema if the
+   original changes its recursive fields.  This approach can be seen in
+   the meta-schema for JSON Hyper-Schema in all prior drafts.
+
+8.3.2.1.  Enabling Recursion with "$recursiveAnchor"
+
+   The desired behavior is for the recursive reference, "r", in the
+   original schema to resolve to the original schema when that is the
+   only schema being used, but to resolve to the extension schema when
+   using the extension.  Then there would be no need to redefine the "r"
+   property, or others like it, in the extension.
+
+   In order to create a recursive reference, we must do three things:
+
+      In our original schema, indicate that the schema author intends
+      for it to be extensible recursively.
+
+      In our extension schema, indicate that it is intended to be a
+      recursive extension.
+
+      Use a reference keyword that explicitly activates the recursive
+      behavior at the point of reference.
+
+   These three things together ensure that all schema authors are
+   intentionally constructing a recursive extension, which in turn gives
+   all uses of the regular "$ref" keyword confidence that it only
+   behaves as it appears to, using lexical scoping.
+
+   The "$recursiveAnchor" keyword is how schema authors indicate that a
+   schema can be extended recursively, and be a recursive schema.  This
+   keyword MAY appear in the root schema of a schema document, and MUST
+   NOT appear in any subschema.
+
+   The value of "$recursiveAnchor" MUST be of type boolean, and MUST be
+   true.  The value false is reserved for possible future use.
+
+8.3.2.2.  Dynamically recursive references with "$recursiveRef"
+
+   The "$recursiveRef" keyword behaves identically to "$ref", except
+   that if the referenced schema has "$recursiveAnchor" set to true,
+   then the implementation MUST examine the dynamic scope for the
+   outermost (first seen) schema document with "$recursiveAnchor" set to
+   true.  If such a schema document exists, then the target of the
+   "$recursiveRef" MUST be set to that document's URI, in place of the
+   URI produced by the rules for "$ref".
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 29]
+
+Internet-Draft                 JSON Schema                      May 2019
+
+
+   Note that if the schema referenced by "$recursiveRef" does not
+   contain "$recursiveAnchor" set to true, or if there are no other
+   "$recursiveAnchor" keywords set to true anywhere further back in the
+   dynamic scope, then "$recursiveRef"'s behavior is identical to that
+   of "$ref".
+
+   With this in mind, we can rewrite the previous example:
+
+
+   {
+       "$schema": "http://json-schema.org/draft/2019-04/schema#",
+       "$id": "https://example.com/original",
+       "$recursiveAnchor": true,
+
+       "properties": {
+           "name": {
+               "type": "string"
+           },
+           "r": {
+               "$recursiveRef": "#"
+           }
+       }
+   }
+
+   {
+       "$schema": "http://json-schema.org/draft/2019-04/schema#",
+       "$id": "https://example.com/extension",
+       "$recursiveAnchor": true,
+
+       "$ref": "original",
+       "properties": {
+           "things": {
+               "type": "array"
+               "items": {
+                   "$recursiveRef": "#"
+               }
+           }
+       }
+   }
+
+
+   Note that the "r" property no longer appears in the extension schema.
+   Instead, all "$ref"s have been changed to "$recursiveRef"s, and both
+   schemas have "$recursiveAnchor" set to true in their root schema.
+
+   When using the original schema on its own, there is no change in
+   behavior.  The "$recursiveRef" does lead to a schema where
+   "$recursiveAnchor" is set to true, but since the original schema is
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 30]
+
+Internet-Draft                 JSON Schema                      May 2019
+
+
+   the only schema document in the dynamics scope (it references itself,
+   and does not reference any other schema documents), the behavior is
+   effectively the same as "$ref".
+
+   When using the extension schema, the "$recursiveRef" within that
+   schema (for the array items within "things") also effectively behaves
+   like "$ref".  The extension schema is the outermost dynamic scope, so
+   the reference target is not changed.
+
+   In contrast, when using the extension schema, the "$recursiveRef" for
+   "r" in the original schema now behaves differently.  Its initial
+   target is the root schema of the original schema document, which has
+   "$recursiveAnchor" set to true.  In this case, the outermost dynamic
+   scope that also has "$recursiveAnchor" set to true is the extension
+   schema.  So when using the extensions schema, "r"'s reference in the
+   original schema will resolve to "https://example.com/extension#", not
+   "https://example.com/original#".
+
+8.3.3.  Guarding Against Infinite Recursion
+
+   A schema MUST NOT be run into an infinite loop against an instance.
+   For example, if two schemas "#alice" and "#bob" both have an "allOf"
+   property that refers to the other, a naive validator might get stuck
+   in an infinite recursive loop trying to validate the instance.
+   Schemas SHOULD NOT make use of infinite recursive nesting like this;
+   the behavior is undefined.
+
+8.3.4.  References to Possible Non-Schemas
+
+   Subschema objects (or booleans) are recognized by their use with
+   known applicator keywords.  These keywords may be the standard
+   applicators from this document, or extension keywords from a known
+   vocabulary, or implementation-specific custom keywords.
+
+   Multi-level structures of unknown keywords are capable of introducing
+   nested subschemas, which would be subject to the processing rules for
+   "$id".  Therefore, having a reference target in such an unrecognized
+   structure cannot be reliably implemented, and the resulting behavior
+   is undefined.  Similarly, a reference target under a known keyword,
+   for which the value is known not to be a schema, results in undefined
+   behavior in order to avoid burdening implementations with the need to
+   detect such targets.  [[CREF5: These scenarios are analogous to
+   fetching a schema over HTTP but receiving a response with a Content-
+   Type other than application/schema+json.  An implementation can
+   certainly try to interpret it as a schema, but the origin server
+   offered no guarantee that it actually is any such thing.  Therefore,
+   interpreting it as such has security implications and may produce
+   unpredictable results.  ]]
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 31]
+
+Internet-Draft                 JSON Schema                      May 2019
+
+
+   Note that single-level custom keywords with identical syntax and
+   semantics to "$defs" do not allow for any intervening "$id" keywords,
+   and therefore will behave correctly under implementations that
+   attempt to use any reference target as a schema.  However, this
+   behavior is implementation-specific and MUST NOT be relied upon for
+   interoperability.
+
+8.3.5.  Loading a referenced schema
+
+   The use of URIs to identify remote schemas does not necessarily mean
+   anything is downloaded, but instead JSON Schema implementations
+   SHOULD understand ahead of time which schemas they will be using, and
+   the URIs that identify them.
+
+   When schemas are downloaded, for example by a generic user-agent that
+   doesn't know until runtime which schemas to download, see Usage for
+   Hypermedia (Section 13).
+
+   Implementations SHOULD be able to associate arbitrary URIs with an
+   arbitrary schema and/or automatically associate a schema's "$id"-
+   given URI, depending on the trust that the validator has in the
+   schema.  Such URIs and schemas can be supplied to an implementation
+   prior to processing instances, or may be noted within a schema
+   document as it is processed, producing associations as shown in
+   section 8.2.4.
+
+   A schema MAY (and likely will) have multiple URIs, but there is no
+   way for a URI to identify more than one schema.  When multiple
+   schemas try to identify as the same URI, validators SHOULD raise an
+   error condition.
+
+8.3.6.  Dereferencing
+
+   Schemas can be identified by any URI that has been given to them,
+   including a JSON Pointer or their URI given directly by "$id".  In
+   all cases, dereferencing a "$ref" reference involves first resolving
+   its value as a URI reference against the current base URI per RFC
+   3986 [RFC3986].
+
+   If the resulting URI identifies a schema within the current document,
+   or within another schema document that has been made available to the
+   implementation, then that schema SHOULD be used automatically.
+
+   For example, consider this schema:
+
+
+
+
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 32]
+
+Internet-Draft                 JSON Schema                      May 2019
+
+
+   {
+       "$id": "http://example.net/root.json",
+       "items": {
+           "type": "array",
+           "items": { "$ref": "#item" }
+       },
+       "$defs": {
+           "single": {
+               "$id": "#item",
+               "type": "object",
+               "additionalProperties": { "$ref": "other.json" }
+           }
+       }
+   }
+
+
+   When an implementation encounters the <#/$defs/single> schema, it
+   resolves the "$id" URI reference against the current base URI to form
+   <http://example.net/root.json#item>.
+
+   When an implementation then looks inside the <#/items> schema, it
+   encounters the <#item> reference, and resolves this to
+   <http://example.net/root.json#item>, which it has seen defined in
+   this same document and can therefore use automatically.
+
+   When an implementation encounters the reference to "other.json", it
+   resolves this to <http://example.net/other.json>, which is not
+   defined in this document.  If a schema with that identifier has
+   otherwise been supplied to the implementation, it can also be used
+   automatically.  [[CREF6: What should implementations do when the
+   referenced schema is not known?  Are there circumstances in which
+   automatic network dereferencing is allowed?  A same origin policy?  A
+   user-configurable option?  In the case of an evolving API described
+   by Hyper-Schema, it is expected that new schemas will be added to the
+   system dynamically, so placing an absolute requirement of pre-loading
+   schema documents is not feasible.  ]]
+
+8.4.  Schema Re-Use With "$defs"
+
+   The "$defs" keyword provides a standardized location for schema
+   authors to inline re-usable JSON Schemas into a more general schema.
+   The keyword does not directly affect the validation result.
+
+   This keyword's value MUST be an object.  Each member value of this
+   object MUST be a valid JSON Schema.
+
+
+
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 33]
+
+Internet-Draft                 JSON Schema                      May 2019
+
+
+   As an example, here is a schema describing an array of positive
+   integers, where the positive integer constraint is a subschema in
+   "$defs":
+
+
+   {
+       "type": "array",
+       "items": { "$ref": "#/$defs/positiveInteger" },
+       "$defs": {
+           "positiveInteger": {
+               "type": "integer",
+               "exclusiveMinimum": 0
+           }
+       }
+   }
+
+
+9.  Comments With "$comment"
+
+   This keyword is reserved for comments from schema authors to readers
+   or maintainers of the schema.  The value of this keyword MUST be a
+   string.  Implementations MUST NOT present this string to end users.
+   Tools for editing schemas SHOULD support displaying and editing this
+   keyword.  The value of this keyword MAY be used in debug or error
+   output which is intended for developers making use of schemas.
+   Schema vocabularies SHOULD allow "$comment" within any object
+   containing vocabulary keywords.  Implementations MAY assume
+   "$comment" is allowed unless the vocabulary specifically forbids it.
+   Vocabularies MUST NOT specify any effect of "$comment" beyond what is
+   described in this specification.  Tools that translate other media
+   types or programming languages to and from application/schema+json
+   MAY choose to convert that media type or programming language's
+   native comments to or from "$comment" values.  The behavior of such
+   translation when both native comments and "$comment" properties are
+   present is implementation-dependent.  Implementations SHOULD treat
+   "$comment" identically to an unknown extension keyword.  They MAY
+   strip "$comment" values at any point during processing.  In
+   particular, this allows for shortening schemas when the size of
+   deployed schemas is a concern.  Implementations MUST NOT take any
+   other action based on the presence, absence, or contents of
+   "$comment" properties.  In particular, the value of "$comment" MUST
+   NOT be collected as an annotation result.
+
+10.  Collecting Annotations
+
+   Annotations are collected by keywords that explicitly define
+   annotation-collecting behavior.  Note that boolean schemas cannot
+   produce annotations as they do not make use of keywords.
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 34]
+
+Internet-Draft                 JSON Schema                      May 2019
+
+
+   A collected annotation MUST include the following information:
+
+      The name of the keyword that produces the annotation
+
+      The instance location to which it is attached, as a JSON Pointer
+
+      The schema location path, indicating how reference keywords such
+      as "$ref" were followed to reach the absolute schema location.
+
+      The absolute schema location of the attaching keyword, as a URI.
+      This MAY be omitted if it is the same as the schema location path
+      from above.
+
+      The attached value(s)
+
+   If the same keyword attaches values from multiple schema locations to
+   the same instance location, and the annotation defines a process for
+   combining such values, then the combined value MUST also be
+   associated with the instance location.
+
+10.1.  Distinguishing Among Multiple Values
+
+   Applications MAY make decisions on which of multiple annotation
+   values to use based on the schema location that contributed the
+   value.  This is intended to allow flexible usage.  Collecting the
+   schema location facilitates such usage.
+
+   For example, consider this schema, which uses annotations and
+   assertions from the Validation specification
+   [json-schema-validation]:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 35]
+
+Internet-Draft                 JSON Schema                      May 2019
+
+
+   Note that some lines are wrapped for clarity.
+
+
+   {
+       "title": "Feature list",
+       "type": "array",
+           "items": [
+               {
+                   "title": "Feature A",
+                   "properties": {
+                       "enabled": {
+                           "$ref": "#/$defs/enabledToggle",
+                           "default": true
+                       }
+                   }
+               },
+               {
+                   "title": "Feature B",
+                   "properties": {
+                       "enabled": {
+                           "description": "If set to null, Feature B
+                                           inherits the enabled
+                                           value from Feature A",
+                           "$ref": "#/$defs/enabledToggle"
+                       }
+                   }
+               }
+           ]
+       },
+       "$defs": {
+           "enabledToggle": {
+               "title": "Enabled",
+               "description": "Whether the feature is enabled (true),
+                               disabled (false), or under
+                               automatic control (null)",
+               "type": ["boolean", "null"],
+               "default": null
+           }
+       }
+   }
+
+
+   In this example, both Feature A and Feature B make use of the re-
+   usable "enabledToggle" schema.  That schema uses the "title",
+   "description", and "default" annotations, none of which define
+   special behavior for handling multiple values.  Therefore the
+   application has to decide how to handle the additional "default"
+
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 36]
+
+Internet-Draft                 JSON Schema                      May 2019
+
+
+   value for Feature A, and the additional "description" value for
+   Feature B.
+
+   The application programmer and the schema author need to agree on the
+   usage.  For this example, let's assume that they agree that the most
+   specific "default" value will be used, and any additional, more
+   generic "default" values will be silently ignored.  Let's also assume
+   that they agree that all "description" text is to be used, starting
+   with the most generic, and ending with the most specific.  This
+   requires the schema author to write descriptions that work when
+   combined in this way.
+
+   The application can use the schema location path to determine which
+   values are which.  The values in the feature's immediate "enabled"
+   property schema are more specific, while the values under the re-
+   usable schema that is referenced to with "$ref" are more generic.
+   The schema location path will show whether each value was found by
+   crossing a "$ref" or not.
+
+   Feature A will therefore use a default value of true, while Feature B
+   will use the generic default value of null.  Feature A will only have
+   the generic description from the "enabledToggle" schema, while
+   Feature B will use that description, and also append its locally
+   defined description that explains how to interpret a null value.
+
+   Note that there are other reasonable approaches that a different
+   application might take.  For example, an application may consider the
+   presence of two different values for "default" to be an error,
+   regardless of their schema locations.
+
+10.2.  Annotations and Assertions
+
+   Schema objects that produce a false assertion result MUST NOT produce
+   any annotation results, whether from their own keywords or from
+   keywords in subschemas.
+
+   Note that the overall schema results may still include annotations
+   collected from other schema locations.  Given this schema:
+
+
+
+
+
+
+
+
+
+
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 37]
+
+Internet-Draft                 JSON Schema                      May 2019
+
+
+   {
+       "oneOf": [
+           {
+               "title": "Integer Value",
+               "type": "integer"
+           },
+           {
+               "title": "String Value",
+               "type": "string"
+           }
+       ]
+   }
+
+
+   And the instance ""This is a string"", the title annotation "Integer
+   Value" is discarded because the type assertion in that schema object
+   fails.  The title annotation "String Value" is kept, as the instance
+   passes the string type assertions.
+
+10.3.  Annotations and Applicators
+
+   In addition to possibly defining annotation results of their own,
+   applicator keywords aggregate the annotations collected in their
+   subschema(s) or referenced schema(s).  The rules for aggregating
+   annotation values are defined by each annotation keyword, and are not
+   directly affected by the logic used for combining assertion results.
+
+11.  A Vocabulary for Applying Subschemas
+
+   This section defines a vocabulary of applicator keywords that are
+   RECOMMENDED for use as the basis of other vocabularies.
+
+   Meta-schemas that do not use "$vocabulary" SHOULD be considered to
+   require this vocabulary as if its URI were present with a value of
+   true.
+
+   The current URI for this vocabulary, known as the Applicator
+   vocabulary, is: <https://json-schema.org/draft/2019-04/vocab/
+   applicator>.
+
+   The current URI for the corresponding meta-schema is: <https://json-
+   schema.org/draft/2019-04/meta/applicator>.
+
+   Updated vocabulary and meta-schema URIs MAY be published between
+   specification drafts in order to correct errors.  Implementations
+   SHOULD consider URIs dated after this specification draft and before
+   the next to indicate the same syntax and semantics as those listed
+   here.
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 38]
+
+Internet-Draft                 JSON Schema                      May 2019
+
+
+11.1.  Keyword Independence
+
+   Schema keywords typically operate independently, without affecting
+   each other's outcomes.
+
+   For schema author convenience, there are some exceptions among the
+   keywords in this vocabulary:
+
+      "additionalProperties", whose behavior is defined in terms of
+      "properties" and "patternProperties"
+
+      "unevaluatedProperties", whose behavior is defined in terms of
+      annotations from "properties", "patternProperties",
+      "additionalProperties" and itself
+
+      "additionalItems", whose behavior is defined in terms of "items"
+
+      "unevaluatedItems", whose behavior is defined in terms of
+      annotations from "items", "additionalItems" and itself
+
+11.2.  Keywords for Applying Subschemas in Place
+
+   These keywords apply subschemas to the same location in the instance
+   as the parent schema is being applied.  They allow combining or
+   modifying the subschema results in various ways.
+
+11.2.1.  Keywords for Applying Subschemas With Boolean Logic
+
+   These keywords correspond to logical operators for combining or
+   modifying the boolean assertion results of the subschemas.  They have
+   no direct impact on annotation collection, although they enable the
+   same annotation keyword to be applied to an instance location with
+   different values.  Annotation keywords define their own rules for
+   combining such values.
+
+11.2.1.1.  allOf
+
+   This keyword's value MUST be a non-empty array.  Each item of the
+   array MUST be a valid JSON Schema.
+
+   An instance validates successfully against this keyword if it
+   validates successfully against all schemas defined by this keyword's
+   value.
+
+
+
+
+
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 39]
+
+Internet-Draft                 JSON Schema                      May 2019
+
+
+11.2.1.2.  anyOf
+
+   This keyword's value MUST be a non-empty array.  Each item of the
+   array MUST be a valid JSON Schema.
+
+   An instance validates successfully against this keyword if it
+   validates successfully against at least one schema defined by this
+   keyword's value.
+
+11.2.1.3.  oneOf
+
+   This keyword's value MUST be a non-empty array.  Each item of the
+   array MUST be a valid JSON Schema.
+
+   An instance validates successfully against this keyword if it
+   validates successfully against exactly one schema defined by this
+   keyword's value.
+
+11.2.1.4.  not
+
+   This keyword's value MUST be a valid JSON Schema.
+
+   An instance is valid against this keyword if it fails to validate
+   successfully against the schema defined by this keyword.
+
+11.2.2.  Keywords for Applying Subschemas Conditionally
+
+   Three of these keywords work together to implement conditional
+   application of a subschema based on the outcome of another subschema.
+   The fourth is a shortcut for a specific conditional case.
+
+   "if", "then", and "else" MUST NOT interact with each other across
+   subschema boundaries.  In other words, an "if" in one branch of an
+   "allOf" MUST NOT have an impact on a "then" or "else" in another
+   branch.
+
+   There is no default behavior for "if", "then", or "else" when they
+   are not present.  In particular, they MUST NOT be treated as if
+   present with an empty schema, and when "if" is not present, both
+   "then" and "else" MUST be entirely ignored.
+
+11.2.2.1.  if
+
+   This keyword's value MUST be a valid JSON Schema.
+
+   This validation outcome of this keyword's subschema has no direct
+   effect on the overall validation result.  Rather, it controls which
+   of the "then" or "else" keywords are evaluated.
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 40]
+
+Internet-Draft                 JSON Schema                      May 2019
+
+
+   Instances that successfully validate against this keyword's subschema
+   MUST also be valid against the subschema value of the "then" keyword,
+   if present.
+
+   Instances that fail to validate against this keyword's subschema MUST
+   also be valid against the subschema value of the "else" keyword, if
+   present.
+
+   If annotations (Section 3.1.5) are being collected, they are
+   collected from this keyword's subschema in the usual way, including
+   when the keyword is present without either "then" or "else".
+
+11.2.2.2.  then
+
+   This keyword's value MUST be a valid JSON Schema.
+
+   When "if" is present, and the instance successfully validates against
+   its subschema, then validation succeeds against this keyword if the
+   instance also successfully validates against this keyword's
+   subschema.
+
+   This keyword has no effect when "if" is absent, or when the instance
+   fails to validate against its subschema.  Implementations MUST NOT
+   evaluate the instance against this keyword, for either validation or
+   annotation collection purposes, in such cases.
+
+11.2.2.3.  else
+
+   This keyword's value MUST be a valid JSON Schema.
+
+   When "if" is present, and the instance fails to validate against its
+   subschema, then validation succeeds against this keyword if the
+   instance successfully validates against this keyword's subschema.
+
+   This keyword has no effect when "if" is absent, or when the instance
+   successfully validates against its subschema.  Implementations MUST
+   NOT evaluate the instance against this keyword, for either validation
+   or annotation collection purposes, in such cases.
+
+11.2.2.4.  dependentSchemas
+
+   This keyword specifies subschemas that are evaluated if the instance
+   is an object and contains a certain property.
+
+   This keyword's value MUST be an object.  Each value in the object
+   MUST be a valid JSON Schema.
+
+
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 41]
+
+Internet-Draft                 JSON Schema                      May 2019
+
+
+   If the object key is a property in the instance, the entire instance
+   must validate against the subschema.  Its use is dependent on the
+   presence of the property.
+
+   Omitting this keyword has the same behavior as an empty object.
+
+11.3.  Keywords for Applying Subschemas to Child Instances
+
+   Each of these keywords defines a rule for applying its subschema(s)
+   to child instances, specifically object properties and array items,
+   and combining their results.
+
+11.3.1.  Keywords for Applying Subschemas to Arrays
+
+11.3.1.1.  items
+
+   The value of "items" MUST be either a valid JSON Schema or an array
+   of valid JSON Schemas.
+
+   If "items" is a schema, validation succeeds if all elements in the
+   array successfully validate against that schema.
+
+   If "items" is an array of schemas, validation succeeds if each
+   element of the instance validates against the schema at the same
+   position, if any.
+
+   This keyword produces an annotation value which is the largest index
+   to which this keyword applied a subschema.  The value MAY be a
+   boolean true if a subschema was applied to every index of the
+   instance, such as when "items" is a schema.
+
+   Annotation results for "items" keywords from multiple schemas applied
+   to the same instance location are combined by setting the combined
+   result to true if any of the values are true, and otherwise retaining
+   the largest numerical value.
+
+   Omitting this keyword has the same assertion behavior as an empty
+   schema.
+
+11.3.1.2.  additionalItems
+
+   The value of "additionalItems" MUST be a valid JSON Schema.
+
+   The behavior of this keyword depends on the presence and annotation
+   result of "items" within the same schema object.  If "items" is
+   present, and its annotation result is a number, validation succeeds
+   if every instance element at an index greater than that number
+   validates against "additionalItems".
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 42]
+
+Internet-Draft                 JSON Schema                      May 2019
+
+
+   Otherwise, if "items" is absent or its annotation result is the
+   boolean true, "additionalItems" MUST be ignored.
+
+   If the "additionalItems" subschema is applied to any positions within
+   the instance array, it produces an annotation result of boolean true,
+   analogous to the single schema behavior of "items".  If any
+   "additionalItems" keyword from any subschema applied to the same
+   instance location produces an annotation value of true, then the
+   combined result from these keywords is also true.
+
+   Omitting this keyword has the same assertion behavior as an empty
+   schema.
+
+   Implementations MAY choose to implement or optimize this keyword in
+   another way that produces the same effect, such as by directly
+   checking for the presence and size of an "items" array.
+   Implementations that do not support annotation collection MUST do so.
+
+11.3.1.3.  unevaluatedItems
+
+   The value of "unevaluatedItems" MUST be a valid JSON Schema.
+
+   The behavior of this keyword depends on the annotation results of
+   adjacent keywords that apply to the instance location being
+   validated.  Specifically, the annotations from "items" and
+   "additionalItems", which can come from those keywords when they are
+   adjacent to the "unevaluatedItems" keyword.  Those two annotations,
+   as well as "unevaluatedItems", can also result from any and all
+   adjacent in-place applicator (Section 11.2) keywords.  This includes
+   but is not limited to the in-place applicators defined in this
+   document.
+
+   If an "items" annotation is present, and its annotation result is a
+   number, and no "additionalItems" or "unevaluatedItems" annotation is
+   present, then validation succeeds if every instance element at an
+   index greater than the "items" annotation validates against
+   "unevaluatedItems".
+
+   Otherwise, if any "items", "additionalItems", or "unevaluatedItems"
+   annotations are present with a value of boolean true, then
+   "unevaluatedItems" MUST be ignored.  However, if none of these
+   annotations are present, "unevaluatedItems" MUST be applied to all
+   locations in the array.
+
+   This means that "items", "additionalItems", and all in-place
+   applicators MUST be evaluated before this keyword can be evaluated.
+   Authors of extension keywords MUST NOT define an in-place applicator
+   that would need to be evaluated before this keyword.
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 43]
+
+Internet-Draft                 JSON Schema                      May 2019
+
+
+   If the "unevaluatedItems" subschema is applied to any positions
+   within the instance array, it produces an annotation result of
+   boolean true, analogous to the single schema behavior of "items".  If
+   any "unevaluatedItems" keyword from any subschema applied to the same
+   instance location produces an annotation value of true, then the
+   combined result from these keywords is also true.
+
+   Omitting this keyword has the same assertion behavior as an empty
+   schema.
+
+   Implementations that do not collect annotations MUST raise an error
+   upon encountering this keyword.
+
+11.3.1.4.  contains
+
+   The value of this keyword MUST be a valid JSON Schema.
+
+   An array instance is valid against "contains" if at least one of its
+   elements is valid against the given schema.  This keyword does not
+   produce annotation results.  [[CREF7: Should it produce a set of the
+   indices for which the array element is valid against the subschema?
+   "contains" does not affect "additionalItems" or any other current or
+   proposed keyword, but the information could be useful, and
+   implementation that collect annotations need to apply "contains" to
+   every element anyway.  ]]
+
+11.3.2.  Keywords for Applying Subschemas to Objects
+
+11.3.2.1.  properties
+
+   The value of "properties" MUST be an object.  Each value of this
+   object MUST be a valid JSON Schema.
+
+   Validation succeeds if, for each name that appears in both the
+   instance and as a name within this keyword's value, the child
+   instance for that name successfully validates against the
+   corresponding schema.
+
+   The annotation result of this keyword is the set of instance property
+   names matched by this keyword.  Annotation results for "properties"
+   keywords from multiple schemas applied to the same instance location
+   are combined by taking the union of the sets.
+
+   Omitting this keyword has the same assertion behavior as an empty
+   object.
+
+
+
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 44]
+
+Internet-Draft                 JSON Schema                      May 2019
+
+
+11.3.2.2.  patternProperties
+
+   The value of "patternProperties" MUST be an object.  Each property
+   name of this object SHOULD be a valid regular expression, according
+   to the ECMA 262 regular expression dialect.  Each property value of
+   this object MUST be a valid JSON Schema.
+
+   Validation succeeds if, for each instance name that matches any
+   regular expressions that appear as a property name in this keyword's
+   value, the child instance for that name successfully validates
+   against each schema that corresponds to a matching regular
+   expression.
+
+   The annotation result of this keyword is the set of instance property
+   names matched by this keyword.  Annotation results for
+   "patternProperties" keywords from multiple schemas applied to the
+   same instance location are combined by taking the union of the sets.
+
+   Omitting this keyword has the same assertion behavior as an empty
+   object.
+
+11.3.2.3.  additionalProperties
+
+   The value of "additionalProperties" MUST be a valid JSON Schema.
+
+   The behavior of this keyword depends on the presence and annotation
+   results of "properties" and "patternProperties" within the same
+   schema object.  Validation with "additionalProperties" applies only
+   to the child values of instance names that do not appear in the
+   annotation results of either "properties" or "patternProperties".
+
+   For all such properties, validation succeeds if the child instance
+   validates against the "additionalProperties" schema.
+
+   The annotation result of this keyword is the set of instance property
+   names validated by this keyword's subschema.  Annotation results for
+   "additionalProperties" keywords from multiple schemas applied to the
+   same instance location are combined by taking the union of the sets.
+
+   Omitting this keyword has the same assertion behavior as an empty
+   schema.
+
+   Implementations MAY choose to implement or optimize this keyword in
+   another way that produces the same effect, such as by directly
+   checking the names in "properties" and the patterns in
+   "patternProperties" against the instance property set.
+   Implementations that do not support annotation collection MUST do so.
+
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 45]
+
+Internet-Draft                 JSON Schema                      May 2019
+
+
+11.3.2.4.  unevaluatedProperties
+
+   The value of "unevaluatedProperties" MUST be a valid JSON Schema.
+
+   The behavior of this keyword depends on the annotation results of
+   adjacent keywords that apply to the instance location being
+   validated.  Specifically, the annotations from "properties",
+   "patternProperties", and "additionalProperties", which can come from
+   those keywords when they are adjacent to the "unevaluatedProperties"
+   keyword.  Those three annotations, as well as
+   "unevaluatedProperties", can also result from any and all adjacent
+   in-place applicator (Section 11.2) keywords.  This includes but is
+   not limited to the in-place applicators defined in this document.
+
+   Validation with "unevaluatedProperties" applies only to the child
+   values of instance names that do not appear in the "properties",
+   "patternProperties", "additionalProperties", or
+   "unevaluatedProperties" annotation results that apply to the instance
+   location being validated.
+
+   For all such properties, validation succeeds if the child instance
+   validates against the "unevaluatedProperties" schema.
+
+   This means that "properties", "patternProperties",
+   "additionalProperties", and all in-place applicators MUST be
+   evaluated before this keyword can be evaluated.  Authors of extension
+   keywords MUST NOT define an in-place applicator that would need to be
+   evaluated before this keyword.
+
+   The annotation result of this keyword is the set of instance property
+   names validated by this keyword's subschema.  Annotation results for
+   "unevaluatedProperties" keywords from multiple schemas applied to the
+   same instance location are combined by taking the union of the sets.
+
+   Omitting this keyword has the same assertion behavior as an empty
+   schema.
+
+   Implementations that do not collect annotations MUST raise an error
+   upon encountering this keyword.
+
+11.3.2.5.  propertyNames
+
+   The value of "propertyNames" MUST be a valid JSON Schema.
+
+   If the instance is an object, this keyword validates if every
+   property name in the instance validates against the provided schema.
+   Note the property name that the schema is testing will always be a
+   string.
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 46]
+
+Internet-Draft                 JSON Schema                      May 2019
+
+
+   Omitting this keyword has the same behavior as an empty schema.
+
+12.  Output Formatting
+
+   JSON Schema is defined to be platform-independent.  As such, to
+   increase compatibility across platforms, implementations SHOULD
+   conform to a standard validation output format.  This section
+   describes the minimum requirements that consumers will need to
+   properly interpret validation results.
+
+12.1.  Format
+
+   JSON Schema output is defined using the JSON Schema data instance
+   model as described in section 4.2.1.  Implementations MAY deviate
+   from this as supported by their specific languages and platforms,
+   however it is RECOMMENDED that the output be convertible to the JSON
+   format defined herein via serialization or other means.
+
+12.2.  Output Formats
+
+   This specification defines four output formats.  See the "Output
+   Structure" section for the requirements of each format.
+
+      Flag - A boolean which simply indicates the overall validation
+      result with no further details.
+
+      Basic - Provides validation information in a flat list structure.
+
+      Detailed - Provides validation information in a condensed
+      hierarchical structure based on the structure of the schema.
+
+      Verbose - Provides validation information in an uncondensed
+      hierarchical structure that matches the exact structure of the
+      schema.
+
+   An implementation SHOULD provide at least the "flag", "basic", or
+   "detailed" format and MAY provide the "verbose" format.  If it
+   provides one or more of the complex formats, it MUST also provide the
+   "flag" format.  Implementations SHOULD specify in their documentation
+   which formats they support.
+
+12.3.  Minimum Information
+
+   Beyond the simplistic "flag" output, additional information is useful
+   to aid in debugging a schema or instance.  Each sub-result SHOULD
+   contain the information contained within this section at a minimum.
+
+
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 47]
+
+Internet-Draft                 JSON Schema                      May 2019
+
+
+   A single object that contains all of these components is considered
+   an output unit.
+
+   Implementations MAY elect to provide additional information.
+
+12.3.1.  Keyword Relative Location
+
+   The relative location of the validating keyword that follows the
+   validation path.  The value MUST be expressed as a JSON Pointer, and
+   it MUST include any by-reference applicators such as "$ref" or
+   "$recursiveRef".
+
+
+   #/properties/minLength/$ref/minimum
+
+
+   Note that this pointer may not be resolvable due to the inclusion of
+   these applicator keywords.
+
+   The JSON key for this information is "keywordLocation".
+
+12.3.2.  Keyword Absolute Location
+
+   The absolute, dereferenced location of the validating keyword.  The
+   value MUST be expressed as an absolute URI, and it MUST NOT include
+   by-reference applicators such as "$ref" or "$recursiveRef".
+
+
+http://json-schema.org/draft/2019-04/schema#/$defs/nonNegativeInteger/minimum
+
+
+   This information MAY be omitted only if either the relative location
+   contains no references or if the schema does not declare an absolute
+   URI as its "$id".
+
+   The JSON key for this information is "absoluteKeywordLocation".
+
+12.3.3.  Instance Location
+
+   The location of the JSON value within the instance being validated.
+   The value MUST be expressed as a JSON Pointer.
+
+   The JSON key for this information is "instanceLocation".
+
+
+
+
+
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 48]
+
+Internet-Draft                 JSON Schema                      May 2019
+
+
+12.3.4.  Error or Annotation
+
+   The error or annotation that is produced by the validation.
+
+   For errors, the specific wording for the message is not defined by
+   this specification.  Implementations will need to provide this.
+
+   The JSON key for failed validations is "error"; for successful
+   validations it is "annotation".
+
+12.3.5.  Nested Results
+
+   For the two hierarchical structures, this property will hold nested
+   errors and annotations.
+
+   The JSON key for nested results in failed validations is "errors";
+   for successful validations it is "annotations".
+
+12.4.  Output Structure
+
+   The output MUST be an object containing a boolean property named
+   "valid".  When additional information about the result is required,
+   the output MUST also contain "errors" or "annotations" as described
+   below.
+
+      "valid" - a boolean value indicating the overall validation
+      success or failure
+
+      "errors" - the collection of errors or annotations produced by a
+      failed validation
+
+      "annotations" - the collection of errors or annotations produced
+      by a successful validation
+
+   For these examples, the following schema and instance will be used.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 49]
+
+Internet-Draft                 JSON Schema                      May 2019
+
+
+   {
+     "$id": "http://example.com/polygon#",
+     "$schema": "http://json-schema.org/draft/2019-04/schema#",
+     "$defs": {
+       "point": {
+         "type": "object",
+         "properties": {
+           "x": { "type": "number" },
+           "y": { "type": "number" }
+         },
+         "additionalProperties": false,
+         "required": [ "x", "y" ]
+       }
+     },
+     "type": "array",
+     "items": { "$ref": "#/$defs/point" },
+     "minItems": 3
+   }
+
+   [
+     {
+       "x": 2.5,
+       "y": 1.3,
+     },
+     {
+       "x": 1,
+       "z": 6.7
+     }
+   ]
+
+
+   This instance will fail validation and produce errors, but it's
+   trivial to deduce examples for passing schemas that produce
+   annotations.
+
+   Specifically, the errors it will produce are:
+
+      The second element in the "vertices" property is missing a "y"
+      property.
+
+      The second element in the "vertices" property has a disallowed "z"
+      property.
+
+      There are only two vertices, but three are required.
+
+   Note that neither the error message property nor its wording as
+   depicted in these examples is not a requirement of this
+
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 50]
+
+Internet-Draft                 JSON Schema                      May 2019
+
+
+   specification.  Implementations SHOULD craft error messages tailored
+   for their audience.
+
+12.4.1.  Flag
+
+   In the simplest case, merely the boolean result for the "valid" valid
+   property needs to be fulfilled.
+
+
+   {
+     "valid": false
+   }
+
+
+   Because no errors or annotations are returned with this format, it is
+   RECOMMENDED that implementations use short-circuiting logic to return
+   failure or success as soon as the outcome can be determined.  For
+   example, if an "anyOf" keyword contains five sub-schemas, and the
+   second one passes, there is no need to check the other three.  The
+   logic can simply return with success.
+
+12.4.2.  Basic
+
+   The "Basic" structure is a flat list of output units.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 51]
+
+Internet-Draft                 JSON Schema                      May 2019
+
+
+{
+  "valid": false,
+  "errors": [
+    {
+      "keywordLocation": "#",
+      "instanceLocation": "#",
+      "error": "A subschema had errors."
+    },
+    {
+      "keywordLocation": "#/items/$ref",
+      "absoluteKeywordLocation":
+        "http://example.com/polygon#/definitions/point",
+      "instanceLocation": "#/1",
+      "error": "A subschema had errors."
+    },
+    {
+      "keywordLocation": "#/items/$ref/required",
+      "absoluteKeywordLocation":
+        "http://example.com/polygon#/definitions/point/required",
+      "instanceLocation": "#/1",
+      "error": "Required property 'y' not found."
+    },
+    {
+      "keywordLocation": "#/items/$ref/additionalProperties",
+      "absoluteKeywordLocation":
+        "http://example.com/polygon#/definitions/point/additionalProperties",
+      "instanceLocation": "#/1/z",
+      "error": "Additional property 'z' found but was invalid."
+    },
+    {
+      "keywordLocation": "#/minItems",
+      "instanceLocation": "#",
+      "error": "Expected at least 3 items but found 2"
+    }
+  ]
+}
+
+
+12.4.3.  Detailed
+
+   The "Detailed" structure is based on the schema and can be more
+   readable for both humans and machines.  Having the structure
+   organized this way makes associations between the errors more
+   apparent.  For example, the fact that the missing "y" property and
+   the extra "z" property both stem from the same location in the
+   instance is not immediately obvious in the "Basic" structure.  In a
+   hierarchy, the correllation is more easily identified.
+
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 52]
+
+Internet-Draft                 JSON Schema                      May 2019
+
+
+   The following rules govern the construction of the results object:
+
+      All applicator keywords ("*Of", "$ref", "if"/"then"/"else", etc.)
+      require a node.
+
+      Nodes that have no children are removed.
+
+      Nodes that have a single child are replaced by the child.
+
+   Branch nodes do not require an error message or an annotation.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 53]
+
+Internet-Draft                 JSON Schema                      May 2019
+
+
+{
+  "valid": false,
+  "keywordLocation": "#",
+  "instanceLocation": "#",
+  "errors": [
+    {
+      "valid": false,
+      "keywordLocation": "#/items/$ref",
+      "absoluteKeywordLocation":
+        "http://example.com/polygon#/definitions/point",
+      "instanceLocation": "#/1",
+      "errors": [
+        {
+          "valid": false,
+          "keywordLocation": "#/items/$ref/required",
+          "absoluteKeywordLocation":
+            "http://example.com/polygon#/definitions/point/required",
+          "instanceLocation": "#/1",
+          "error": "Required property 'y' not found."
+        },
+        {
+          "valid": false,
+          "keywordLocation": "#/items/$ref/additionalProperties",
+          "absoluteKeywordLocation":
+            "http://example.com/polygon#/definitions/point/additionalProperties",
+          "instanceLocation": "#/1/z",
+          "error": "Additional property 'z' found but was invalid."
+        }
+      ]
+    },
+    {
+      "valid": false,
+      "keywordLocation": "#/minItems",
+      "instanceLocation": "#",
+      "error": "Expected at least 3 items but found 2"
+    }
+  ]
+}
+
+
+12.4.4.  Verbose
+
+   The "Verbose" structure is a fully realized hierarchy that exactly
+   matches that of the schema.  This structure has applications in form
+   generation and validation where the error's location is important.
+
+   The primary difference between this and the "Detailed" structure is
+   that all results are returned.  This includes sub-schema validation
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 54]
+
+Internet-Draft                 JSON Schema                      May 2019
+
+
+   results that would otherwise be removed (e.g. annotations for failed
+   validations, successful validations inside a `not` keyword, etc.).
+   Because of this, it is RECOMMENDED that each node also carry a
+   `valid` property to indicate the validation result for that node.
+
+   Because this output structure can be quite large, a smaller example
+   is given here for brevity.  The URI of the full output structure of
+   the example above is: <https://json-schema.org/draft/2019-04/output/
+   verbose-example>.
+
+
+// schema
+{
+  "$id": "http://example.com/polygon#",
+  "$schema": "http://json-schema.org/draft/2019-04/schema#",
+  "type": "object",
+  "properties": {
+    "validProp": true,
+  },
+  "additionalProperties": false
+}
+
+// instance
+{
+  "validProp": 5,
+  "disallowedProp": "value"
+}
+
+// result
+{
+  "valid": false,
+  "keywordLocation": "#",
+  "instanceLocation": "#",
+  "errors": [
+    {
+      "valid": true,
+      "keywordLocation": "#/type",
+      "instanceLocation": "#"
+    },
+    {
+      "valid": true,
+      "keywordLocation": "#/properties",
+      "instanceLocation": "#"
+    },
+    {
+      "valid": false,
+      "keywordLocation": "#/additionalProperties",
+      "instanceLocation": "#",
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 55]
+
+Internet-Draft                 JSON Schema                      May 2019
+
+
+      "errors": [
+        {
+          "valid": false,
+          "keywordLocation": "#/additionalProperties",
+          "instanceLocation": "#/disallowedProp",
+          "error": "Additional property 'disallowedProp' found but was invalid."
+        }
+      ]
+    }
+  ]
+}
+
+
+12.4.5.  Output validation schemas
+
+   For convenience, JSON Schema has been provided to validate output
+   generated by implementations.  Its URI is: <https://json-schema.org/
+   draft/2019-04/output/schema>.
+
+13.  Usage for Hypermedia
+
+   JSON has been adopted widely by HTTP servers for automated APIs and
+   robots.  This section describes how to enhance processing of JSON
+   documents in a more RESTful manner when used with protocols that
+   support media types and Web linking [RFC8288].
+
+13.1.  Linking to a Schema
+
+   It is RECOMMENDED that instances described by a schema provide a link
+   to a downloadable JSON Schema using the link relation "describedby",
+   as defined by Linked Data Protocol 1.0, section 8.1
+   [W3C.REC-ldp-20150226].
+
+   In HTTP, such links can be attached to any response using the Link
+   header [RFC8288].  An example of such a header would be:
+
+
+   Link: <http://example.com/my-hyper-schema#>; rel="describedby"
+
+
+13.2.  Identifying a Schema via a Media Type Parameter
+
+   Media types MAY allow for a "schema" media type parameter, which
+   gives HTTP servers the ability to perform Content-Type Negotiation
+   based on schema.  The media-type parameter MUST be a whitespace-
+   separated list of URIs (i.e. relative references are invalid).
+
+
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 56]
+
+Internet-Draft                 JSON Schema                      May 2019
+
+
+   When using the media type application/schema-instance+json, the
+   "schema" parameter MUST be supplied.
+
+   When using the media type application/schema+json, the "schema"
+   parameter MAY be supplied.  If supplied, it SHOULD contain the same
+   URI as identified by the "$schema" keyword, and MAY contain
+   additional URIs.  The "$schema" URI MUST be considered the schema's
+   canonical meta-schema, regardless of the presence of alternative or
+   additional meta-schemas as a media type parameter.
+
+   The schema URI is opaque and SHOULD NOT automatically be
+   dereferenced.  If the implementation does not understand the
+   semantics of the provided schema, the implementation can instead
+   follow the "describedby" links, if any, which may provide information
+   on how to handle the schema.  Since "schema" doesn't necessarily
+   point to a network location, the "describedby" relation is used for
+   linking to a downloadable schema.  However, for simplicity, schema
+   authors should make these URIs point to the same resource when
+   possible.
+
+   In HTTP, the media-type parameter would be sent inside the Content-
+   Type header:
+
+
+   Content-Type: application/json;
+             schema="http://example.com/my-hyper-schema#"
+
+
+   Multiple schemas are whitespace separated, and indicate that the
+   instance conforms to all of the listed schemas:
+
+
+   Content-Type: application/json;
+             schema="http://example.com/alice http://example.com/bob"
+
+
+   Media type parameters are also used in HTTP's Accept request header:
+
+
+   Accept: application/json;
+             schema="http://example.com/qiang http://example.com/li",
+           application/json;
+             schema="http://example.com/kumar"
+
+
+   As with Content-Type, multiple schema parameters in the same string
+   requests an instance that conforms to all of the listed schemas.
+
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 57]
+
+Internet-Draft                 JSON Schema                      May 2019
+
+
+   Unlike Content-Type, Accept can contain multiple values to indicate
+   that the client can accept several media types.  In the above
+   example, note that the two media types differ only by their schema
+   parameter values.  This requests an application/json representation
+   that conforms to at least one of the identified schemas.
+
+   [[CREF8: This paragraph assumes that we can register a "schema" link
+   relation.  Should we instead specify something like "tag:json-
+   schema.org,2017:schema" for now? ]] HTTP can also send the "schema"
+   in a Link, though this may impact media-type semantics and Content-
+   Type negotiation if this replaces the media-type parameter entirely:
+
+
+   Link: </alice>;rel="schema", </bob>;rel="schema"
+
+
+13.3.  Usage Over HTTP
+
+   When used for hypermedia systems over a network, HTTP [RFC7231] is
+   frequently the protocol of choice for distributing schemas.
+   Misbehaving clients can pose problems for server maintainers if they
+   pull a schema over the network more frequently than necessary, when
+   it's instead possible to cache a schema for a long period of time.
+
+   HTTP servers SHOULD set long-lived caching headers on JSON Schemas.
+   HTTP clients SHOULD observe caching headers and not re-request
+   documents within their freshness period.  Distributed systems SHOULD
+   make use of a shared cache and/or caching proxy.
+
+   Clients SHOULD set or prepend a User-Agent header specific to the
+   JSON Schema implementation or software product.  Since symbols are
+   listed in decreasing order of significance, the JSON Schema library
+   name/version should precede the more generic HTTP library name (if
+   any).  For example:
+
+
+   User-Agent: product-name/5.4.1 so-cool-json-schema/1.0.2 curl/7.43.0
+
+
+   Clients SHOULD be able to make requests with a "From" header so that
+   server operators can contact the owner of a potentially misbehaving
+   script.
+
+14.  Security Considerations
+
+   Both schemas and instances are JSON values.  As such, all security
+   considerations defined in RFC 8259 [RFC8259] apply.
+
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 58]
+
+Internet-Draft                 JSON Schema                      May 2019
+
+
+   Instances and schemas are both frequently written by untrusted third
+   parties, to be deployed on public Internet servers.  Validators
+   should take care that the parsing and validating against schemas
+   doesn't consume excessive system resources.  Validators MUST NOT fall
+   into an infinite loop.
+
+   Servers MUST ensure that malicious parties can't change the
+   functionality of existing schemas by uploading a schema with a pre-
+   existing or very similar "$id".
+
+   Individual JSON Schema vocabularies are liable to also have their own
+   security considerations.  Consult the respective specifications for
+   more information.
+
+   Schema authors should take care with "$comment" contents, as a
+   malicious implementation can display them to end-users in violation
+   of a spec, or fail to strip them if such behavior is expected.
+
+   A malicious schema author could place executable code or other
+   dangerous material within a "$comment".  Implementations MUST NOT
+   parse or otherwise take action based on "$comment" contents.
+
+15.  IANA Considerations
+
+15.1.  application/schema+json
+
+   The proposed MIME media type for JSON Schema is defined as follows:
+
+      Type name: application
+
+      Subtype name: schema+json
+
+      Required parameters: N/A
+
+      Optional parameters:
+
+      schema:  A non-empty list of space-separated URIs, each
+         identifying a JSON Schema resource.  The instance SHOULD
+         successfully validate against at least one of these meta-
+         schemas.  Non-validating meta-schemas MAY be included for
+         purposes such as allowing clients to make use of older versions
+         of a meta-schema as long as the runtime instance validates
+         against that older version.
+
+      Encoding considerations: Encoding considerations are identical to
+      those specified for the "application/json" media type.  See JSON
+      [RFC8259].
+
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 59]
+
+Internet-Draft                 JSON Schema                      May 2019
+
+
+      Security considerations: See Section 14 above.
+
+      Interoperability considerations: See Sections 6.2, 6.3, and 6.4
+      above.
+
+      Fragment identifier considerations: See Section 5
+
+15.2.  application/schema-instance+json
+
+   The proposed MIME media type for JSON Schema Instances that require a
+   JSON Schema-specific media type is defined as follows:
+
+      Type name: application
+
+      Subtype name: schema-instance+json
+
+      Required parameters:
+
+      schema:  A non-empty list of space-separated URIs, each
+         identifying a JSON Schema resource.  The instance SHOULD
+         successfully validate against at least one of these schemas.
+         Non-validating schemas MAY be included for purposes such as
+         allowing clients to make use of older versions of a schema as
+         long as the runtime instance validates against that older
+         version.
+
+      Encoding considerations: Encoding considerations are identical to
+      those specified for the "application/json" media type.  See JSON
+      [RFC8259].
+
+      Security considerations: See Section 14 above.
+
+      Interoperability considerations: See Sections 6.2, 6.3, and 6.4
+      above.
+
+      Fragment identifier considerations: See Section 5
+
+16.  References
+
+16.1.  Normative References
+
+   [ecma262]  "ECMA 262 specification", <http://www.ecma-
+              international.org/publications/files/ECMA-ST/
+              Ecma-262.pdf>.
+
+
+
+
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 60]
+
+Internet-Draft                 JSON Schema                      May 2019
+
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119,
+              DOI 10.17487/RFC2119, March 1997,
+              <https://www.rfc-editor.org/info/rfc2119>.
+
+   [RFC3986]  Berners-Lee, T., Fielding, R., and L. Masinter, "Uniform
+              Resource Identifier (URI): Generic Syntax", STD 66,
+              RFC 3986, DOI 10.17487/RFC3986, January 2005,
+              <https://www.rfc-editor.org/info/rfc3986>.
+
+   [RFC6839]  Hansen, T. and A. Melnikov, "Additional Media Type
+              Structured Syntax Suffixes", RFC 6839,
+              DOI 10.17487/RFC6839, January 2013,
+              <https://www.rfc-editor.org/info/rfc6839>.
+
+   [RFC6901]  Bryan, P., Ed., Zyp, K., and M. Nottingham, Ed.,
+              "JavaScript Object Notation (JSON) Pointer", RFC 6901,
+              DOI 10.17487/RFC6901, April 2013,
+              <https://www.rfc-editor.org/info/rfc6901>.
+
+   [RFC8259]  Bray, T., Ed., "The JavaScript Object Notation (JSON) Data
+              Interchange Format", STD 90, RFC 8259,
+              DOI 10.17487/RFC8259, December 2017,
+              <https://www.rfc-editor.org/info/rfc8259>.
+
+   [W3C.REC-ldp-20150226]
+              Speicher, S., Arwe, J., and A. Malhotra, "Linked Data
+              Platform 1.0", World Wide Web Consortium Recommendation
+              REC-ldp-20150226, February 2015,
+              <http://www.w3.org/TR/2015/REC-ldp-20150226>.
+
+16.2.  Informative References
+
+   [json-hyper-schema]
+              Andrews, H. and A. Wright, "JSON Hyper-Schema: A
+              Vocabulary for Hypermedia Annotation of JSON", draft-
+              handrews-json-schema-hyperschema-02 (work in progress),
+              November 2017.
+
+   [json-schema-validation]
+              Wright, A., Andrews, H., and G. Luff, "JSON Schema
+              Validation: A Vocabulary for Structural Validation of
+              JSON", draft-handrews-json-schema-validation-02 (work in
+              progress), November 2017.
+
+   [RFC7049]  Bormann, C. and P. Hoffman, "Concise Binary Object
+              Representation (CBOR)", RFC 7049, DOI 10.17487/RFC7049,
+              October 2013, <https://www.rfc-editor.org/info/rfc7049>.
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 61]
+
+Internet-Draft                 JSON Schema                      May 2019
+
+
+   [RFC7231]  Fielding, R., Ed. and J. Reschke, Ed., "Hypertext Transfer
+              Protocol (HTTP/1.1): Semantics and Content", RFC 7231,
+              DOI 10.17487/RFC7231, June 2014,
+              <https://www.rfc-editor.org/info/rfc7231>.
+
+   [RFC8288]  Nottingham, M., "Web Linking", RFC 8288,
+              DOI 10.17487/RFC8288, October 2017,
+              <https://www.rfc-editor.org/info/rfc8288>.
+
+   [W3C.WD-fragid-best-practices-20121025]
+              Tennison, J., "Best Practices for Fragment Identifiers and
+              Media Type Definitions", World Wide Web Consortium WD WD-
+              fragid-best-practices-20121025, October 2012,
+              <http://www.w3.org/TR/2012/
+              WD-fragid-best-practices-20121025>.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 62]
+
+Internet-Draft                 JSON Schema                      May 2019
+
+
+Appendix A.  Acknowledgments
+
+   Thanks to Gary Court, Francis Galiegue, Kris Zyp, and Geraint Luff
+   for their work on the initial drafts of JSON Schema.
+
+   Thanks to Jason Desrosiers, Daniel Perrett, Erik Wilde, Ben Hutton,
+   Evgeny Poberezkin, Brad Bowman, Gowry Sankar, Donald Pipowitch, and
+   Dave Finlay for their submissions and patches to the document.
+
+Appendix B.  ChangeLog
+
+   [[CREF9: This section to be removed before leaving Internet-Draft
+   status.]]
+
+   draft-handrews-json-schema-02
+
+      *  Update to RFC 8359 for JSON specification
+
+      *  Moved "definitions" from the Validation specification here as
+         "$defs"
+
+      *  Moved applicator keywords from the Validation specification as
+         their own vocabulary
+
+      *  Moved the schema form of "dependencies" from the Validation
+         specification as "dependentSchemas"
+
+      *  Formalized annotation collection
+
+      *  Specified recommended output formats
+
+      *  Defined keyword interactions in terms of annotation and
+         assertion results
+
+      *  Added "unevaluatedProperties" and "unevaluatedItems"
+
+      *  Define "$ref" behavior in terms of the assertion, applicator,
+         and annotation model
+
+      *  Allow keywords adjacent to "$ref"
+
+      *  Note undefined behavior for "$ref" targets involving unknown
+         keywords
+
+      *  Add recursive referencing, primarily for meta-schema extension
+
+      *  Add the concept of formal vocabularies, and how they can be
+         recognized through meta-schemas
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 63]
+
+Internet-Draft                 JSON Schema                      May 2019
+
+
+      *  Additional guidance on initial base URIs beyond network
+         retrieval
+
+      *  Allow "schema" media type parameter for "application/
+         schema+json"
+
+      *  Better explanation of media type parameters and the HTTP Accept
+         header
+
+   draft-handrews-json-schema-01
+
+      *  This draft is purely a clarification with no functional changes
+
+      *  Emphasized annotations as a primary usage of JSON Schema
+
+      *  Clarified $id by use cases
+
+      *  Exhaustive schema identification examples
+
+      *  Replaced "external referencing" with how and when an
+         implementation might know of a schema from another document
+
+      *  Replaced "internal referencing" with how an implementation
+         should recognized schema identifiers during parsing
+
+      *  Dereferencing the former "internal" or "external" references is
+         always the same process
+
+      *  Minor formatting improvements
+
+   draft-handrews-json-schema-00
+
+      *  Make the concept of a schema keyword vocabulary more clear
+
+      *  Note that the concept of "integer" is from a vocabulary, not
+         the data model
+
+      *  Classify keywords as assertions or annotations and describe
+         their general behavior
+
+      *  Explain the boolean schemas in terms of generalized assertions
+
+      *  Reserve "$comment" for non-user-visible notes about the schema
+
+      *  Wording improvements around "$id" and fragments
+
+      *  Note the challenges of extending meta-schemas with recursive
+         references
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 64]
+
+Internet-Draft                 JSON Schema                      May 2019
+
+
+      *  Add "application/schema-instance+json" media type
+
+      *  Recommend a "schema" link relation / parameter instead of
+         "profile"
+
+   draft-wright-json-schema-01
+
+      *  Updated intro
+
+      *  Allowed for any schema to be a boolean
+
+      *  "$schema" SHOULD NOT appear in subschemas, although that may
+         change
+
+      *  Changed "id" to "$id"; all core keywords prefixed with "$"
+
+      *  Clarify and formalize fragments for application/schema+json
+
+      *  Note applicability to formats such as CBOR that can be
+         represented in the JSON data model
+
+   draft-wright-json-schema-00
+
+      *  Updated references to JSON
+
+      *  Updated references to HTTP
+
+      *  Updated references to JSON Pointer
+
+      *  Behavior for "id" is now specified in terms of RFC3986
+
+      *  Aligned vocabulary usage for URIs with RFC3986
+
+      *  Removed reference to draft-pbryan-zyp-json-ref-03
+
+      *  Limited use of "$ref" to wherever a schema is expected
+
+      *  Added definition of the "JSON Schema data model"
+
+      *  Added additional security considerations
+
+      *  Defined use of subschema identifiers for "id"
+
+      *  Rewrote section on usage with HTTP
+
+      *  Rewrote section on usage with rel="describedBy" and
+         rel="profile"
+
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 65]
+
+Internet-Draft                 JSON Schema                      May 2019
+
+
+      *  Fixed numerous invalid examples
+
+   draft-zyp-json-schema-04
+
+      *  Salvaged from draft v3.
+
+      *  Split validation keywords into separate document.
+
+      *  Split hypermedia keywords into separate document.
+
+      *  Initial post-split draft.
+
+      *  Mandate the use of JSON Reference, JSON Pointer.
+
+      *  Define the role of "id".  Define URI resolution scope.
+
+      *  Add interoperability considerations.
+
+   draft-zyp-json-schema-00
+
+      *  Initial draft.
+
+Authors' Addresses
+
+   Austin Wright (editor)
+
+   EMail: aaa@bzfx.net
+
+
+   Henry Andrews (editor)
+   Riverbed Technology
+   680 Folsom St.
+   San Francisco, CA
+   USA
+
+   EMail: handrews@riverbed.com
+
+
+   Ben Hutton (editor)
+   Wellcome Sanger Institute
+
+   EMail: bh7@sanger.ac.uk
+
+
+
+
+
+
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 66]
+
+Internet-Draft                 JSON Schema                      May 2019
+
+
+   Greg Dennis
+   Auckland
+   NZ
+
+   EMail: gregsdennis@yahoo.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 67]

--- a/work-in-progress/WIP-jsonschema-hyperschema.html
+++ b/work-in-progress/WIP-jsonschema-hyperschema.html
@@ -1,0 +1,2009 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" 
+  "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+<head profile="http://www.w3.org/2006/03/hcard http://dublincore.org/documents/2008/08/04/dc-html/">
+  <meta http-equiv="Content-Type" content="text/html; charset=us-ascii" />
+
+  <title>JSON Hyper-Schema: A Vocabulary for Hypermedia Annotation of JSON </title>
+
+  <style type="text/css" title="Xml2Rfc (sans serif)">
+  /*<![CDATA[*/
+	  a {
+	  text-decoration: none;
+	  }
+      /* info code from SantaKlauss at http://www.madaboutstyle.com/tooltip2.html */
+      a.info {
+          /* This is the key. */
+          position: relative;
+          z-index: 24;
+          text-decoration: none;
+      }
+      a.info:hover {
+          z-index: 25;
+          color: #FFF; background-color: #900;
+      }
+      a.info span { display: none; }
+      a.info:hover span.info {
+          /* The span will display just on :hover state. */
+          display: block;
+          position: absolute;
+          font-size: smaller;
+          top: 2em; left: -5em; width: 15em;
+          padding: 2px; border: 1px solid #333;
+          color: #900; background-color: #EEE;
+          text-align: left;
+      }
+	  a.smpl {
+	  color: black;
+	  }
+	  a:hover {
+	  text-decoration: underline;
+	  }
+	  a:active {
+	  text-decoration: underline;
+	  }
+	  address {
+	  margin-top: 1em;
+	  margin-left: 2em;
+	  font-style: normal;
+	  }
+	  body {
+	  color: black;
+	  font-family: verdana, helvetica, arial, sans-serif;
+	  font-size: 10pt;
+	  max-width: 55em;
+	  
+	  }
+	  cite {
+	  font-style: normal;
+	  }
+	  dd {
+	  margin-right: 2em;
+	  }
+	  dl {
+	  margin-left: 2em;
+	  }
+	
+	  ul.empty {
+	  list-style-type: none;
+	  }
+	  ul.empty li {
+	  margin-top: .5em;
+	  }
+	  dl p {
+	  margin-left: 0em;
+	  }
+	  dt {
+	  margin-top: .5em;
+	  }
+	  h1 {
+	  font-size: 14pt;
+	  line-height: 21pt;
+	  page-break-after: avoid;
+	  }
+	  h1.np {
+	  page-break-before: always;
+	  }
+	  h1 a {
+	  color: #333333;
+	  }
+	  h2 {
+	  font-size: 12pt;
+	  line-height: 15pt;
+	  page-break-after: avoid;
+	  }
+	  h3, h4, h5, h6 {
+	  font-size: 10pt;
+	  page-break-after: avoid;
+	  }
+	  h2 a, h3 a, h4 a, h5 a, h6 a {
+	  color: black;
+	  }
+	  img {
+	  margin-left: 3em;
+	  }
+	  li {
+	  margin-left: 2em;
+	  margin-right: 2em;
+	  }
+	  ol {
+	  margin-left: 2em;
+	  margin-right: 2em;
+	  }
+	  ol p {
+	  margin-left: 0em;
+	  }
+	  p {
+	  margin-left: 2em;
+	  margin-right: 2em;
+	  }
+	  pre {
+	  margin-left: 3em;
+	  background-color: lightyellow;
+	  padding: .25em;
+	  }
+	  pre.text2 {
+	  border-style: dotted;
+	  border-width: 1px;
+	  background-color: #f0f0f0;
+	  width: 69em;
+	  }
+	  pre.inline {
+	  background-color: white;
+	  padding: 0em;
+	  }
+	  pre.text {
+	  border-style: dotted;
+	  border-width: 1px;
+	  background-color: #f8f8f8;
+	  width: 69em;
+	  }
+	  pre.drawing {
+	  border-style: solid;
+	  border-width: 1px;
+	  background-color: #f8f8f8;
+	  padding: 2em;
+	  }
+	  table {
+	  margin-left: 2em;
+	  }
+	  table.tt {
+	  vertical-align: top;
+	  }
+	  table.full {
+	  border-style: outset;
+	  border-width: 1px;
+	  }
+	  table.headers {
+	  border-style: outset;
+	  border-width: 1px;
+	  }
+	  table.tt td {
+	  vertical-align: top;
+	  }
+	  table.full td {
+	  border-style: inset;
+	  border-width: 1px;
+	  }
+	  table.tt th {
+	  vertical-align: top;
+	  }
+	  table.full th {
+	  border-style: inset;
+	  border-width: 1px;
+	  }
+	  table.headers th {
+	  border-style: none none inset none;
+	  border-width: 1px;
+	  }
+	  table.left {
+	  margin-right: auto;
+	  }
+	  table.right {
+	  margin-left: auto;
+	  }
+	  table.center {
+	  margin-left: auto;
+	  margin-right: auto;
+	  }
+	  caption {
+	  caption-side: bottom;
+	  font-weight: bold;
+	  font-size: 9pt;
+	  margin-top: .5em;
+	  }
+	
+	  table.header {
+	  border-spacing: 1px;
+	  width: 95%;
+	  font-size: 10pt;
+	  color: white;
+	  }
+	  td.top {
+	  vertical-align: top;
+	  }
+	  td.topnowrap {
+	  vertical-align: top;
+	  white-space: nowrap; 
+	  }
+	  table.header td {
+	  background-color: gray;
+	  width: 50%;
+	  }
+	  table.header a {
+	  color: white;
+	  }
+	  td.reference {
+	  vertical-align: top;
+	  white-space: nowrap;
+	  padding-right: 1em;
+	  }
+	  thead {
+	  display:table-header-group;
+	  }
+	  ul.toc, ul.toc ul {
+	  list-style: none;
+	  margin-left: 1.5em;
+	  margin-right: 0em;
+	  padding-left: 0em;
+	  }
+	  ul.toc li {
+	  line-height: 150%;
+	  font-weight: bold;
+	  font-size: 10pt;
+	  margin-left: 0em;
+	  margin-right: 0em;
+	  }
+	  ul.toc li li {
+	  line-height: normal;
+	  font-weight: normal;
+	  font-size: 9pt;
+	  margin-left: 0em;
+	  margin-right: 0em;
+	  }
+	  li.excluded {
+	  font-size: 0pt;
+	  }
+	  ul p {
+	  margin-left: 0em;
+	  }
+	
+	  .comment {
+	  background-color: yellow;
+	  }
+	  .center {
+	  text-align: center;
+	  }
+	  .error {
+	  color: red;
+	  font-style: italic;
+	  font-weight: bold;
+	  }
+	  .figure {
+	  font-weight: bold;
+	  text-align: center;
+	  font-size: 9pt;
+	  }
+	  .filename {
+	  color: #333333;
+	  font-weight: bold;
+	  font-size: 12pt;
+	  line-height: 21pt;
+	  text-align: center;
+	  }
+	  .fn {
+	  font-weight: bold;
+	  }
+	  .hidden {
+	  display: none;
+	  }
+	  .left {
+	  text-align: left;
+	  }
+	  .right {
+	  text-align: right;
+	  }
+	  .title {
+	  color: #990000;
+	  font-size: 18pt;
+	  line-height: 18pt;
+	  font-weight: bold;
+	  text-align: center;
+	  margin-top: 36pt;
+	  }
+	  .vcardline {
+	  display: block;
+	  }
+	  .warning {
+	  font-size: 14pt;
+	  background-color: yellow;
+	  }
+	
+	
+	  @media print {
+	  .noprint {
+		display: none;
+	  }
+	
+	  a {
+		color: black;
+		text-decoration: none;
+	  }
+	
+	  table.header {
+		width: 90%;
+	  }
+	
+	  td.header {
+		width: 50%;
+		color: black;
+		background-color: white;
+		vertical-align: top;
+		font-size: 12pt;
+	  }
+	
+	  ul.toc a::after {
+		content: leader('.') target-counter(attr(href), page);
+	  }
+	
+	  ul.ind li li a {
+		content: target-counter(attr(href), page);
+	  }
+	
+	  .print2col {
+		column-count: 2;
+		-moz-column-count: 2;
+		column-fill: auto;
+	  }
+	  }
+	
+	  @page {
+	  @top-left {
+		   content: "Internet-Draft"; 
+	  } 
+	  @top-right {
+		   content: "December 2010"; 
+	  } 
+	  @top-center {
+		   content: "Abbreviated Title";
+	  } 
+	  @bottom-left {
+		   content: "Doe"; 
+	  } 
+	  @bottom-center {
+		   content: "Expires June 2011"; 
+	  } 
+	  @bottom-right {
+		   content: "[Page " counter(page) "]"; 
+	  } 
+	  }
+	
+	  @page:first { 
+		@top-left {
+		  content: normal;
+		}
+		@top-right {
+		  content: normal;
+		}
+		@top-center {
+		  content: normal;
+		}
+	  }
+  /*]]>*/
+  </style>
+
+  <link href="#rfc.toc" rel="Contents">
+<link href="#rfc.section.1" rel="Chapter" title="1 Introduction">
+<link href="#rfc.section.2" rel="Chapter" title="2 Notational Conventions">
+<link href="#rfc.section.3" rel="Chapter" title="3 Overview">
+<link href="#rfc.section.3.1" rel="Chapter" title="3.1 Terminology">
+<link href="#rfc.section.3.2" rel="Chapter" title="3.2 Functionality">
+<link href="#rfc.section.4" rel="Chapter" title="4 Meta-Schemas and Output Schema">
+<link href="#rfc.section.5" rel="Chapter" title="5 Schema Keywords">
+<link href="#rfc.section.5.1" rel="Chapter" title="5.1 base">
+<link href="#rfc.section.5.2" rel="Chapter" title="5.2 links">
+<link href="#rfc.section.6" rel="Chapter" title="6 Link Description Object">
+<link href="#rfc.section.6.1" rel="Chapter" title="6.1 Link Context">
+<link href="#rfc.section.6.1.1" rel="Chapter" title="6.1.1 anchor">
+<link href="#rfc.section.6.1.2" rel="Chapter" title="6.1.2 anchorPointer">
+<link href="#rfc.section.6.2" rel="Chapter" title="6.2 Link Relation Type">
+<link href="#rfc.section.6.2.1" rel="Chapter" title="6.2.1 rel">
+<link href="#rfc.section.6.2.2" rel="Chapter" title='6.2.2 "self" Links'>
+<link href="#rfc.section.6.2.3" rel="Chapter" title='6.2.3 "collection" and "item" Links'>
+<link href="#rfc.section.6.2.4" rel="Chapter" title="6.2.4 Using Extension Relation Types">
+<link href="#rfc.section.6.3" rel="Chapter" title="6.3 Link Target">
+<link href="#rfc.section.6.3.1" rel="Chapter" title="6.3.1 href">
+<link href="#rfc.section.6.4" rel="Chapter" title="6.4 Adjusting URI Template Resolution">
+<link href="#rfc.section.6.4.1" rel="Chapter" title="6.4.1 templatePointers">
+<link href="#rfc.section.6.4.2" rel="Chapter" title="6.4.2 templateRequired">
+<link href="#rfc.section.6.5" rel="Chapter" title="6.5 Link Target Attributes">
+<link href="#rfc.section.6.5.1" rel="Chapter" title="6.5.1 title">
+<link href="#rfc.section.6.5.2" rel="Chapter" title="6.5.2 description">
+<link href="#rfc.section.6.5.3" rel="Chapter" title="6.5.3 targetMediaType">
+<link href="#rfc.section.6.5.4" rel="Chapter" title="6.5.4 targetSchema">
+<link href="#rfc.section.6.5.5" rel="Chapter" title="6.5.5 targetHints">
+<link href="#rfc.section.6.6" rel="Chapter" title="6.6 Link Input">
+<link href="#rfc.section.6.6.1" rel="Chapter" title="6.6.1 hrefSchema">
+<link href="#rfc.section.6.6.2" rel="Chapter" title="6.6.2 headerSchema">
+<link href="#rfc.section.6.6.3" rel="Chapter" title="6.6.3 Manipulating the Target Resource Representation">
+<link href="#rfc.section.6.6.4" rel="Chapter" title="6.6.4 Submitting Data for Processing">
+<link href="#rfc.section.7" rel="Chapter" title="7 Implementation Requirements">
+<link href="#rfc.section.7.1" rel="Chapter" title="7.1 Link Discovery and Look-Up">
+<link href="#rfc.section.7.2" rel="Chapter" title="7.2 URI Templating">
+<link href="#rfc.section.7.2.1" rel="Chapter" title="7.2.1 Populating Template Data From the Instance">
+<link href="#rfc.section.7.2.2" rel="Chapter" title="7.2.2 Accepting Input for Template Data">
+<link href="#rfc.section.7.2.3" rel="Chapter" title="7.2.3 Encoding Data as Strings">
+<link href="#rfc.section.7.3" rel="Chapter" title="7.3 Providing Access to LDO Keywords">
+<link href="#rfc.section.7.4" rel="Chapter" title="7.4 Requests">
+<link href="#rfc.section.7.5" rel="Chapter" title="7.5 Responses">
+<link href="#rfc.section.7.6" rel="Chapter" title="7.6 Streaming Parsers">
+<link href="#rfc.section.8" rel="Chapter" title="8 JSON Hyper-Schema and HTTP">
+<link href="#rfc.section.8.1" rel="Chapter" title="8.1 One Link Per Target and Relation Type">
+<link href="#rfc.section.8.2" rel="Chapter" title='8.2 "targetSchema" and HTTP'>
+<link href="#rfc.section.8.3" rel="Chapter" title='8.3 HTTP POST and the "submission*" keywords'>
+<link href="#rfc.section.8.4" rel="Chapter" title='8.4 Optimizing HTTP Discoverability With "targetHints"'>
+<link href="#rfc.section.8.5" rel="Chapter" title='8.5 Advertising HTTP Features With "headerSchema"'>
+<link href="#rfc.section.8.6" rel="Chapter" title="8.6 Creating Resources Through Collections">
+<link href="#rfc.section.8.7" rel="Chapter" title="8.7 Content Negotiation and Schema Evolution">
+<link href="#rfc.section.9" rel="Chapter" title="9 Examples">
+<link href="#rfc.section.9.1" rel="Chapter" title="9.1 Entry Point Links, No Templates">
+<link href="#rfc.section.9.2" rel="Chapter" title="9.2 Individually Identified Resources">
+<link href="#rfc.section.9.3" rel="Chapter" title="9.3 Submitting a Payload and Accepting URI Input">
+<link href="#rfc.section.9.4" rel="Chapter" title='9.4 "anchor", "base" and URI Template Resolution'>
+<link href="#rfc.section.9.5" rel="Chapter" title="9.5 Collections">
+<link href="#rfc.section.9.5.1" rel="Chapter" title="9.5.1 Pagination">
+<link href="#rfc.section.9.5.2" rel="Chapter" title="9.5.2 Creating the First Item">
+<link href="#rfc.section.10" rel="Chapter" title="10 Security Considerations">
+<link href="#rfc.section.10.1" rel="Chapter" title="10.1 Target Attributes">
+<link href="#rfc.section.10.2" rel="Chapter" title='10.2 "self" Links'>
+<link href="#rfc.section.11" rel="Chapter" title="11 Acknowledgments">
+<link href="#rfc.references" rel="Chapter" title="12 References">
+<link href="#rfc.references.1" rel="Chapter" title="12.1 Normative References">
+<link href="#rfc.references.2" rel="Chapter" title="12.2 Informative References">
+<link href="#rfc.appendix.A" rel="Chapter" title="A Using JSON Hyper-Schema in APIs">
+<link href="#rfc.appendix.A.1" rel="Chapter" title="A.1 Resource Evolution With Hyper-Schema">
+<link href="#rfc.appendix.A.2" rel="Chapter" title="A.2 Responses and Errors">
+<link href="#rfc.appendix.A.3" rel="Chapter" title="A.3 Static Analysis of an API's Hyper-Schemas">
+<link href="#rfc.appendix.B" rel="Chapter" title="B ChangeLog">
+<link href="#rfc.authors" rel="Chapter">
+
+
+  <meta name="generator" content="xml2rfc version 2.20.1 - https://tools.ietf.org/tools/xml2rfc" />
+  <link rel="schema.dct" href="http://purl.org/dc/terms/" />
+
+  <meta name="dct.creator" content="Andrews, H., Ed. and A. Wright, Ed." />
+  <meta name="dct.identifier" content="urn:ietf:id:draft-handrews-json-schema-hyperschema-02" />
+  <meta name="dct.issued" scheme="ISO8601" content="2019-25" />
+  <meta name="dct.abstract" content="JSON Schema is a JSON-based format for describing JSON data using various vocabularies.  This document specifies a vocabulary for annotating JSON documents with hyperlinks.  These hyperlinks include attributes describing how to manipulate and interact with remote resources through hypermedia environments such as HTTP, as well as determining whether the link is usable based on the instance value.  The hyperlink serialization format described in this document is also usable independent of JSON Schema.  " />
+  <meta name="description" content="JSON Schema is a JSON-based format for describing JSON data using various vocabularies.  This document specifies a vocabulary for annotating JSON documents with hyperlinks.  These hyperlinks include attributes describing how to manipulate and interact with remote resources through hypermedia environments such as HTTP, as well as determining whether the link is usable based on the instance value.  The hyperlink serialization format described in this document is also usable independent of JSON Schema.  " />
+
+</head>
+
+<body>
+
+  <table class="header">
+    <tbody>
+    
+    	<tr>
+<td class="left">Internet Engineering Task Force</td>
+<td class="right">H. Andrews, Ed.</td>
+</tr>
+<tr>
+<td class="left">Internet-Draft</td>
+<td class="right">Riverbed Technology</td>
+</tr>
+<tr>
+<td class="left">Intended status: Informational</td>
+<td class="right">A. Wright, Ed.</td>
+</tr>
+<tr>
+<td class="left">Expires: November 26, 2019</td>
+<td class="right">May 25, 2019</td>
+</tr>
+
+    	
+    </tbody>
+  </table>
+
+  <p class="title">JSON Hyper-Schema: A Vocabulary for Hypermedia Annotation of JSON <br />
+  <span class="filename">draft-handrews-json-schema-hyperschema-02</span></p>
+  
+  <h1 id="rfc.abstract"><a href="#rfc.abstract">Abstract</a></h1>
+<p>JSON Schema is a JSON-based format for describing JSON data using various vocabularies.  This document specifies a vocabulary for annotating JSON documents with hyperlinks.  These hyperlinks include attributes describing how to manipulate and interact with remote resources through hypermedia environments such as HTTP, as well as determining whether the link is usable based on the instance value.  The hyperlink serialization format described in this document is also usable independent of JSON Schema.  </p>
+<h1><a>Note to Readers</a></h1>
+<p>The issues list for this draft can be found at <span>&lt;</span><a href="https://github.com/json-schema-org/json-schema-spec/issues">https://github.com/json-schema-org/json-schema-spec/issues</a><span>&gt;</span>.  </p>
+<p>For additional information, see <span>&lt;</span><a href="http://json-schema.org/">http://json-schema.org/</a><span>&gt;</span>.  </p>
+<p>To provide feedback, use this issue tracker, the communication methods listed on the homepage, or email the document editors.  </p>
+<h1 id="rfc.status"><a href="#rfc.status">Status of This Memo</a></h1>
+<p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.</p>
+<p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at https://datatracker.ietf.org/drafts/current/.</p>
+<p>Internet-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use Internet-Drafts as reference material or to cite them other than as "work in progress."</p>
+<p>This Internet-Draft will expire on November 26, 2019.</p>
+<h1 id="rfc.copyrightnotice"><a href="#rfc.copyrightnotice">Copyright Notice</a></h1>
+<p>Copyright (c) 2019 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
+<p>This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating to IETF Documents (https://trustee.ietf.org/license-info) in effect on the date of publication of this document.  Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.</p>
+
+  
+  <hr class="noprint" />
+  <h1 class="np" id="rfc.toc"><a href="#rfc.toc">Table of Contents</a></h1>
+  <ul class="toc">
+
+  	<li>1.   <a href="#rfc.section.1">Introduction</a>
+</li>
+<li>2.   <a href="#rfc.section.2">Notational Conventions</a>
+</li>
+<li>3.   <a href="#rfc.section.3">Overview</a>
+</li>
+<ul><li>3.1.   <a href="#rfc.section.3.1">Terminology</a>
+</li>
+<li>3.2.   <a href="#rfc.section.3.2">Functionality</a>
+</li>
+</ul><li>4.   <a href="#rfc.section.4">Meta-Schemas and Output Schema</a>
+</li>
+<li>5.   <a href="#rfc.section.5">Schema Keywords</a>
+</li>
+<ul><li>5.1.   <a href="#rfc.section.5.1">base</a>
+</li>
+<li>5.2.   <a href="#rfc.section.5.2">links</a>
+</li>
+</ul><li>6.   <a href="#rfc.section.6">Link Description Object</a>
+</li>
+<ul><li>6.1.   <a href="#rfc.section.6.1">Link Context</a>
+</li>
+<ul><li>6.1.1.   <a href="#rfc.section.6.1.1">anchor</a>
+</li>
+<li>6.1.2.   <a href="#rfc.section.6.1.2">anchorPointer</a>
+</li>
+</ul><li>6.2.   <a href="#rfc.section.6.2">Link Relation Type</a>
+</li>
+<ul><li>6.2.1.   <a href="#rfc.section.6.2.1">rel</a>
+</li>
+<li>6.2.2.   <a href="#rfc.section.6.2.2">"self" Links</a>
+</li>
+<li>6.2.3.   <a href="#rfc.section.6.2.3">"collection" and "item" Links</a>
+</li>
+<li>6.2.4.   <a href="#rfc.section.6.2.4">Using Extension Relation Types</a>
+</li>
+</ul><li>6.3.   <a href="#rfc.section.6.3">Link Target</a>
+</li>
+<ul><li>6.3.1.   <a href="#rfc.section.6.3.1">href</a>
+</li>
+</ul><li>6.4.   <a href="#rfc.section.6.4">Adjusting URI Template Resolution</a>
+</li>
+<ul><li>6.4.1.   <a href="#rfc.section.6.4.1">templatePointers</a>
+</li>
+<li>6.4.2.   <a href="#rfc.section.6.4.2">templateRequired</a>
+</li>
+</ul><li>6.5.   <a href="#rfc.section.6.5">Link Target Attributes</a>
+</li>
+<ul><li>6.5.1.   <a href="#rfc.section.6.5.1">title</a>
+</li>
+<li>6.5.2.   <a href="#rfc.section.6.5.2">description</a>
+</li>
+<li>6.5.3.   <a href="#rfc.section.6.5.3">targetMediaType</a>
+</li>
+<li>6.5.4.   <a href="#rfc.section.6.5.4">targetSchema</a>
+</li>
+<li>6.5.5.   <a href="#rfc.section.6.5.5">targetHints</a>
+</li>
+</ul><li>6.6.   <a href="#rfc.section.6.6">Link Input</a>
+</li>
+<ul><li>6.6.1.   <a href="#rfc.section.6.6.1">hrefSchema</a>
+</li>
+<li>6.6.2.   <a href="#rfc.section.6.6.2">headerSchema</a>
+</li>
+<li>6.6.3.   <a href="#rfc.section.6.6.3">Manipulating the Target Resource Representation</a>
+</li>
+<li>6.6.4.   <a href="#rfc.section.6.6.4">Submitting Data for Processing</a>
+</li>
+</ul></ul><li>7.   <a href="#rfc.section.7">Implementation Requirements</a>
+</li>
+<ul><li>7.1.   <a href="#rfc.section.7.1">Link Discovery and Look-Up</a>
+</li>
+<li>7.2.   <a href="#rfc.section.7.2">URI Templating</a>
+</li>
+<ul><li>7.2.1.   <a href="#rfc.section.7.2.1">Populating Template Data From the Instance</a>
+</li>
+<li>7.2.2.   <a href="#rfc.section.7.2.2">Accepting Input for Template Data</a>
+</li>
+<li>7.2.3.   <a href="#rfc.section.7.2.3">Encoding Data as Strings</a>
+</li>
+</ul><li>7.3.   <a href="#rfc.section.7.3">Providing Access to LDO Keywords</a>
+</li>
+<li>7.4.   <a href="#rfc.section.7.4">Requests</a>
+</li>
+<li>7.5.   <a href="#rfc.section.7.5">Responses</a>
+</li>
+<li>7.6.   <a href="#rfc.section.7.6">Streaming Parsers</a>
+</li>
+</ul><li>8.   <a href="#rfc.section.8">JSON Hyper-Schema and HTTP</a>
+</li>
+<ul><li>8.1.   <a href="#rfc.section.8.1">One Link Per Target and Relation Type</a>
+</li>
+<li>8.2.   <a href="#rfc.section.8.2">"targetSchema" and HTTP</a>
+</li>
+<li>8.3.   <a href="#rfc.section.8.3">HTTP POST and the "submission*" keywords</a>
+</li>
+<li>8.4.   <a href="#rfc.section.8.4">Optimizing HTTP Discoverability With "targetHints"</a>
+</li>
+<li>8.5.   <a href="#rfc.section.8.5">Advertising HTTP Features With "headerSchema"</a>
+</li>
+<li>8.6.   <a href="#rfc.section.8.6">Creating Resources Through Collections</a>
+</li>
+<li>8.7.   <a href="#rfc.section.8.7">Content Negotiation and Schema Evolution</a>
+</li>
+</ul><li>9.   <a href="#rfc.section.9">Examples</a>
+</li>
+<ul><li>9.1.   <a href="#rfc.section.9.1">Entry Point Links, No Templates</a>
+</li>
+<li>9.2.   <a href="#rfc.section.9.2">Individually Identified Resources</a>
+</li>
+<li>9.3.   <a href="#rfc.section.9.3">Submitting a Payload and Accepting URI Input</a>
+</li>
+<li>9.4.   <a href="#rfc.section.9.4">"anchor", "base" and URI Template Resolution</a>
+</li>
+<li>9.5.   <a href="#rfc.section.9.5">Collections</a>
+</li>
+<ul><li>9.5.1.   <a href="#rfc.section.9.5.1">Pagination</a>
+</li>
+<li>9.5.2.   <a href="#rfc.section.9.5.2">Creating the First Item</a>
+</li>
+</ul></ul><li>10.   <a href="#rfc.section.10">Security Considerations</a>
+</li>
+<ul><li>10.1.   <a href="#rfc.section.10.1">Target Attributes</a>
+</li>
+<li>10.2.   <a href="#rfc.section.10.2">"self" Links</a>
+</li>
+</ul><li>11.   <a href="#rfc.section.11">Acknowledgments</a>
+</li>
+<li>12.   <a href="#rfc.references">References</a>
+</li>
+<ul><li>12.1.   <a href="#rfc.references.1">Normative References</a>
+</li>
+<li>12.2.   <a href="#rfc.references.2">Informative References</a>
+</li>
+</ul><li>Appendix A.   <a href="#rfc.appendix.A">Using JSON Hyper-Schema in APIs</a>
+</li>
+<ul><li>A.1.   <a href="#rfc.appendix.A.1">Resource Evolution With Hyper-Schema</a>
+</li>
+<li>A.2.   <a href="#rfc.appendix.A.2">Responses and Errors</a>
+</li>
+<li>A.3.   <a href="#rfc.appendix.A.3">Static Analysis of an API's Hyper-Schemas</a>
+</li>
+</ul><li>Appendix B.   <a href="#rfc.appendix.B">ChangeLog</a>
+</li>
+<li><a href="#rfc.authors">Authors' Addresses</a>
+</li>
+
+
+  </ul>
+
+  <h1 id="rfc.section.1">
+<a href="#rfc.section.1">1.</a> Introduction</h1>
+<p id="rfc.section.1.p.1">JSON Hyper-Schema is a JSON Schema vocabulary for annotating JSON documents with hyperlinks and instructions for processing and manipulating remote JSON resources through hypermedia environments such as HTTP.  </p>
+<p id="rfc.section.1.p.2">The term JSON Hyper-Schema is used to refer to a JSON Schema that uses these keywords.  The term "hyper-schema" on its own refers to a JSON Hyper-Schema within the scope of this specification.  </p>
+<p id="rfc.section.1.p.3">The primary mechanism introduced for specifying links is the Link Description Object (LDO), which is a serialization of the abstract link model defined in <a href="#RFC8288" class="xref">RFC 8288, section 2</a>.  </p>
+<p id="rfc.section.1.p.4">This specification will use the concepts, syntax, and terminology defined by the <a href="#json-schema" class="xref">JSON Schema core</a> and <a href="#json-schema-validation" class="xref">JSON Schema validation</a> specifications.  It is advised that readers have a copy of these specifications.  </p>
+<h1 id="rfc.section.2">
+<a href="#rfc.section.2">2.</a> Notational Conventions</h1>
+<p id="rfc.section.2.p.1">The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in <a href="#RFC2119" class="xref">RFC 2119</a>.  </p>
+<h1 id="rfc.section.3">
+<a href="#rfc.section.3">3.</a> Overview</h1>
+<p id="rfc.section.3.p.1">JSON Hyper-Schema makes it possible to build hypermedia systems from JSON documents by describing how to construct hyperlinks from instance data.  </p>
+<p id="rfc.section.3.p.2">The combination of a JSON instance document and a valid application/schema+json hyper-schema for that instance behaves as a single hypermedia representation.  By allowing this separation, hyper-schema-based systems can gracefully support applications that expect plain JSON, while providing full hypermedia capabilities for hyper-schema-aware applications and user agents.  </p>
+<p id="rfc.section.3.p.3">User agents can detect the presence of hyper-schema by looking for the application/schema+json media type and a "$schema" value that indicates the presence of the hyper-schema vocabulary.  A user agent can then use an implementation of JSON Hyper-Schema to provide an interface to the combination of the schema and instance documents as a single logical representation of a resource, just as with any single-document hypermedia representation format.  </p>
+<p id="rfc.section.3.p.4">Hyper-schemas allow representations to take up fewer bytes on the wire, and distribute the burden of link construction from the server to each client.  A user agent need not construct a link unless a client application requests that link.  JSON Hyper-Schema can also be used on the server side to generate other link serializations or representation formats at runtime, or pre-emptively follow links to facilitate server push usage.  </p>
+<p>Here is an example hyper-schema that adds a single link, with the IANA-registered link relation type "self", that is built from an instance with one known object field named "id": </p>
+<pre>
+{
+    "type": "object",
+    "properties": {
+        "id": {
+            "type": "number",
+            "readOnly": true
+        }
+    },
+    "links": [
+        {
+            "rel": "self",
+            "href": "thing/{id}"
+        }
+    ]
+}
+                </pre>
+<p>If the instance is {"id": 1234}, and its base URI according to <a href="#RFC3986" class="xref">RFC 3986 section 5.1</a>, is "https://example.com/api/", then "https://example.com/api/thing/1234" is the resulting link's target URI.  </p>
+<h1 id="rfc.section.3.1">
+<a href="#rfc.section.3.1">3.1.</a> Terminology</h1>
+<p id="rfc.section.3.1.p.1">The terms "schema", "instance", and "meta-schema" are to be interpreted as defined in the <a href="#json-schema" class="xref">JSON Schema core specification</a>.  </p>
+<p id="rfc.section.3.1.p.2">The terms "applicable" and "attached" are to be interpreted as defined in <a href="#json-schema" class="xref">Section 3.1 of the JSON Schema core specification</a>.  </p>
+<p id="rfc.section.3.1.p.3">The terms "link", "link context" (or "context"), "link target" (or "target"), and "target attributes" are to be interpreted as defined in <a href="#RFC8288" class="xref">Section 2 of RFC 8288</a>.  </p>
+<p id="rfc.section.3.1.p.4">The term "user agent" is to be interpreted as defined in <a href="#RFC7230" class="xref">Section 2.1 of RFC 7230</a>, generalized to apply to any protocol that may be used in a hypermedia system rather than specifically being an HTTP client.  </p>
+<p id="rfc.section.3.1.p.5">This specification defines the following terms: </p>
+
+<dl>
+<dt>JSON Hyper-Schema</dt>
+<dd style="margin-left: 8">A JSON Schema using the keywords defined by this specification.  </dd>
+<dt>hyper-schema</dt>
+<dd style="margin-left: 8">Within this document, the term "hyper-schema" always refers to a JSON Hyper-Schema </dd>
+<dt>link validity</dt>
+<dd style="margin-left: 8">A valid link for an instance is one that is applicable to that instance and does not fail any requirement imposed by the keywords in the Link Description Object.  Note that invalid links can occur when using keywords such as "if" or "oneOf" (from the Core specification) to describe links that are conditional on the representation's structure or value.  </dd>
+<dt>generic user agent</dt>
+<dd style="margin-left: 8">A user agent which can be used to interact with any resource, from any server, from among the standardized link relations, media types, URI schemes, and protocols that it supports; though it may be extendible to specially handle particular profiles of media types.  </dd>
+<dt>client application</dt>
+<dd style="margin-left: 8">An application which uses a hypermedia system for a specific purpose.  Such an application may also be its own user agent, or it may be built on top of a generic user agent.  A client application is programmed with knowledge of link relations, media types, URI schemes, protocols, and data structures that are specific to the application's domain.  </dd>
+<dt>client input</dt>
+<dd style="margin-left: 8">Data provided through a user agent, and most often also through a client application.  Such data may be requested from a user interactively, or provided before interaction in forms such as command-line arguments, configuration files, or hardcoded values in source code.  </dd>
+<dt>operation</dt>
+<dd style="margin-left: 8">A specific use of a hyperlink, such as making a network request (for a URI with a scheme such as "http://" that indicates a protocol) or otherwise taking action based on a link (reading data from a "data:" URI, or constructing an email message based on a "mailto:" link).  For protocols such as HTTP that support multiple methods, each method is considered to be a separate operation on the same link.  </dd>
+</dl>
+
+<p> </p>
+<h1 id="rfc.section.3.2">
+<a href="#rfc.section.3.2">3.2.</a> Functionality</h1>
+<p id="rfc.section.3.2.p.1">A JSON Hyper-Schema implementation is able to take a hyper-schema, an instance, and in some cases client input, and produce a set of fully resolved valid links.  As defined by <a href="#RFC8288" class="xref">RFC 8288, section 2</a>, a link consists of a context, a typed relation, a target, and optionally additional target attributes.  </p>
+<p id="rfc.section.3.2.p.2">The relation type and target attributes are taken directly from each link's Link Description Object.  The context and target identifiers are constructed from some combination of URI Templates, instance data, and (in the case of the target identifier) client input.  </p>
+<p id="rfc.section.3.2.p.3">The target is always fully identified by a URI.  Due to the lack of a URI fragment identifier syntax for application/json and many other media types that can be used with JSON Hyper-Schema, the context may be only partially identified by a URI.  In such cases, the remaining identification will be provided as a JSON Pointer.  </p>
+<p id="rfc.section.3.2.p.4">A few IANA-registered link relation types are given specific semantics in a JSON Hyper-Schema document.  A "self" link is used to interact with the resource that the instance document represents, while "collection" and "item" links identify resources for which collection-specific semantics can be assumed.  </p>
+<h1 id="rfc.section.4">
+<a href="#rfc.section.4">4.</a> Meta-Schemas and Output Schema</h1>
+<p id="rfc.section.4.p.1">The current URI for the JSON Hyper-Schema meta-schema is <span>&lt;</span><a href="http://json-schema.org/draft/2019-04/hyper-schema#">http://json-schema.org/draft/2019-04/hyper-schema#</a><span>&gt;</span>.  </p>
+<p id="rfc.section.4.p.2">The current URI for this vocabulary, known as the Hyper-Schema vocabulary, is: <span>&lt;</span><a href="https://json-schema.org/draft/2019-04/vocab/hyper-schema">https://json-schema.org/draft/2019-04/vocab/hyper-schema</a><span>&gt;</span>.  </p>
+<p id="rfc.section.4.p.3">The current URI for the corresponding meta-schema, which differs from the convenience meta-schema above in that it describes only the hyper-schema keywords ("base" and "link") is: <span>&lt;</span><a href="https://json-schema.org/draft/2019-04/meta/hyper-schema">https://json-schema.org/draft/2019-04/meta/hyper-schema</a><span>&gt;</span>.  </p>
+<p id="rfc.section.4.p.4">The <a href="#ldo" class="xref">link description format</a> can be used without JSON Schema, and use of this format can be declared by referencing the normative link description schema as the schema for the data structure that uses the links.  The URI of the normative link description schema is: <span>&lt;</span><a href="http://json-schema.org/draft/2019-04/links#">http://json-schema.org/draft/2019-04/links#</a><span>&gt;</span>.  </p>
+<p id="rfc.section.4.p.5">JSON Hyper-Schema implementations are free to provide output in any format.  However, a specific format is defined for use in the conformance test suite, which is also used to illustrate points in the <a href="#implementation" class="xref">"Implementation Requirements"</a>, and to show the output generated by <a href="#examples" class="xref">examples</a>.  It is RECOMMENDED that implementations be capable of producing output in this format to facilitated testing.  The URI of the JSON Schema describing the recommended output format is <span>&lt;</span><a href="http://json-schema.org/draft/2019-04/output/hyper-schema#">http://json-schema.org/draft/2019-04/output/hyper-schema#</a><span>&gt;</span>.  </p>
+<p id="rfc.section.4.p.6">Updated vocabulary and meta-schema URIs MAY be published between specification drafts in order to correct errors.  Implementations SHOULD consider URIs dated after this specification draft and before the next to indicate the same syntax and semantics as those listed here.  </p>
+<h1 id="rfc.section.5">
+<a href="#rfc.section.5">5.</a> Schema Keywords</h1>
+<p id="rfc.section.5.p.1">Hyper-schema keywords from all schemas that are applicable to a position in an instance, as defined by <a href="#json-schema" class="xref">Section 3.1 of JSON Schema core</a>, can be used with that instance.  </p>
+<p id="rfc.section.5.p.2">When multiple subschemas are applicable to a given sub-instance, all "link" arrays MUST be combined, in any order, into a single set.  Each object in the resulting set MUST retain its own list of applicable "base" values, in resolution order, from the same schema and any parent schemas.  </p>
+<p id="rfc.section.5.p.3">As with all JSON Schema keywords, all keywords described in this section are optional.  The minimal valid JSON Hyper-schema is the blank object.  </p>
+<h1 id="rfc.section.5.1">
+<a href="#rfc.section.5.1">5.1.</a> <a href="#base" id="base">base</a>
+</h1>
+<p id="rfc.section.5.1.p.1">If present, this keyword MUST be first <a href="#uriTemplating" class="xref">resolved as a URI Template</a>, and then MUST be resolved as a URI Reference against the current URI base of the instance.  The result MUST be set as the new URI base for the instance while processing the sub-schema containing "base" and all sub-schemas within it.  </p>
+<p id="rfc.section.5.1.p.2">The process for resolving the "base" template can be different when being resolved for use with "anchor" than when being resolved for use with "href", which is explained in detail in the URI Templating section.  </p>
+<h1 id="rfc.section.5.2">
+<a href="#rfc.section.5.2">5.2.</a> links</h1>
+<p id="rfc.section.5.2.p.1">The "links" property of schemas is used to associate Link Description Objects with instances.  The value of this property MUST be an array, and the items in the array must be Link Description Objects, as defined below.  </p>
+<h1 id="rfc.section.6">
+<a href="#rfc.section.6">6.</a> <a href="#ldo" id="ldo">Link Description Object</a>
+</h1>
+<p id="rfc.section.6.p.1">A Link Description Object (LDO) is a serialization of the abstract link model defined in <a href="#RFC8288" class="xref">RFC 8288, section 2</a>.  As described in that document, a link consists of a context, a relation type, a target, and optionally target attributes.  JSON Hyper-Schema's LDO provides all of these, along with additional features using JSON Schema to describe input for use with the links in various ways.  </p>
+<p id="rfc.section.6.p.2">Due to the use of URI Templates to identify link contexts and targets, as well as optional further use of client input when identifying targets, an LDO is a link template that may resolve to multiple links when used with a JSON instance document.  </p>
+<p id="rfc.section.6.p.3">A specific use of an LDO, typically involving a request and response across a protocol, is referred to as an operation.  For many protocols, multiple operations are possible on any given link.  The protocol is indicated by the target's URI scheme.  Note that not all URI schemes indicate a protocol that can be used for communications, and even resources with URI schemes that do indicate such protocols need not be available over that protocol.  </p>
+<p id="rfc.section.6.p.4">A Link Description Object MUST be an object, and the <a href="#href" class="xref">"href"</a> and <a href="#rel" class="xref">"rel"</a> properties MUST be present.  Each keyword is covered briefly in this section, with additional usage explanation and comprehensive examples given later in the document.  </p>
+<h1 id="rfc.section.6.1">
+<a href="#rfc.section.6.1">6.1.</a> <a href="#context" id="context">Link Context</a>
+</h1>
+<p id="rfc.section.6.1.p.1">In JSON Hyper-Schema, the link's context resource is, by default, the sub-instance to which it is attached (as defined by <a href="#json-schema" class="xref">Section 3.1 of the JSON Schema core specification</a>).  This is often not the entire instance document.  This default context can be changed using the keywords in this section.  </p>
+<p id="rfc.section.6.1.p.2">Depending on the media type of the instance, it may or may not be possible to assign a URI to the exact default context resource.  In particular, application/json does not define a URI fragment resolution syntax, so properties or array elements within a plain JSON document cannot be fully identified by a URI.  When it is not possible to produce a complete URI, the position of the context SHOULD be conveyed by the URI of the instance document, together with a separate plain-string JSON Pointer.  </p>
+<p id="rfc.section.6.1.p.3">Implementations MUST be able to construct the link context's URI, and (if necessary for full identification), a JSON Pointer in string representation form as per <a href="#RFC6901" class="xref">RFC 6901, section 5</a> in place of a URI fragment.  The process for constructing a URI based on a URI template is given in the <a href="#uriTemplating" class="xref">URI Templating</a> section.  </p>
+<h1 id="rfc.section.6.1.1">
+<a href="#rfc.section.6.1.1">6.1.1.</a> <a href="#anchor" id="anchor">anchor</a>
+</h1>
+<p id="rfc.section.6.1.1.p.1">This property sets the context URI of the link.  The value of the property is a <a href="#RFC6570" class="xref">URI Template</a>, and the resulting <a href="#RFC3986" class="xref">URI-reference</a> MUST be resolved against the base URI of the instance.  </p>
+<p id="rfc.section.6.1.1.p.2">The URI is computed from the provided URI template using the same process described for the <a href="#href" class="xref">"href"</a> property, with the exception that <a href="#hrefSchema" class="xref">"hrefSchema"</a> MUST NOT be applied.  Unlike target URIs, context URIs do not accept user input.  </p>
+<h1 id="rfc.section.6.1.2">
+<a href="#rfc.section.6.1.2">6.1.2.</a> <a href="#anchorPointer" id="anchorPointer">anchorPointer</a>
+</h1>
+<p id="rfc.section.6.1.2.p.1">This property changes the point within the instance that is considered to be the context resource of the link.  The value of the property MUST be a valid JSON Pointer in JSON String representation form, or a valid <a href="#relative-json-pointer" class="xref">Relative JSON Pointer</a> which is evaluated relative to the default context.  </p>
+<p id="rfc.section.6.1.2.p.2">While an alternate context with a known URI is best set with the <a href="#anchor" class="xref">"anchor"</a> keyword, the lack of a fragment identifier syntax for application/json means that it is usually not possible to change the context within a JSON instance using a URI.  </p>
+<p id="rfc.section.6.1.2.p.3">Even in "+json" media types that define JSON Pointer as a fragment identifier syntax, if the default context is nested within an array, it is not possible to obtain the index of the default context's position in that array in order to construct a pointer to another property in that same nested JSON object.  This will be demonstrated in the examples.  </p>
+<p id="rfc.section.6.1.2.p.4">The result of processing this keyword SHOULD be a URI fragment if the media type of the instance allows for such a fragment.  Otherwise it MUST be a string-encoded JSON Pointer.  </p>
+<h1 id="rfc.section.6.2">
+<a href="#rfc.section.6.2">6.2.</a> <a href="#relationType" id="relationType">Link Relation Type</a>
+</h1>
+<p id="rfc.section.6.2.p.1">The link's relation type identifies its semantics.  It is the primary means of conveying how an application can interact with a resource.  </p>
+<p id="rfc.section.6.2.p.2">Relationship definitions are not normally media type dependent, and users are encouraged to utilize the most suitable existing accepted relation definitions.  </p>
+<h1 id="rfc.section.6.2.1">
+<a href="#rfc.section.6.2.1">6.2.1.</a> <a href="#rel" id="rel">rel</a>
+</h1>
+<p id="rfc.section.6.2.1.p.1">The value of this property MUST be either a string or an array of strings.  If the value is an array, it MUST contain at least one string.  </p>
+<p id="rfc.section.6.2.1.p.2">Each string MUST be a single Link Relation Type as defined in RFC 8288, Section 2.1, including the restriction that additional semantics SHOULD NOT be inferred based upon the presence or absence of another link relation type.  </p>
+<p id="rfc.section.6.2.1.p.3">This property is required.  </p>
+<h1 id="rfc.section.6.2.2">
+<a href="#rfc.section.6.2.2">6.2.2.</a> <a href="#self" id="self">"self" Links</a>
+</h1>
+<p id="rfc.section.6.2.2.p.1">A "self" link, as originally defined by <a href="#RFC4287" class="xref">Section 4.2.7.2 of RFC 4287</a>, indicates that the target URI identifies a resource equivalent to the link context.  In JSON Hyper-Schema, a "self" link MUST be resolvable from the instance, and therefore "hrefSchema" MUST NOT be present.  </p>
+<p id="rfc.section.6.2.2.p.2">Hyper-schema authors SHOULD use "templateRequired" to ensure that the "self" link has all instance data that is needed for use.  </p>
+<p id="rfc.section.6.2.2.p.3">A hyper-schema implementation MUST recognize that a link with relation type "self" that has the entire current instance document as its context describes how a user agent can interact with the resource represented by that instance document.  </p>
+<h1 id="rfc.section.6.2.3">
+<a href="#rfc.section.6.2.3">6.2.3.</a> <a href="#collectionAndItem" id="collectionAndItem">"collection" and "item" Links</a>
+</h1>
+<p><a href="#RFC6573" class="xref">RFC 6573</a> defines and registers the "item" and "collection" link relation types.  JSON Hyper-Schema imposes additional semantics on collection resources indicated by these types.  </p>
+<p id="rfc.section.6.2.3.p.2">Implementations MUST recognize the target of a "collection" link and the context of an "item" link as collections.  </p>
+<p id="rfc.section.6.2.3.p.3">A well-known design pattern in hypermedia is to use a collection resource to create a member of the collection and give it a server-assigned URI.  If the protocol indicated by the URI scheme defines a specific method that is suited to creating a resource with a server-assigned URI, then a collection resource, as identified by these link relation types, MUST NOT define semantics for that method that conflict with the semantics of creating a collection member.  Collection resources MAY implement item creation via such a protocol method, and user agents MAY assume that any such operation, if it exists, has item creation semantics.  </p>
+<p id="rfc.section.6.2.3.p.4">As such a method would correspond to JSON Hyper-Schema's data submission concept, the <a href="#submissionSchema" class="xref">"submissionSchema"</a> field for the link SHOULD be compatible with the schema of the representation of the collection's items, as indicated by the "item" link's target resource or the "self" link of the "collection" link's context resource.  </p>
+<h1 id="rfc.section.6.2.4">
+<a href="#rfc.section.6.2.4">6.2.4.</a> <a href="#extensionRelationTypes" id="extensionRelationTypes">Using Extension Relation Types</a>
+</h1>
+<p id="rfc.section.6.2.4.p.1">When no registered relation (aside from "related") applies, users are encouraged to mint their own extension relation types, as described in <a href="#RFC8288" class="xref">section 2.1.2 of RFC 8288</a>.  The simplest approaches for choosing link relation type URIs are to either use a URI scheme that is already in use to identify the system's primary resources, or to use a human-readable, non-dereferenceable URI scheme such as <a href="#RFC4151" class="xref">"tag", defined by RFC 4151</a>.  </p>
+<p id="rfc.section.6.2.4.p.2">Extension relation type URIs need not be dereferenceable, even when using a scheme that allows it.  </p>
+<h1 id="rfc.section.6.3">
+<a href="#rfc.section.6.3">6.3.</a> <a href="#target" id="target">Link Target</a>
+</h1>
+<p id="rfc.section.6.3.p.1">The target URI template is used to identify the link's target, potentially making use of instance data.  Additionally, with <a href="#hrefSchema" class="xref">"hrefSchema"</a>, this template can identify a set of possible target resources to use based on client input.  The full process of resolving the URI template, with or without client input, is covered in the <a href="#uriTemplating" class="xref">URI Templating</a> section.  </p>
+<h1 id="rfc.section.6.3.1">
+<a href="#rfc.section.6.3.1">6.3.1.</a> <a href="#href" id="href">href</a>
+</h1>
+<p id="rfc.section.6.3.1.p.1">The value of the "href" link description property is a template used to determine the target URI of the related resource.  The value of the instance property MUST be resolved as a <a href="#RFC3986" class="xref">URI-reference</a> against the base URI of the instance.  </p>
+<p id="rfc.section.6.3.1.p.2">This property is REQUIRED.  </p>
+<h1 id="rfc.section.6.4">
+<a href="#rfc.section.6.4">6.4.</a> Adjusting URI Template Resolution</h1>
+<p id="rfc.section.6.4.p.1">The keywords in this section are used when resolving all URI Templates involved in hyper-schema: "base", "anchor", and "href".  See the <a href="#uriTemplating" class="xref">URI Templating</a> section for the complete template resolution algorithm.  </p>
+<p id="rfc.section.6.4.p.2">Note that when resolving a "base" template, the attachment point from which resolution begins is the attachment point of the "href" or "anchor" keyword being resolved which requires "base" templates to be resolved, not the attachment point of the "base" keyword itself.  </p>
+<h1 id="rfc.section.6.4.1">
+<a href="#rfc.section.6.4.1">6.4.1.</a> <a href="#templatePointers" id="templatePointers">templatePointers</a>
+</h1>
+<p id="rfc.section.6.4.1.p.1">The value of the "templatePointers" link description property MUST be an object.  Each property value in the object MUST be a valid <a href="#RFC6901" class="xref">JSON Pointer</a>, or a valid <a href="#relative-json-pointer" class="xref">Relative JSON Pointer</a> which is evaluated relative to the attachment point of the link for which the template is being resolved.  </p>
+<p id="rfc.section.6.4.1.p.2">For each property name in the object that matches a variable name in the template being resolved, the value of that property adjusts the starting position of variable resolution for that variable.  Properties which do not match template variable names in the template being resolved MUST be ignored.  </p>
+<h1 id="rfc.section.6.4.2">
+<a href="#rfc.section.6.4.2">6.4.2.</a> <a href="#templateRequired" id="templateRequired">templateRequired</a>
+</h1>
+<p id="rfc.section.6.4.2.p.1">The value of this keyword MUST be an array, and the elements MUST be unique.  Each element SHOULD match a variable in the link's URI Template, without percent-encoding.  After completing the entire URI Template resolution process, if any variable that is present in this array does not have a value, the link MUST NOT be used.  </p>
+<h1 id="rfc.section.6.5">
+<a href="#rfc.section.6.5">6.5.</a> <a href="#targetAttributes" id="targetAttributes">Link Target Attributes</a>
+</h1>
+<p id="rfc.section.6.5.p.1">All properties in this section are advisory only.  While keywords such as "title" and "description" are used primarily to present the link to users, those keywords that predict the nature of a link interaction or response MUST NOT be considered authoritative.  The runtime behavior of the target resource MUST be respected whenever it conflicts with the target attributes in the LDO.  </p>
+<h1 id="rfc.section.6.5.1">
+<a href="#rfc.section.6.5.1">6.5.1.</a> title</h1>
+<p id="rfc.section.6.5.1.p.1">This property defines a title for the link.  The value MUST be a string.  </p>
+<p id="rfc.section.6.5.1.p.2">User agents MAY use this title when presenting the link to the user.  </p>
+<h1 id="rfc.section.6.5.2">
+<a href="#rfc.section.6.5.2">6.5.2.</a> description</h1>
+<p id="rfc.section.6.5.2.p.1">This property provides additional information beyond what is present in the title.  The value MUST be a string.  While a title is preferably short, a description can be used to go into more detail about the purpose and usage of the link.  </p>
+<p id="rfc.section.6.5.2.p.2">User agents MAY use this description when presenting the link to the user.  </p>
+<h1 id="rfc.section.6.5.3">
+<a href="#rfc.section.6.5.3">6.5.3.</a> targetMediaType</h1>
+<p id="rfc.section.6.5.3.p.1">The value of this property represents the media type <a href="#RFC2046" class="xref">RFC 2046</a>, that is expected to be returned when fetching this resource.  This property value MAY be a media range instead, using the same pattern defined in <a href="#RFC7231" class="xref">RFC 7231, section 5.3.2 - HTTP "Accept" header</a>.  </p>
+<p id="rfc.section.6.5.3.p.2">This property is analogous to the "type" property of other link serialization formats.  User agents MAY use this information to inform the interface they present to the user before the link is followed, but MUST NOT use this information in the interpretation of the resulting data.  Instead, a user agent MUST use the media type given by the response for run-time interpretation.  See the section on <a href="#security" class="xref">"Security Concerns"</a> for a detailed examination of mis-use of "targetMediaType".  </p>
+<p id="rfc.section.6.5.3.p.3">For protocols supporting content-negotiation, implementations MAY choose to describe possible target media types using protocol-specific information in <a href="#headerSchema" class="xref">"headerSchema"</a>.  If both protocol-specific information and "targetMediaType" are present, then the value of "targetMediaType" MUST be compatible with the protocol-specific information, and SHOULD indicate the media type that will be returned in the absence of content negotiation.  </p>
+<p id="rfc.section.6.5.3.p.4">When no such protocol-specific information is available, or when the implementation does not recognize the protocol involved, then the value SHOULD be taken to be "application/json".  </p>
+<h1 id="rfc.section.6.5.4">
+<a href="#rfc.section.6.5.4">6.5.4.</a> <a href="#targetSchema" id="targetSchema">targetSchema</a>
+</h1>
+<p id="rfc.section.6.5.4.p.1">This property provides a schema that is expected to describe the link target's representation.  Depending on the protocol, the schema may or may not describe the request or response to any particular operation performed with the link.  See the <a href="#HTTP" class="xref">JSON Hyper-Schema and HTTP</a> section for an in-depth discussion of how this keyword is used with HTTP.  </p>
+<h1 id="rfc.section.6.5.5">
+<a href="#rfc.section.6.5.5">6.5.5.</a> <a href="#targetHints" id="targetHints">targetHints</a>
+</h1>
+<p><a id="CREF1" class="info">[CREF1]<span class="info">This section attempts to strike a balance between comprehensiveness and flexibility by deferring most of its structure to the protocol indicated by the URI scheme.  Note that a resource can be identified by a URI with a dereferenceable scheme, yet not be accessible over that protocol.  While currently very loose, this section is expected to become more well-defined based on draft feedback, and may change significantly in future drafts.  </span></a> </p>
+<p id="rfc.section.6.5.5.p.2">The value of this property is advisory only.  It represents information that is expected to be discoverable through interacting with the target resource, typically in the form of protocol-specific control information or meta-data such as headers returned in response to an HTTP HEAD or OPTIONS request.  The protocol is determined by the "href" URI scheme, although note that resources are not guaranteed to be accessible over such a protocol.  </p>
+<p id="rfc.section.6.5.5.p.3">The value of this property SHOULD be an object.  The keys to this object SHOULD be lower-cased forms of the control data field names.  Each value SHOULD be an array, in order to uniformly handle multi-valued fields.  Multiple values MUST be presented as an array, and not as a single string.  </p>
+<p id="rfc.section.6.5.5.p.4">Protocols with control information not suitable for representation as a JSON object MAY be represented by another data type, such as an array.  </p>
+<p id="rfc.section.6.5.5.p.5">Values that cannot be understood as part of the indicated protocol MUST be ignored by a JSON Hyper-Schema implementation.  Applications MAY make use of such values, but MUST NOT assume interoperability with other implementations.  </p>
+<p id="rfc.section.6.5.5.p.6">Implementations MUST NOT assume that all discoverable information is accounted for in this object.  Client applications MUST properly handle run-time responses that contradict this property's values.  </p>
+<p id="rfc.section.6.5.5.p.7">Client applications MUST NOT assume that an implementation will automatically take any action based on the value of this property.  </p>
+<p id="rfc.section.6.5.5.p.8">See <a href="#HTTP" class="xref">"JSON Hyper-Schema and HTTP"</a> for guidance on using this keyword with HTTP and analogous protocols.  </p>
+<h1 id="rfc.section.6.6">
+<a href="#rfc.section.6.6">6.6.</a> <a href="#input" id="input">Link Input</a>
+</h1>
+<p id="rfc.section.6.6.p.1">There are four ways to use client input with a link, and each is addressed by a separate link description object keyword.  When performing operations, user agents SHOULD ignore schemas that are not relevant to their semantics.  </p>
+<h1 id="rfc.section.6.6.1">
+<a href="#rfc.section.6.6.1">6.6.1.</a> <a href="#hrefSchema" id="hrefSchema">hrefSchema</a>
+</h1>
+<p id="rfc.section.6.6.1.p.1">The value of the "hrefSchema" link description property MUST be a valid JSON Schema.  This schema is used to validate user input or other user agent data for filling out the URI Template in <a href="#href" class="xref">"href"</a>.  </p>
+<p id="rfc.section.6.6.1.p.2">Omitting "hrefSchema" or setting the entire schema to "false" prevents any user agent data from being accepted.  </p>
+<p id="rfc.section.6.6.1.p.3">Setting any subschema that applies to a particular variable to the JSON literal value "false" prevents any user agent data from being accepted for that single variable.  </p>
+<p id="rfc.section.6.6.1.p.4">For template variables that can be resolved from the instance data, if the instance data is valid against all applicable subschemas in "hrefSchema", then it MUST be used to pre-populate the input data set for that variable.  </p>
+<p id="rfc.section.6.6.1.p.5">Note that even when data is pre-populated from the instance, the validation schema for that variable in "hrefSchema" need not be identical to the validation schema(s) that apply to the instance data's location.  This allows for different validation rules for user agent data, such as supporting spelled-out months for date-time input, but using the standard date-time format for storage.  </p>
+<p id="rfc.section.6.6.1.p.6">After input is accepted, potentially overriding the pre-populated instance data, the resulting data set MUST successfully validate against the value of "hrefSchema".  If it does not then the link MUST NOT be used.  If it is valid, then the process given in the "URI Templating" section continues with this updated data set.  </p>
+<h1 id="rfc.section.6.6.2">
+<a href="#rfc.section.6.6.2">6.6.2.</a> <a href="#headerSchema" id="headerSchema">headerSchema</a>
+</h1>
+<p><a id="CREF2" class="info">[CREF2]<span class="info">As with "targetHints", this keyword is somewhat under-specified to encourage experimentation and feedback as we try to balance flexibility and clarity.  </span></a> </p>
+<p id="rfc.section.6.6.2.p.2">If present, this property is a schema for protocol-specific request headers or analogous control and meta-data.  The value of this object MUST be a valid JSON Schema.  The protocol is determined by the "href" URI scheme, although note that resources are not guaranteed to be accessible over such a protocol.  The schema is advisory only; the target resource's behavior is not constrained by its presence.  </p>
+<p id="rfc.section.6.6.2.p.3">The purpose of this keyword is to advertise target resource interaction features, and indicate to user agents and client applications what headers and header values are likely to be useful.  User agents and client applications MAY use the schema to validate relevant headers, but MUST NOT assume that missing headers or values are forbidden from use.  While schema authors MAY set "additionalProperties" to false, this is NOT RECOMMENDED and MUST NOT prevent client applications or user agents from supplying additional headers when requests are made.  </p>
+<p id="rfc.section.6.6.2.p.4">The exact mapping of the JSON data model into the headers is protocol-dependent.  However, in most cases this schema SHOULD specify a type of "object", and the property names SHOULD be lower-cased forms of the control data field names.  As with "targetHints", the values SHOULD be described as arrays to allow for multiple values, even if only one value is expected.  </p>
+<p id="rfc.section.6.6.2.p.5">See the <a href="#HTTP" class="xref">"JSON Hyper-Schema and HTTP"</a> section for detailed guidance on using this keyword with HTTP and analogous protocols.  </p>
+<p id="rfc.section.6.6.2.p.6">"headerSchema" is applicable to any request method or command that the protocol supports.  When generating a request, user agents and client applications SHOULD ignore schemas for headers that are not relevant to that request.  </p>
+<h1 id="rfc.section.6.6.3">
+<a href="#rfc.section.6.6.3">6.6.3.</a> Manipulating the Target Resource Representation</h1>
+<p id="rfc.section.6.6.3.p.1">In JSON Hyper-Schema, <a href="#targetSchema" class="xref">"targetSchema"</a> supplies a non-authoritative description of the target resource's representation.  A client application can use "targetSchema" to structure input for replacing or modifying the representation, or as the base representation for building a patch document based on a patch media type.  </p>
+<p id="rfc.section.6.6.3.p.2">Alternatively, if "targetSchema" is absent or if the client application prefers to only use authoritative information, it can interact with the target resource to confirm or discover its representation structure.  </p>
+<p id="rfc.section.6.6.3.p.3">"targetSchema" is not intended to describe link operation responses, except when the response semantics indicate that it is a representation of the target resource.  In all cases, the schema indicated by the response itself is authoritative.  See <a href="#HTTP" class="xref">"JSON Hyper-Schema and HTTP"</a> for detailed examples.  </p>
+<h1 id="rfc.section.6.6.4">
+<a href="#rfc.section.6.6.4">6.6.4.</a> Submitting Data for Processing</h1>
+<p id="rfc.section.6.6.4.p.1">The <a href="#submissionSchema" class="xref">"submissionSchema"</a> and <a href="#submissionMediaType" class="xref">"submissionMediaType"</a> keywords describe the domain of the processing function implemented by the target resource.  Otherwise, as noted above, the submission schema and media type are ignored for operations to which they are not relevant.  </p>
+<h1 id="rfc.section.6.6.4.1">
+<a href="#rfc.section.6.6.4.1">6.6.4.1.</a> <a href="#submissionMediaType" id="submissionMediaType">submissionMediaType</a>
+</h1>
+<p id="rfc.section.6.6.4.1.p.1">If present, this property indicates the media type format the client application and user agent should use for the request payload described by <a href="#submissionSchema" class="xref">"submissionSchema"</a>.  </p>
+<p id="rfc.section.6.6.4.1.p.2">Omitting this keyword has the same behavior as a value of application/json.  </p>
+<p id="rfc.section.6.6.4.1.p.3">Note that "submissionMediaType" and "submissionSchema" are not restricted to HTTP URIs.  <a id="CREF3" class="info">[CREF3]<span class="info">This statement might move to wherever the example ends up.</span></a> </p>
+<h1 id="rfc.section.6.6.4.2">
+<a href="#rfc.section.6.6.4.2">6.6.4.2.</a> <a href="#submissionSchema" id="submissionSchema">submissionSchema</a>
+</h1>
+<p id="rfc.section.6.6.4.2.p.1">This property contains a schema which defines the acceptable structure of the document to be encoded according to the "submissionMediaType" property and sent to the target resource for processing.  This can be viewed as describing the domain of the processing function implemented by the target resource.  </p>
+<p id="rfc.section.6.6.4.2.p.2">This is a separate concept from the <a href="#targetSchema" class="xref">"targetSchema"</a> property, which describes the target information resource (including for replacing the contents of the resource in a PUT request), unlike "submissionSchema" which describes the user-submitted request data to be evaluated by the resource.  "submissionSchema" is intended for use with requests that have payloads that are not necessarily defined in terms of the target representation.  </p>
+<p id="rfc.section.6.6.4.2.p.3">Omitting "submissionSchema" has the same behavior as a value of "true".  </p>
+<h1 id="rfc.section.7">
+<a href="#rfc.section.7">7.</a> <a href="#implementation" id="implementation">Implementation Requirements</a>
+</h1>
+<p id="rfc.section.7.p.1">At a high level, a conforming implementation will meet the following requirements.  Each of these requirements is covered in more detail in the individual keyword sections and keyword group overviews.  </p>
+<p id="rfc.section.7.p.2">Note that the requirements around how an implementation MUST recognize "self", "collection", and "item" links are thoroughly covered in the <a href="#relationType" class="xref">link relation type</a> section and are not repeated here.  </p>
+<p id="rfc.section.7.p.3">While it is not a mandatory format for implementations, the output format used in the test suite summarizes what needs to be computed for each link before it can be used: </p>
+
+<dl>
+<dt>contextUri</dt>
+<dd style="margin-left: 8">The fully resolved URI (with scheme) of the context resource.  If the context is not the entire resource and there is a usable fragment identifier syntax, then the URI includes a fragment.  Note that there is no such syntax for application/json.  </dd>
+<dt>contextPointer</dt>
+<dd style="margin-left: 8">The JSON Pointer for the location within the instance of the context resource.  If the instance media type supports JSON Pointers as fragment identifiers, this pointer will be the same as the one encoded in the fragment of the "contextUri" field.  </dd>
+<dt>rel</dt>
+<dd style="margin-left: 8">The link relation type.  When multiple link relation types appear in the LDO, for the purpose of producing output, they are to be treated as multiple LDOs, each with a single link relation type but otherwise identical.  </dd>
+<dt>targetUri</dt>
+<dd style="margin-left: 8">The fully resolved URI (with a scheme) of the target resource.  If the link accepts input, this can only be produced once the input has been supplied.  </dd>
+<dt>hrefInputTemplates</dt>
+<dd style="margin-left: 8">The list of partially resolved URI references for a link that accepts input.  The first entry in the list is the partially resolved "href".  The additional entries, if any, are the partially resolved "base" values ordered from the most immediate out to the root of the schema.  Template variables that are pre-populated in the input are not resolved at this stage, as the pre-populated value can be overridden.  </dd>
+<dt>hrefPrepopulatedInput</dt>
+<dd style="margin-left: 8">The data set that the user agent should use to prepopulate any input mechanism before accepting client input.  If input is to be accepted but no fields are to be pre-populated, then this will be an empty object.  </dd>
+<dt>attachmentPointer</dt>
+<dd style="margin-left: 8">The JSON Pointer for the location within the instance to which the link is attached.  By default, "contextUri" and "attachmentPointer" are the same, but "contextUri" can be changed by LDO keywords, while "attachmentPointer" cannot.  </dd>
+</dl>
+
+<p> Other LDO keywords that are not involved in producing the above information are included exactly as they appear when producing output for the test suite.  Those fields will not be further discussed here unless specifically relevant.  </p>
+<h1 id="rfc.section.7.1">
+<a href="#rfc.section.7.1">7.1.</a> Link Discovery and Look-Up</h1>
+<p id="rfc.section.7.1.p.1">Before links can be used, they must be discovered by applying the hyper-schema to the instance and finding all applicable and valid links.  Note that in addition to collecting valid links, any <a href="#base" class="xref">"base"</a> values necessary to resolve each LDO's URI Templates must also be located and associated with the LDO through whatever mechanism is most useful for the implementation's URI Template resolution process.  </p>
+<p id="rfc.section.7.1.p.2">And implementation MUST support looking up links by either their attachment pointer or context pointer, either by performing the look-up or by providing the set of all links with both pointers determined so that user agents can implement the look-up themselves.  </p>
+<p id="rfc.section.7.1.p.3">When performing look-ups by context pointer, links that are attached to elements of the same array MUST be returned in the same order as the array elements to which they are attached.  </p>
+<h1 id="rfc.section.7.2">
+<a href="#rfc.section.7.2">7.2.</a> <a href="#uriTemplating" id="uriTemplating">URI Templating</a>
+</h1>
+<p id="rfc.section.7.2.p.1">Three hyper-schema keywords are <a href="#RFC6570" class="xref">URI Templates</a>: "base", "anchor", and "href".  Each are resolved separately to URI-references, and then the anchor or href URI-reference is resolved against the base (which is itself resolved against earlier bases as needed, each of which was first resolved from a URI Template to a URI-reference).  </p>
+<p id="rfc.section.7.2.p.2">All three keywords share the same algorithm for resolving variables from instance data, which makes use of the "templatePointers" and "templateRequired" keywords.  When resolving "href", both it and any "base" templates needed for resolution to an absolute URI, the algorithm is modified to optionally accept user input based on the "hrefSchema" keyword.  </p>
+<p id="rfc.section.7.2.p.3">For each URI Template (T), the following pseudocode describes an algorithm for resolving T into a URI-reference (R).  For the purpose of this algorithm: </p>
+
+<ul>
+<li>"ldo.templatePointers" is an empty object if the keyword was not present and "ldo.templateRequired" is likewise an empty array.  </li>
+<li>"attachmentPointer" is the absolute JSON Pointer for the attachment location of the LDO.  </li>
+<li>"getApplicableSchemas()" returns an iterable set of all (sub)schemas that apply to the attachment point in the instance.  </li>
+</ul>
+
+<p> </p>
+<p id="rfc.section.7.2.p.4">This algorithm should be applied first to either "href" or "anchor", and then as needed to each successive "base".  The order is important, as it is not always possible to tell whether a template will resolve to a full URI or a URI-reference.  </p>
+<p id="rfc.section.7.2.p.5">In English, the high-level algorithm is: </p>
+
+<ol>
+<li>Populate template variable data from the instance</li>
+<li>If input is desired, accept input</li>
+<li>Check that all required variables have a value</li>
+<li>Encode values into strings and fill out the template</li>
+</ol>
+
+<p> </p>
+<p>This is the high-level algorithm as pseudocode.  "T" comes from either "href" or "anchor" within the LDO, or from "base" in a containing schema.  Pseudocode for each step follows.  "initialTemplateKeyword" indicates which of the two started the process (since "base" is always resolved in order to finish resolving one or the other of those keywords).  </p>
+<pre>
+
+templateData = populateDataFromInstance(T, ldo, instance)
+
+if initialTemplateKeyword == "href" and ldo.hrefSchema exists:
+    inputData = acceptInput(ldo, instance, templateData)
+    for varname in inputData:
+        templateData[varname] = inputData[varname]
+
+for varname in ldo.templateRequired:
+    if not exists templateData[varname]
+        fatal("Missing required variable(s)")
+
+templateData = stringEncode(templateData)
+R = rfc6570ResolutionAlgorithm(T, templateData)
+
+                    </pre>
+<h1 id="rfc.section.7.2.1">
+<a href="#rfc.section.7.2.1">7.2.1.</a> Populating Template Data From the Instance</h1>
+<p id="rfc.section.7.2.1.p.1">This step looks at various locations in the instance for variable values.  For each variable: </p>
+
+<ol>
+<li>Use "templatePointers" to find a value if the variable appears in that keyword's value </li>
+<li>Otherwise, look for a property name matching the variable in the instance location to which the link is attached </li>
+<li>In either case, if there is a value at the location, put it in the template resolution data set </li>
+</ol>
+
+<p> </p>
+<pre>
+
+for varname in T:
+    varname = rfc3986PercentDecode(varname)
+    if varname in ldo.templatePointers:
+        valuePointer = templatePointers[varname]
+        if valuePointer is relative:
+            valuePointer = resolveRelative(attachmentPointer,
+                                           valuePointer)
+    else
+        valuePointer = attachmentPointer + "/" + varname
+
+    value = instance.valueAt(valuePointer)
+    if value is defined:
+        templateData[varname] = value
+
+                        </pre>
+<h1 id="rfc.section.7.2.2">
+<a href="#rfc.section.7.2.2">7.2.2.</a> Accepting Input for Template Data</h1>
+<p id="rfc.section.7.2.2.p.1">This step is relatively complex, as there are several cases to support.  Some variables will forbid input and some will allow it.  Some will have initial values that need to be presented in the input interface, and some will not.  </p>
+<p></p>
+
+<ol>
+<li>Determine which variables can accept input </li>
+<li>Pre-populate the input data set if the template resolution data set has a value </li>
+<li>Accept input (present a web form, make a callback, etc.) </li>
+<li>Validate the input data set, (not the template resolution data set) </li>
+<li>Put the input in the template resolution data set, overriding any existing values </li>
+</ol>
+
+<p> </p>
+<p>"InputForm" represents whatever sort of input mechanism is appropriate.  This may be a literal web form, or may be a more programmatic construct such as a callback function accepting specific fields and data types, with the given initial values, if any.  </p>
+<pre>
+
+form = new InputForm()
+for varname in T:
+    useField = true
+    useInitialData = true
+    for schema in getApplicableSchemas(ldo.hrefSchema,
+                                       "/" + varname):
+        if schema is false:
+            useField = false
+            break
+
+        if varname in templateData and
+           not isValid(templateData[varname], schema)):
+            useInitialData = false
+            break
+
+    if useField:
+        if useInitialData:
+            form.addInputFieldFor(varname, ldo.hrefSchema,
+                                  templateData[varname])
+        else:
+            form.addInputFieldFor(varname, ldo.hrefSchema)
+
+inputData = form.acceptInput()
+
+if not isValid(inputData, hrefSchema):
+    fatal("Input invalid, link is not usable")
+
+return inputData:
+
+                        </pre>
+<h1 id="rfc.section.7.2.3">
+<a href="#rfc.section.7.2.3">7.2.3.</a> Encoding Data as Strings</h1>
+<p id="rfc.section.7.2.3.p.1">This section is straightforward, converting literals to their names as strings, and converting numbers to strings in the most obvious manner, and percent-encoding as needed for use in the URI.  </p>
+<pre>
+
+for varname in templateData:
+    value = templateData[varname]
+    if value is true:
+        templateData[varname] = "true"
+    else if value is false:
+        temlateData[varname] = "false"
+    else if value is null:
+        templateData[varname] = "null"
+    else if value is a number:
+        templateData[varname] =
+            bestEffortOriginalJsonString(value)
+    else:
+        templateData[varname] = rfc3986PercentEncode(value)
+
+                        </pre>
+<p>In some software environments the original JSON representation of a number will not be available (there is no way to tell the difference between 1.0 and 1), so any reasonable representation should be used.  Schema and API authors should bear this in mind, and use other types (such as string or boolean) if the exact representation is important.  If the number was provide as input in the form of a string, the string used as input SHOULD be used.  </p>
+<h1 id="rfc.section.7.3">
+<a href="#rfc.section.7.3">7.3.</a> Providing Access to LDO Keywords</h1>
+<p id="rfc.section.7.3.p.1">For a given link, an implementation MUST make the values of all target attribute keywords directly available to the user agent.  Implementations MAY provide additional interfaces for using this information, as discussed in each keyword's section.  </p>
+<p id="rfc.section.7.3.p.2">For a given link, an implementation MUST make the value of each input schema keyword directly available to the user agent.  </p>
+<p id="rfc.section.7.3.p.3">To encourage encapsulation of the URI Template resolution process, implementations MAY omit the LDO keywords that are used only to construct URIs.  However, implementations MUST provide access to the link relation type.  </p>
+<p id="rfc.section.7.3.p.4">Unrecognized keywords SHOULD be made available to the user agent, and MUST otherwise be ignored.  </p>
+<h1 id="rfc.section.7.4">
+<a href="#rfc.section.7.4">7.4.</a> Requests</h1>
+<p id="rfc.section.7.4.p.1">A hyper-schema implementation SHOULD provide access to all information needed to construct any valid request to the target resource.  </p>
+<p id="rfc.section.7.4.p.2">The LDO can express all information needed to perform any operation on a link.  This section explains what hyper-schema fields a user agent should examine to build requests from any combination of instance data and client input.  A hyper-schema implementation is not itself expected to construct and send requests.  </p>
+<p id="rfc.section.7.4.p.3">Target URI construction rules, including "hrefSchema" for accepting input, are identical for all possible requests.  </p>
+<p id="rfc.section.7.4.p.4">Requests that do not carry a body payload do not require additional keyword support.  </p>
+<p id="rfc.section.7.4.p.5">Requests that take a target representation as a payload SHOULD use the "targetSchema" and "targetMediaType" keywords for input description and payload validation.  If a protocol allows an operation taking a payload that is based on the representation as modified by a media type (such as a patch media type), then such a media type SHOULD be indicated through "targetHints" in a protocol-specific manner.  </p>
+<p id="rfc.section.7.4.p.6">Requests that take a payload that is not derived from the target resource's representation SHOULD use the "submissionSchema" and "submissionMediaType" keywords for input description and payload validation.  Protocols used in hypermedia generally only support one such non-representation operation per link.  </p>
+<p id="rfc.section.7.4.p.7">RPC systems that pipe many application operations with arbitrarily different request structures through a single hypermedia protocol operation are outside of the scope of a hypermedia format such as JSON Hyper-Schema.  </p>
+<h1 id="rfc.section.7.5">
+<a href="#rfc.section.7.5">7.5.</a> Responses</h1>
+<p id="rfc.section.7.5.p.1">As a hypermedia format, JSON Hyper-Schema is concerned with describing a resource, including describing its links in sufficient detail to make all valid requests.  It is not concerned with directly describing all possible responses for those requests.  </p>
+<p id="rfc.section.7.5.p.2">As in any hypermedia system, responses are expected to be self-describing.  In the context of hyper-schema, this means that each response MUST link its own hyper-schema(s).  While responses that consist of a representation of the target resource are expected to be valid against "targetSchema" and "targetMediaType", those keywords are advisory only and MUST be ignored if contradicted by the response itself.  </p>
+<p id="rfc.section.7.5.p.3">Other responses, including error responses, complex redirections, and processing status representations SHOULD also link to their own schemas and use appropriate media types (e.g. <a href="#RFC7807" class="xref">"application/problem+json"</a> for errors).  Certain errors might not link a schema due to being generated by an intermediary that is not aware of hyper-schema, rather than by the origin.  </p>
+<p id="rfc.section.7.5.p.4">User agents are expected to understand protocol status codes and response media types well enough to handle common situations, and provide enough information to client applications to handle domain-specific responses.  </p>
+<p id="rfc.section.7.5.p.5">Statically mapping all possible responses and their schemas at design time is outside of the scope of JSON Hyper-Schema, but may be within the scope of other JSON Schema vocabularies which build on hyper-schema (see <a href="#staticAnalysis" class="xref">Appendix A.3</a>).  </p>
+<h1 id="rfc.section.7.6">
+<a href="#rfc.section.7.6">7.6.</a> <a href="#streaming" id="streaming">Streaming Parsers</a>
+</h1>
+<p id="rfc.section.7.6.p.1">The requirements around discovering links based on their context, or using the context of links to identify collections, present unique challenges when used with streaming parsers.  It is not possible to authoritatively fulfill these requirements without processing the entire schema and instance documents.  </p>
+<p id="rfc.section.7.6.p.2">Such implementations MAY choose to return non-authoritative answers based on data processed to date.  When offering this approach, implementations MUST be clear on the nature of the response, and MUST offer an option to block and wait until all data is processed and an authoritative answer can be returned.  </p>
+<h1 id="rfc.section.8">
+<a href="#rfc.section.8">8.</a> <a href="#HTTP" id="HTTP">JSON Hyper-Schema and HTTP</a>
+</h1>
+<p id="rfc.section.8.p.1">While JSON Hyper-Schema is a hypermedia format and therefore protocol-independent, it is expected that its most common use will be in HTTP systems, or systems using protocols such as CoAP that are explicitly analogous to HTTP.  </p>
+<p id="rfc.section.8.p.2">This section provides guidance on how to use each common HTTP method with a link, and how collection resources impose additional constraints on HTTP POST.  Additionally, guidance is provided on hinting at HTTP response header values and describing possible HTTP request headers that are relevant to the given resource.  </p>
+<p><a href="#json-schema" class="xref">Section 13 of the JSON Schema core specification</a> provides guidance on linking instances in a hypermedia system to their schemas.  This may be done with network-accessible schemas, or may simply identify schemas which were pre-packaged within the client application.  JSON Hyper-Schema intentionally does not constrain this mechanism, although it is RECOMMENDED that the techniques outlined in the core specification be used to whatever extent is possible.  </p>
+<h1 id="rfc.section.8.1">
+<a href="#rfc.section.8.1">8.1.</a> One Link Per Target and Relation Type</h1>
+<p id="rfc.section.8.1.p.1">Link Description Objects do not directly indicate what operations, such as HTTP methods, are supported by the target resource.  Instead, operations should be inferred primarily from link <a href="#rel" class="xref">relation types</a> and URI schemes.  </p>
+<p id="rfc.section.8.1.p.2">This means that for each target resource and link relation type pair, schema authors SHOULD only define a single LDO.  While it is possible to use "allow" with "targetHints" to repeat a relation type and target pair with different HTTP methods marked as allowed, this is NOT RECOMMENDED and may not be well-supported by conforming implementations.  </p>
+<p id="rfc.section.8.1.p.3">All information necessary to use each HTTP method can be conveyed in a single LDO as explained in this section.  The "allow" field in "targetHints" is intended simply to hint at which operations are supported, not to separately define each operation.  </p>
+<p id="rfc.section.8.1.p.4">Note, however, that a resource may always decline an operation at runtime, for instance due to authorization failure, or due to other application state that controls the operation's availability.  </p>
+<h1 id="rfc.section.8.2">
+<a href="#rfc.section.8.2">8.2.</a> <a href="#targetHTTP" id="targetHTTP">"targetSchema" and HTTP</a>
+</h1>
+<p id="rfc.section.8.2.p.1">"targetSchema" describes the resource on the target end of the link, while "targetMediaType" defines that resource's media type.  With HTTP links, "headerSchema" can also be used to describe valid values for use in an "Accept" request header, which can support multiple media types or media ranges.  When both ways of indicating the target media type are present, "targetMediaType" SHOULD indicate the default representation media type, while the schema for "accept" in "headerSchema" SHOULD include the default as well as any alternate media types or media ranges that can be requested.  </p>
+<p id="rfc.section.8.2.p.2">Since the semantics of many HTTP methods are defined in terms of the target resource, "targetSchema" is used for requests and/or responses for several HTTP methods.  In particular, "targetSchema" suggests what a client application can expect for the response to an HTTP GET or any response for which the "Content-Location" header is equal to the request URI, and what a client application should send if it creates or replaces the resource with an HTTP PUT request.  These correlations are defined by <a href="#RFC7231" class="xref">RFC 7231, section 4.3.1 - "GET", section 4.3.4 "PUT", and section 3.1.4.2, "Content-Location"</a>.  </p>
+<p id="rfc.section.8.2.p.3">Per <a href="#RFC5789" class="xref">RFC 5789</a>, the request structure for an HTTP PATCH is determined by the combination of "targetSchema" and the request media type, which is conveyed by the "Accept-Patch" header, which may be included in "targetHints".  Media types that are suitable for PATCH-ing define a syntax for expressing changes to a document, which can be applied to the representation described by "targetSchema" to determine the set of syntactically valid request payloads.  Often, the simplest way to validate a PATCH request is to apply it and validate the result as a normal representation.  </p>
+<h1 id="rfc.section.8.3">
+<a href="#rfc.section.8.3">8.3.</a> <a href="#post" id="post">HTTP POST and the "submission*" keywords</a>
+</h1>
+<p id="rfc.section.8.3.p.1">JSON Hyper-Schema allows for resources that process arbitrary data in addition to or instead of working with the target's representation.  This arbitrary data is described by the "submissionSchema" and "submissionMediaType" keywords.  In the case of HTTP, the POST method is the only one that handles such data.  While there are certain conventions around using POST with collections, the semantics of a POST request are defined by the target resource, not HTTP.  </p>
+<p id="rfc.section.8.3.p.2">In addition to the protocol-neutral "submission*" keywords (see <a href="#mailto" class="xref">Section 9.3</a> for a non-HTTP example), the "Accept-Post" header can be used to specify the necessary media type, and MAY be advertised via the "targetHints" field.  <a id="CREF4" class="info">[CREF4]<span class="info">What happens if both are used?  Also, "submissionSchema" is a MUST to support, while "targetHints" are at most a SHOULD.  But forbidding the use of "Accept-Post" in "targetHints" seems incorrect.  </span></a> </p>
+<p id="rfc.section.8.3.p.3">Successful responses to POST other than a 201 or a 200 with "Content-Location" set likewise have no HTTP-defined semantics.  As with all HTTP responses, any representation in the response should link to its own hyper-schema to indicate how it may be processed.  As noted in <a href="#responses" class="xref">Appendix A.2</a>, connecting hyperlinks with all possible operation responses is not within the scope of JSON Hyper-Schema.  </p>
+<h1 id="rfc.section.8.4">
+<a href="#rfc.section.8.4">8.4.</a> Optimizing HTTP Discoverability With "targetHints"</h1>
+<p><a id="CREF5" class="info">[CREF5]<span class="info">It would be good to also include a section with CoAP examples.</span></a> </p>
+<p id="rfc.section.8.4.p.2">JSON serializations of HTTP response header information SHOULD follow the guidelines established by the work in progress <a href="#I-D.reschke-http-jfv" class="xref">"A JSON Encoding for HTTP Header Field Values"</a>.  Approaches shown in that document's examples SHOULD be applied to other similarly structured headers wherever possible.  </p>
+<p id="rfc.section.8.4.p.3">Headers for all possible HTTP method responses all share "headerSchema".  In particular, both headers that appear in a HEAD response and those that appear in an OPTIONS response can appear.  No distinction is made within "headerSchema" as to which method response contains which header.  </p>
+<p id="rfc.section.8.4.p.4">It is RECOMMENDED that schema authors provide hints for the values of the following types of HTTP headers whenever applicable: </p>
+
+<ul>
+<li>Method allowance</li>
+<li>Method-specific request media types</li>
+<li>Authentication challenges</li>
+</ul>
+
+<p> </p>
+<p id="rfc.section.8.4.p.5">In general, headers that are likely to have different values at different times SHOULD NOT be included in "targetHints".  </p>
+<p>As an example, an Allow header allowing HEAD, GET, and POST would be shown as follows: </p>
+<pre>
+
+{
+    "targetHints": {
+        "allow": ["HEAD", "GET", "POST"]
+    }
+}
+
+                    </pre>
+<p>Note that this is represented identically whether there is a single-line Allow header with comma-separated values, multiple Allow headers on separate lines, each with one value, or any combination of such arrangements.  As is generally true with HTTP headers, comma-separated values and multiple occurrences of the header are treated the same way.  </p>
+<h1 id="rfc.section.8.5">
+<a href="#rfc.section.8.5">8.5.</a> Advertising HTTP Features With "headerSchema"</h1>
+<p id="rfc.section.8.5.p.1">Schemas SHOULD be written to describe JSON serializations that follow guidelines established by the work in progress <a href="#I-D.reschke-http-jfv" class="xref">"A JSON Encoding for HTTP Header Field Values"</a> Approaches shown in that document's examples SHOULD be applied to other similarly structured headers wherever possible.  </p>
+<p id="rfc.section.8.5.p.2">It is RECOMMENDED that schema authors describe the available usage of the following types of HTTP headers whenever applicable: </p>
+
+<ul>
+<li>Content negotiation</li>
+<li>Authentication and authorization</li>
+<li>Range requests</li>
+<li>The "Prefer" header</li>
+</ul>
+
+<p> </p>
+<p id="rfc.section.8.5.p.3">Headers such as cache control and conditional request headers are generally implemented by intermediaries rather than the resource, and are therefore not generally useful to describe.  While the resource must supply the information needed to use conditional requests, the runtime handling of such headers and related responses is not resource-specific.  </p>
+<h1 id="rfc.section.8.6">
+<a href="#rfc.section.8.6">8.6.</a> Creating Resources Through Collections</h1>
+<p id="rfc.section.8.6.p.1">When using HTTP, or a protocol such as CoAP that is explicitly analogous to HTTP, this is done by POST-ing a representation of the individual resource to be created to the collection resource.  The process for recognizing collection and item resources is described in <a href="#collectionAndItem" class="xref">Section 6.2.3</a>.  </p>
+<h1 id="rfc.section.8.7">
+<a href="#rfc.section.8.7">8.7.</a> Content Negotiation and Schema Evolution</h1>
+<p id="rfc.section.8.7.p.1">JSON Hyper-Schema facilitates HTTP content negotiation, and allows for a hybrid of the proactive and reactive strategies.  As mentioned above, a hyper-schema can include a schema for HTTP headers such as "Accept", "Accept-Charset", "Accept-Language", etc with the "headerSchema" keyword.  A user agent or client application can use information in this schema, such as an enumerated list of supported languages, in lieu of making an initial request to start the reactive negotiation process.  </p>
+<p id="rfc.section.8.7.p.2">In this way, the proactive content negotiation technique of setting these headers can be informed by server information about what values are possible, similar to examining a list of alternatives in reactive negotiation.  </p>
+<p id="rfc.section.8.7.p.3">For media types that allow specifying a schema as a media type parameter, the "Accept" values sent in a request or advertised in "headerSchema" can include the URI(s) of the schema(s) to which the negotiated representation is expected to conform.  One possible use for schema parameters in content negotiation is if the resource has conformed to several different schema versions over time.  The client application can indicate what version(s) it understands in the "Accept" header in this way.  </p>
+<h1 id="rfc.section.9">
+<a href="#rfc.section.9">9.</a> <a href="#examples" id="examples">Examples</a>
+</h1>
+<p id="rfc.section.9.p.1">This section shows how the keywords that construct URIs and JSON Pointers are used.  The results are shown in the format used by the test suite.  <a id="CREF6" class="info">[CREF6]<span class="info">Need to post that and link it, but it should be pretty self-explanatory to those of you reviewing things at this stage.  </span></a> </p>
+<p id="rfc.section.9.p.2">Most other keywords are either straightforward ("title" and "description"), apply validation to specific sorts of input, requests, or responses, or have protocol-specific behavior.  Examples demonstrating HTTP usage are available in <a href="#HTTP" class="xref">an Appendix</a>.  </p>
+<h1 id="rfc.section.9.1">
+<a href="#rfc.section.9.1">9.1.</a> <a href="#entryPoint" id="entryPoint">Entry Point Links, No Templates</a>
+</h1>
+<p id="rfc.section.9.1.p.1">For this example, we will assume an example API with a documented entry point URI of https://example.com/api, which is an empty JSON object with a link to a schema.  Here, the entry point has no data of its own and exists only to provide an initial set of links: </p>
+<pre>
+
+GET https://example.com/api HTTP/1.1
+
+200 OK
+Content-Type: application/json
+Link: &lt;https://schema.example.com/entry&gt;; rel="describedBy"
+{}
+
+                    </pre>
+<p id="rfc.section.9.1.p.2">The linked hyper-schema defines the API's base URI and provides two links:  an "about" link to API documentation, and a "self" link indicating that this is a schema for the base URI.  </p>
+<pre>
+
+{
+    "$id": "https://schema.example.com/entry",
+    "$schema": "http://json-schema.org/draft/2019-04/hyper-schema#",
+    "base": "https://example.com/api/",
+    "links": [
+        {
+            "rel": "self",
+            "href": "../api",
+        }, {
+            "rel": "about",
+            "href": "docs"
+        }
+    ]
+}
+                    </pre>
+<p id="rfc.section.9.1.p.3">These are the simplest possible links, with only a relation type and an "href" with no template variables.  They resolve as follows: </p>
+<p id="rfc.section.9.1.p.4">The duplication of "api" in both the base and the "../api" href in the "self" link is due to quirks of the RFC 3986 URI-reference resolution algorithm.  In order for relative URI-references to work well in general, the base URI needs to include a trailing slash.  The "about" link with its "docs" href shows the common case of relative references, which is used in the other examples in this document.  </p>
+<p id="rfc.section.9.1.p.5">However, if an API uses URIs without trailing slashes for its resources, there is no way to provide a relative reference that just removes a trailing slash without duplicating the path component above it.  Which makes the case of the entry point resource, which differs from the base URI only in terms of the trailing slash, somewhat awkward.  </p>
+<p id="rfc.section.9.1.p.6">Resource URIs, of course, may have trailing slashes, but this example is intended to highlight this frequently confusing special case.  </p>
+<pre>
+[
+    {
+        "contextUri": "https://example.com/api",
+        "contextPointer": "",
+        "rel": "self",
+        "targetUri": "https://example.com/api",
+        "attachmentPointer": ""
+    },
+    {
+        "contextUri": "https://example.com/api",
+        "contextPointer": "",
+        "rel": "about",
+        "targetUri": "https://example.com/api/docs",
+        "attachmentPointer": ""
+    }
+]
+                    </pre>
+<p id="rfc.section.9.1.p.7">The attachment pointer is the root pointer (the only possibility with an empty object for the instance).  The context URI is the default, which is the requested document.  Since application/json does not allow for fragments, the context pointer is necessary to fully describe the context.  Its default behavior is to be the same as the attachment pointer.  </p>
+<h1 id="rfc.section.9.2">
+<a href="#rfc.section.9.2">9.2.</a> Individually Identified Resources</h1>
+<p id="rfc.section.9.2.p.1">Let's add "things" to our system, starting with an individual thing: </p>
+<pre>
+{
+    "$id": "https://schema.example.com/thing",
+    "$schema": "http://json-schema.org/draft/2019-04/hyper-schema#",
+    "base": "https://example.com/api/",
+    "type": "object",
+    "required": ["data"],
+    "properties": {
+        "id": {"$ref": "#/$defs/id"},
+        "data": true
+    },
+    "links": [
+        {
+            "rel": "self",
+            "href": "things/{id}",
+            "templateRequired": ["id"],
+            "targetSchema": {"$ref": "#"}
+        }
+    ],
+    "$defs": {
+        "id": {
+            "type": "integer",
+            "minimum": 1,
+            "readOnly": true
+        }
+    }
+}
+                    </pre>
+<p id="rfc.section.9.2.p.2">Our "thing" has a server-assigned id, which is required in order to construct the "self" link.  It also has a "data" field which can be of any type.  The reason for the "$defs" section will be clear in the next example.  </p>
+<p id="rfc.section.9.2.p.3">Note that "id" is not required by the validation schema, but is required by the self link.  This makes sense: a "thing" only has a URI if it has been created, and the server has assigned an id.  However, you can use this schema with an instance containing only the data field, which allows you to validate "thing" instances that you are about to create.  </p>
+<p id="rfc.section.9.2.p.4">Let's add a link to our entry point schema that lets you jump directly to a particular thing if you can supply it's id as input.  To save space, only the new LDO is shown.  Unlike "self" and "about", there is no IANA-registered relationship about hypothetical things, so an extension relationship is defined using the <a href="#RFC4151" class="xref">"tag:" URI scheme</a>: </p>
+<pre>
+{
+    "rel": "tag:rel.example.com,2017:thing",
+    "href": "things/{id}",
+    "hrefSchema": {
+        "required": ["id"],
+        "properties": {
+            "id": {"$ref": "thing#/$defs/id"}
+        }
+    },
+    "targetSchema": {"$ref": "thing#"}
+}
+                    </pre>
+<p id="rfc.section.9.2.p.5">The "href" value here is the same, but everything else is different.  Recall that the instance is an empty object, so "id" cannot be resolved from instance data.  Instead it is required as client input.  This LDO could also have used "templateRequired" but with "required" in "hrefSchema" it is not strictly necessary.  Providing "templateRequired" without marking "id" as required in "hrefSchema" would lead to errors, as client input is the only possible source for resolving this link.  </p>
+<h1 id="rfc.section.9.3">
+<a href="#rfc.section.9.3">9.3.</a> <a href="#mailto" id="mailto">Submitting a Payload and Accepting URI Input</a>
+</h1>
+<p id="rfc.section.9.3.p.1">This example covers using the "submission" fields for non-representation input, as well as using them alongside of resolving the URI Template with input.  Unlike HTML forms, which require either constructing a URI or sending a payload, but do not allow not both at once, JSON Hyper-Schema can describe both sorts of input for the same operation on the same link.  </p>
+<p id="rfc.section.9.3.p.2">The "submissionSchema" and "submissionMediaType" fields are for describing payloads that are not representations of the target resource.  When used with "http(s)://" URIs, they generally refer to a POST request payload, as seen in the <a href="#HTTP" class="xref">appendix on HTTP usage</a>.  </p>
+<p id="rfc.section.9.3.p.3">In this case, we use a "mailto:" URI, which, per <a href="#RFC6068" class="xref">RFC 6068, Section 3"</a>, does not provide any operation for retrieving a resource.  It can only be used to construct a message for sending.  Since there is no concept of a retrievable, replaceable, or deletable target resource, "targetSchema" and "targetMediaType" are not used.  Non-representation payloads are described by "submissionSchema" and "submissionMediaType".  </p>
+<p id="rfc.section.9.3.p.4">We use "submissionMediaType" to indicate a multipart/alternative payload format, providing two representations of the same data (HTML and plain text).  Since a multipart/alternative message is an ordered sequence (the last part is the most preferred alternative), we model the sequence as an array in "submissionSchema".  Since each part is itself a document with a media type, we model each item in the array as a string, using "contentMediaType" to indicate the format within the string.  </p>
+<p id="rfc.section.9.3.p.5">Note that media types such as multipart/form-data, which associate a name with each part and are not ordered, should be modeled as JSON objects rather than arrays.  </p>
+<p>Note that some lines are wrapped to fit this document's width restrictions.  </p>
+<pre>
+{
+    "$id": "https://schema.example.com/interesting-stuff",
+    "$schema": "http://json-schema.org/draft/2019-04/hyper-schema#",
+    "required": ["stuffWorthEmailingAbout", "email", "title"],
+    "properties": {
+        "title": {
+            "type": "string"
+        },
+        "stuffWorthEmailingAbout": {
+            "type": "string"
+        },
+        "email": {
+            "type": "string",
+            "format": "email"
+        },
+        "cc": false
+    },
+    "links": [
+        {
+            "rel": "author",
+            "href": "mailto:{email}?subject={title}{&amp;cc}",
+            "templateRequired": ["email"],
+            "hrefSchema": {
+                "required": ["title"],
+                "properties": {
+                    "title": {
+                        "type": "string"
+                    },
+                    "cc": {
+                        "type": "string",
+                        "format": "email"
+                    },
+                    "email": false
+                }
+            },
+            "submissionMediaType":
+                    "multipart/alternative; boundary=ab2",
+            "submissionSchema": {
+                "type": "array",
+                "items": [
+                    {
+                        "type": "string",
+                        "contentMediaType":
+                                "text/plain; charset=utf8"
+                    },
+                    {
+                        "type": "string",
+                        "contentMediaType": "text/html"
+                    }
+                ],
+                "minItems": 2
+            }
+        }
+    ]
+}
+                    </pre>
+<p id="rfc.section.9.3.p.6">For the URI parameters, each of the three demonstrates a different way of resolving the input: </p>
+
+<dl>
+<dt>email:</dt>
+<dd style="margin-left: 8">This variable's presence in "templateRequired" means that it must be resolved for the template to be used.  Since the "false" schema assigned to it in "hrefSchema" excludes it from the input data set, it must be resolved from the instance.  </dd>
+<dt>title:</dt>
+<dd style="margin-left: 8">The instance field matching this variable is required, and it is also allowed in the input data.  So its instance value is used to pre-populate the input data set before accepting client input.  The client application can opt to leave the instance value in place.  Since this field is required in "hrefSchema", the client application cannot delete it (although it could set it to an empty string).  </dd>
+<dt>cc:</dt>
+<dd style="margin-left: 8">The "false" schema set for this in the main schema prevents this field from having an instance value.  If it is present at all, it must come from client input.  As it is not required in "hrefSchema", it may not be used at all.  </dd>
+</dl>
+
+<p> </p>
+<p id="rfc.section.9.3.p.7">So, given the following instance retrieved from "https://example.com/api/stuff": </p>
+<pre>
+{
+    "title": "The Awesome Thing",
+    "stuffWorthEmailingAbout": "Lots of text here...",
+    "email": "someone@example.com"
+}
+                    </pre>
+<p id="rfc.section.9.3.p.8">We can partially resolve the link as follows, before asking the client application for input.  </p>
+<pre>
+{
+    "contextUri": "https://example.com/api/stuff",
+    "contextPointer": "",
+    "rel": "author",
+    "hrefInputTemplates": [
+      "mailto:someone@example.com?subject={title}{&amp;cc}"
+    ],
+    "hrefPrepopulatedInput": {
+        "title": "The Awesome Thing"
+    },
+    "attachmentPointer": ""
+}
+                    </pre>
+<p id="rfc.section.9.3.p.9">Notice the "href*" keywords in place of "targetUri".  These are three possible kinds of "targetUri" values covering different sorts of input.  Here are examples of each: </p>
+
+<dl>
+<dt>No additional or changed input:</dt>
+<dd style="margin-left: 8">"mailto:someone@example.com?subject=The%20Awesome%20Thing" </dd>
+<dt>Change "title" to "your work":</dt>
+<dd style="margin-left: 8">"mailto:someone@example.com?subject=your%20work" </dd>
+<dt>Change title and add a "cc" of "other@elsewhere.org":</dt>
+<dd style="margin-left: 8">"mailto:someone@example.com?subject=your%20work&amp;cc=other@elsewhere.org" </dd>
+</dl>
+
+<p> </p>
+<h1 id="rfc.section.9.4">
+<a href="#rfc.section.9.4">9.4.</a> "anchor", "base" and URI Template Resolution</h1>
+<p id="rfc.section.9.4.p.1">A link is a typed connection from a context resource to a target resource.  Older link serializations support a "rev" keyword that takes a link relation type as "rel" does, but reverses the semantics.  This has long been deprecated, so JSON Hyper-Schema does not support it.  Instead, "anchor"'s ability to change the context URI can be used to reverse the direction of a link.  It can also be used to describe a link between two resources, neither of which is the current resource.  </p>
+<p id="rfc.section.9.4.p.2">As an example, there is an IANA-registered "up" relation, but there is no "down".  In an HTTP Link header, you could implement "down" as <samp>"rev": "up"</samp>.  </p>
+<p>First let's look at how this could be done in HTTP, showing a "self" link and two semantically identical links, one with "rev": "up" and the other using "anchor" with "rel": "up" (line wrapped due to formatting limitations).  </p>
+<pre>
+
+GET https://example.com/api/trees/1/nodes/123 HTTP/1.1
+
+200 OK
+Content-Type: application/json
+Link: &lt;https://example.com/api/trees/1/nodes/123&gt;; rel="self"
+Link: &lt;https://example.com/api/trees/1/nodes/123&gt;; rel="up";
+        anchor="https://example.com/api/trees/1/nodes/456"
+Link: &lt;https://example.com/api/trees/1/nodes/456&gt;; rev="up"
+{
+    "id": 123,
+    "treeId": 1,
+    "childIds": [456]
+}
+
+                    </pre>
+<p>Note that the "rel=up" link has a target URI identical to the "rel=self" link, and sets "anchor" (which identifies the link's context) to the child's URI.  This sort of reversed link is easily detectable by tools when a "self" link is also present.  </p>
+<p>The following hyper-schema, applied to the instance in the response above, would produce the same "self" link and "up" link with "anchor".  It also shows the use of a templated "base" URI, plus both absolute and relative JSON Pointers in "templatePointers".  </p>
+<pre>
+{
+    "$id": "https://schema.example.com/tree-node",
+    "$schema": "http://json-schema.org/draft/2019-04/hyper-schema#",
+    "base": "trees/{treeId}/",
+    "properties": {
+        "id": {"type": "integer"},
+        "treeId": {"type": "integer"},
+        "childIds": {
+            "type": "array",
+            "items": {
+                "type": "integer",
+                "links": [
+                    {
+                        "anchor": "nodes/{thisNodeId}",
+                        "rel": "up",
+                        "href": "nodes/{childId}",
+                        "templatePointers": {
+                            "thisNodeId": "/id",
+                            "childId": "0"
+                        }
+                    }
+                ]
+            }
+        }
+    },
+    "links": [
+        {
+            "rel": "self",
+            "href": "nodes/{id}"
+        }
+    ]
+}
+                    </pre>
+<p>The "base" template is evaluated identically for both the target ("href") and context ("anchor") URIs.  </p>
+<p id="rfc.section.9.4.p.3">Note the two different sorts of templatePointers used.  "thisNodeId" is mapped to an absolute JSON Pointer, "/id", while "childId" is mapped to a relative pointer, "0", which indicates the value of the current item.  Absolute JSON Pointers do not support any kind of wildcarding, so there is no way to specify a concept like "current item" without a relative JSON Pointer.  </p>
+<h1 id="rfc.section.9.5">
+<a href="#rfc.section.9.5">9.5.</a> Collections</h1>
+<p id="rfc.section.9.5.p.1">In many systems, individual resources are grouped into collections.  Those collections also often provide a way to create individual item resources with server-assigned identifiers.  </p>
+<p>For this example, we will re-use the individual thing schema as shown in an earlier section.  It is repeated here for convenience, with an added "collection" link with a "targetSchema" reference pointing to the collection schema we will introduce next.  </p>
+<pre>
+{
+    "$id": "https://schema.example.com/thing",
+    "$schema": "http://json-schema.org/draft/2019-04/hyper-schema#",
+    "base": "https://example.com/api/",
+    "type": "object",
+    "required": ["data"],
+    "properties": {
+        "id": {"$ref": "#/$defs/id"},
+        "data": true
+    },
+    "links": [
+        {
+            "rel": "self",
+            "href": "things/{id}",
+            "templateRequired": ["id"],
+            "targetSchema": {"$ref": "#"}
+        }, {
+            "rel": "collection",
+            "href": "/things",
+            "targetSchema": {"$ref": "thing-collection#"},
+            "submissionSchema": {"$ref": "#"}
+        }
+    ],
+    "$defs": {
+        "id": {
+            "type": "integer",
+            "minimum": 1,
+            "readOnly": true
+        }
+    }
+}
+                    </pre>
+<p>The "collection" link is the same for all items, so there are no URI Template variables.  The "submissionSchema" is that of the item itself.  As described in <a href="#collectionAndItem" class="xref">Section 6.2.3</a>, if a "collection" link supports a submission mechanism (POST in HTTP) then it MUST implement item creation semantics.  Therefore "submissionSchema" is the schema for creating a "thing" via this link.  </p>
+<p>Now we want to describe collections of "thing"s.  This schema describes a collection where each item representation is identical to the individual "thing" representation.  While many collection representations only include subset of the item representations, this example uses the entirety to minimize the number of schemas involved.  The actual collection items appear as an array within an object, as we will add more fields to the object in the next example.  </p>
+<pre>
+{
+    "$id": "https://schema.example.com/thing-collection",
+    "$schema": "http://json-schema.org/draft/2019-04/hyper-schema#",
+    "base": "https://example.com/api/",
+    "type": "object",
+    "required": ["elements"],
+    "properties": {
+        "elements": {
+            "type": "array",
+            "items": {
+                "allOf": [{"$ref": "thing#"}],
+                "links": [
+                    {
+                        "anchorPointer": "",
+                        "rel": "item",
+                        "href": "things/{id}",
+                        "templateRequired": ["id"],
+                        "targetSchema": {"$ref": "thing#"}
+                    }
+                ]
+            }
+        }
+    },
+    "links": [
+        {
+            "rel": "self",
+            "href": "things",
+            "targetSchema": {"$ref": "#"},
+            "submissionSchema": {"$ref": "thing"}
+        }
+    ]
+}
+                    </pre>
+<p>Here is a simple two-element collection instance: </p>
+<pre>
+{
+    "elements": [
+        {"id": 12345, "data": {}},
+        {"id": 67890, "data": {}}
+    ]
+}
+                    </pre>
+<p>Here are all of the links that apply to this instance, including those that are defined in the referenced individual "thing" schema: </p>
+<pre>
+[
+    {
+        "contextUri": "https://example.com/api/things",
+        "contextPointer": "",
+        "rel": "self",
+        "targetUri": "https://example.com/api/things",
+        "attachmentPointer": ""
+    },
+    {
+        "contextUri": "https://example.com/api/things",
+        "contextPointer": "/elements/0",
+        "rel": "self",
+        "targetUri": "https://example.com/api/things/12345",
+        "attachmentPointer": "/elements/0"
+    },
+    {
+        "contextUri": "https://example.com/api/things",
+        "contextPointer": "/elements/1",
+        "rel": "self",
+        "targetUri": "https://example.com/api/things/67890",
+        "attachmentPointer": "/elements/1"
+    },
+    {
+        "contextUri": "https://example.com/api/things",
+        "contextPointer": "",
+        "rel": "item",
+        "targetUri": "https://example.com/api/things/12345",
+        "attachmentPointer": "/elements/0"
+    },
+    {
+        "contextUri": "https://example.com/api/things",
+        "contextPointer": "",
+        "rel": "item",
+        "targetUri": "https://example.com/api/things/67890",
+        "attachmentPointer": "/elements/1"
+    },
+    {
+        "contextUri": "https://example.com/api/things",
+        "contextPointer": "/elements/0",
+        "rel": "collection",
+        "targetUri": "https://example.com/api/things",
+        "attachmentPointer": "/elements/0"
+    },
+    {
+        "contextUri": "https://example.com/api/things",
+        "contextPointer": "/elements/1",
+        "rel": "collection",
+        "targetUri": "https://example.com/api/things",
+        "attachmentPointer": "/elements/1"
+    }
+]
+
+                    </pre>
+<p>In all cases, the context URI is shown for an instance of media type application/json, which does not support fragments.  If the instance media type was application/instance+json, which supports JSON Pointer fragments, then the context URIs would contain fragments identical to the context pointer field.  For application/json and other media types without fragments, it is critically important to consider the context pointer as well as the context URI.  </p>
+<p id="rfc.section.9.5.p.2">There are three "self" links, one for the collection, and one for each item in the "elements" array.  The item "self" links are defined in the individual "thing" schema which is referenced with "$ref".  The three links can be distinguished by their context or attachment pointers.  We will revisit the "submissionSchema" of the collection's "self" link in <a href="#firstItem" class="xref">Section 9.5.2</a>.  </p>
+<p id="rfc.section.9.5.p.3">There are two "item" links, one for each item in the "elements" array.  Unlike the "self" links, these are defined only in the collection schema.  Each of them have the same target URI as the corresponding "self" link that shares the same attachment pointer.  However, each has a different context pointer.  The context of the "self" link is the entry in "elements", while the context of the "item" link is always the entire collection regardless of the specific item.  </p>
+<p id="rfc.section.9.5.p.4">Finally, there are two "collection" links, one for each item in "elements".  In the individual item schema, these produce links with the item resource as the context.  When referenced from the collection schema, the context is the location in the "elements" array of the relevant "thing", rather than that "thing"'s own separate resource URI.  </p>
+<p id="rfc.section.9.5.p.5">The collection links have identical target URIs as there is only one relevant collection URI.  While calculating both links as part of a full set of constructed links may not seem useful, when constructing links on an as-needed basis, this arrangement means that there is a "collection" link definition close at hand no matter which "elements" entry you are processing.  </p>
+<h1 id="rfc.section.9.5.1">
+<a href="#rfc.section.9.5.1">9.5.1.</a> Pagination</h1>
+<p>Here we add pagination to our collection.  There is a "meta" section to hold the information about current, next, and previous pages.  Most of the schema is the same as in the previous section and has been omitted.  Only new fields and new or (in the case of the main "self" link) changed links are shown in full.  </p>
+<pre>
+{
+    "properties": {
+        "elements": {
+            ...
+        },
+        "meta": {
+            "type": "object",
+            "properties": {
+                "prev": {"$ref": "#/$defs/pagination"},
+                "current": {"$ref": "#/$defs/pagination"},
+                "next": {"$ref": "#/$defs/pagination"}
+            }
+        }
+    },
+    "links": [
+        {
+            "rel": "self",
+            "href": "things{?offset,limit}",
+            "templateRequired": ["offset", "limit"],
+            "templatePointers": {
+                "offset": "/meta/current/offset",
+                "limit": "/meta/current/limit"
+            },
+            "targetSchema": {"$ref": "#"}
+        }, {
+            "rel": "prev",
+            "href": "things{?offset,limit}",
+            "templateRequired": ["offset", "limit"],
+            "templatePointers": {
+                "offset": "/meta/prev/offset",
+                "limit": "/meta/prev/limit"
+            },
+            "targetSchema": {"$ref": "#"}
+        }, {
+            "rel": "next",
+            "href": "things{?offset,limit}",
+            "templateRequired": ["offset", "limit"],
+            "templatePointers": {
+                "offset": "/meta/next/offset",
+                "limit": "/meta/next/limit"
+            },
+            "targetSchema": {"$ref": "#"}
+        }
+    ],
+    "$defs": {
+        "pagination": {
+            "type": "object",
+            "properties": {
+                "offset": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "default": 0
+                },
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 100,
+                    "default": 10
+                }
+            }
+        }
+    }
+}
+                        </pre>
+<p>Notice that the "self" link includes the pagination query that produced the exact representation, rather than being a generic link to the collection allowing selecting the page via input.  </p>
+<p>Given this instance: </p>
+<pre>
+{
+    "elements": [
+        {"id": 12345, "data": {}},
+        {"id": 67890, "data": {}}
+    ],
+    "meta": {
+        "current": {
+            "offset": 0,
+            "limit": 2
+        },
+        "next": {
+            "offset": 3,
+            "limit": 2
+        }
+    }
+}
+                        </pre>
+<p>Here are all of the links that apply to this instance that either did not appear in the previous example or have been changed with pagination added.  </p>
+<pre>
+[
+    {
+        "contextUri": "https://example.com/api/things",
+        "contextPointer": "",
+        "rel": "self",
+        "targetUri":
+            "https://example.com/api/things?offset=0&amp;limit=2",
+        "attachmentPointer": ""
+    },
+    {
+        "contextUri": "https://example.com/api/things",
+        "contextPointer": "",
+        "rel": "next",
+        "targetUri":
+            "https://example.com/api/things?offset=3&amp;limit=2",
+        "attachmentPointer": ""
+    }
+]
+                        </pre>
+<p>Note that there is no "prev" link in the output, as we are looking at the first page.  The lack of a "prev" field under "meta", together with the "prev" link's "templateRequired" values, means that the link is not usable with this particular instance.  </p>
+<p><a id="CREF7" class="info">[CREF7]<span class="info">It's not clear how pagination should work with the link from the "collection" links in the individual "thing" schema.  Technically, a link from an item to a paginated or filtered collection should go to a page/filter that contains the item (in this case the "thing") that is the link context.  See GitHub issue #421 for more discussion.  </span></a> </p>
+<p id="rfc.section.9.5.1.p.2">Let's add a link for this collection to the entry point schema (<a href="#entryPoint" class="xref">Section 9.1</a>), including pagination input in order to allow client applications to jump directly to a specific page.  Recall that the entry point schema consists only of links, therefore we only show the newly added link: </p>
+<pre>
+{
+    "rel": "tag:rel.example.com,2017:thing-collection",
+    "href": "/things{?offset,limit}",
+    "hrefSchema": {
+        "$ref": "thing-collection#/$defs/pagination"
+    },
+    "submissionSchema": {
+        "$ref": "thing#"
+    },
+    "targetSchema": {
+        "$ref": "thing-collection#"
+    }
+}
+                        </pre>
+<p>Now we see the pagination parameters being accepted as input, so we can jump to any page within the collection.  The link relation type is a custom one as the generic "collection" link can only be used with an item as its context, not an entry point or other resource.  </p>
+<h1 id="rfc.section.9.5.2">
+<a href="#rfc.section.9.5.2">9.5.2.</a> <a href="#firstItem" id="firstItem">Creating the First Item</a>
+</h1>
+<p id="rfc.section.9.5.2.p.1">When we do not have any "thing"s, we do not have any resources with a relevant "collection" link.  Therefore we cannot use a "collection" link's submission keywords to create the first "thing"; hyper-schemas must be evaluated with respect to an instance.  Since the "elements" array in the collection instance would be empty, it cannot provide us with a collection link either.  </p>
+<p id="rfc.section.9.5.2.p.2">However, our entry point link can take us to the empty collection, and we can use the presence of "item" links in the hyper-schema to recognize that it is a collection.  Since the context of the "item" link is the collection, we simply look for a "self" link with the same context, which we can then treat as collection for the purposes of a creation operation.  </p>
+<p id="rfc.section.9.5.2.p.3">Presumably, our custom link relation type in the entry point schema was sufficient to ensure that we have found the right collection.  A client application that recognizes that custom link relation type may know that it can immediately assume that the target is a collection, but a generic user agent cannot do so.  Despite the presence of a "-collection" suffix in our example, a generic user agent would have no way of knowing whether that substring indicates a hypermedia resource collection, or some other sort of collection.  </p>
+<p id="rfc.section.9.5.2.p.4">Once we have recognized the "self" link as being for the correct collection, we can use its "submissionSchema" and/or "submissionMediaType" keywords to perform an item creation operation.  <a id="CREF8" class="info">[CREF8]<span class="info">This works perfectly if the collection is unfiltered and unpaginated.  However, one should generally POST to a collection that will contain the created resource, and a "self" link MUST include any filters, pagination, or other query parameters.  Is it still valid to POST to such a "self" link even if the resulting item would not match the filter or appear within that page?  See GitHub issue #421 for further discussion.  </span></a> <a id="CREF9" class="info">[CREF9]<span class="info">Draft-04 of Hyper-Schema defined a "create" link relation that had the schema, rather than the instance, as its context.  This did not fit into the instance-based link model, and incorrectly used an operation name for a link relation type.  However, defining a more correctly designed link from the schema to the collection instance may be one possible approach to solving this.  Again, see GitHub issue #421 for more details.  </span></a> </p>
+<h1 id="rfc.section.10">
+<a href="#rfc.section.10">10.</a> <a href="#security" id="security">Security Considerations</a>
+</h1>
+<p id="rfc.section.10.p.1">JSON Hyper-Schema defines a vocabulary for JSON Schema core and concerns all the security considerations listed there.  As a link serialization format, the security considerations of <a href="#RFC8288" class="xref">RFC 8288 Web Linking</a> also apply, with appropriate adjustments (e.g. "anchor" as an LDO keyword rather than an HTTP Link header attribute).  </p>
+<h1 id="rfc.section.10.1">
+<a href="#rfc.section.10.1">10.1.</a> Target Attributes</h1>
+<p id="rfc.section.10.1.p.1">As stated in <a href="#targetAttributes" class="xref">Section 6.5</a>, all LDO keywords describing the target resource are advisory and MUST NOT be used in place of the authoritative information supplied by the target resource in response to an operation.  Target resource responses SHOULD indicate their own hyper-schema, which is authoritative.  </p>
+<p id="rfc.section.10.1.p.2">If the hyper-schema in the target response matches (by "$id") the hyper-schema in which the current LDO was found, then the target attributes MAY be considered authoritative.  <a id="CREF10" class="info">[CREF10]<span class="info">Need to add something about the risks of spoofing by "$id", but given that other parts of the specification discourage always re-downloading the linked schema, the risk mitigation options are unclear.  </span></a> </p>
+<p id="rfc.section.10.1.p.3">User agents or client applications MUST NOT use the value of "targetSchema" to aid in the interpretation of the data received in response to following the link, as this leaves "safe" data open to re-interpretation.  </p>
+<p id="rfc.section.10.1.p.4">When choosing how to interpret data, the type information provided by the server (or inferred from the filename, or any other usual method) MUST be the only consideration, and the "targetMediaType" property of the link MUST NOT be used.  User agents MAY use this information to determine how they represent the link or where to display it (for example hover-text, opening in a new tab).  If user agents decide to pass the link to an external program, they SHOULD first verify that the data is of a type that would normally be passed to that external program.  </p>
+<p id="rfc.section.10.1.p.5">This is to guard against re-interpretation of "safe" data, similar to the precautions for "targetSchema".  </p>
+<p id="rfc.section.10.1.p.6">Protocol meta-data values conveyed in "targetHints" MUST NOT be considered authoritative.  Any security considerations defined by the protocol that may apply based on incorrect assumptions about meta-data values apply.  </p>
+<p id="rfc.section.10.1.p.7">Even when no protocol security considerations are directly applicable, implementations MUST be prepared to handle responses that do not match the link's "targetHints" values.  </p>
+<h1 id="rfc.section.10.2">
+<a href="#rfc.section.10.2">10.2.</a> "self" Links</h1>
+<p id="rfc.section.10.2.p.1">When link relation of "self" is used to denote a full representation of an object, the user agent SHOULD NOT consider the representation to be the authoritative representation of the resource denoted by the target URI if the target URI is not equivalent to or a sub-path of the URI used to request the resource representation which contains the target URI with the "self" link.  <a id="CREF11" class="info">[CREF11]<span class="info">It is no longer entirely clear what was intended by the "sub-path" option in this paragraph.  It may have been intended to allow "self" links for embedded item representations in a collection, which usually have target URIs that are sub-paths of that collection's URI, to be considered authoritative.  However, this is simply a common design convention and does not appear to be based in RFC 3986 or any other guidance on URI usage.  See GitHub issue #485 for further discussion.  </span></a> </p>
+<h1 id="rfc.section.11">
+<a href="#rfc.section.11">11.</a> Acknowledgments</h1>
+<p id="rfc.section.11.p.1">Thanks to Gary Court, Francis Galiegue, Kris Zyp, and Geraint Luff for their work on the initial drafts of JSON Schema.  </p>
+<p id="rfc.section.11.p.2">Thanks to Jason Desrosiers, Daniel Perrett, Erik Wilde, Ben Hutton, Evgeny Poberezkin, Brad Bowman, Gowry Sankar, Donald Pipowitch, Dave Finlay, and Denis Laxalde for their submissions and patches to the document.  </p>
+<h1 id="rfc.references">
+<a href="#rfc.references">12.</a> References</h1>
+<h1 id="rfc.references.1">
+<a href="#rfc.references.1">12.1.</a> Normative References</h1>
+<table><tbody>
+<tr>
+<td class="reference"><b id="json-schema">[json-schema]</b></td>
+<td class="top">
+<a>Wright, A.</a> and <a>H. Andrews</a>, "<a href="https://tools.ietf.org/html/draft-handrews-json-schema-02">JSON Schema: A Media Type for Describing JSON Documents</a>", Internet-Draft draft-handrews-json-schema-02, November 2017.</td>
+</tr>
+<tr>
+<td class="reference"><b id="json-schema-validation">[json-schema-validation]</b></td>
+<td class="top">
+<a>Wright, A.</a>, <a>Andrews, H.</a> and <a>G. Luff</a>, "<a href="https://tools.ietf.org/html/draft-handrews-json-schema-validation-02">JSON Schema Validation: A Vocabulary for Structural Validation of JSON</a>", Internet-Draft draft-handrews-json-schema-validation-02, November 2017.</td>
+</tr>
+<tr>
+<td class="reference"><b id="relative-json-pointer">[relative-json-pointer]</b></td>
+<td class="top">
+<a>Luff, G.</a> and <a>H. Andrews</a>, "<a href="https://tools.ietf.org/html/draft-handrews-relative-json-pointer-02">Relative JSON Pointers</a>", Internet-Draft draft-handrews-relative-json-pointer-02, January 2018.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC2119">[RFC2119]</b></td>
+<td class="top">
+<a>Bradner, S.</a>, "<a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>", BCP 14, RFC 2119, DOI 10.17487/RFC2119, March 1997.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC3986">[RFC3986]</b></td>
+<td class="top">
+<a>Berners-Lee, T.</a>, <a>Fielding, R.</a> and <a>L. Masinter</a>, "<a href="https://tools.ietf.org/html/rfc3986">Uniform Resource Identifier (URI): Generic Syntax</a>", STD 66, RFC 3986, DOI 10.17487/RFC3986, January 2005.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC4287">[RFC4287]</b></td>
+<td class="top">
+<a>Nottingham, M.</a> and <a>R. Sayre</a>, "<a href="https://tools.ietf.org/html/rfc4287">The Atom Syndication Format</a>", RFC 4287, DOI 10.17487/RFC4287, December 2005.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC6570">[RFC6570]</b></td>
+<td class="top">
+<a>Gregorio, J.</a>, <a>Fielding, R.</a>, <a>Hadley, M.</a>, <a>Nottingham, M.</a> and <a>D. Orchard</a>, "<a href="https://tools.ietf.org/html/rfc6570">URI Template</a>", RFC 6570, DOI 10.17487/RFC6570, March 2012.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC6573">[RFC6573]</b></td>
+<td class="top">
+<a>Amundsen, M.</a>, "<a href="https://tools.ietf.org/html/rfc6573">The Item and Collection Link Relations</a>", RFC 6573, DOI 10.17487/RFC6573, April 2012.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC6901">[RFC6901]</b></td>
+<td class="top">
+<a>Bryan, P.</a>, <a>Zyp, K.</a> and <a>M. Nottingham</a>, "<a href="https://tools.ietf.org/html/rfc6901">JavaScript Object Notation (JSON) Pointer</a>", RFC 6901, DOI 10.17487/RFC6901, April 2013.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC8288">[RFC8288]</b></td>
+<td class="top">
+<a>Nottingham, M.</a>, "<a href="https://tools.ietf.org/html/rfc8288">Web Linking</a>", RFC 8288, DOI 10.17487/RFC8288, October 2017.</td>
+</tr>
+</tbody></table>
+<h1 id="rfc.references.2">
+<a href="#rfc.references.2">12.2.</a> Informative References</h1>
+<table><tbody>
+<tr>
+<td class="reference"><b id="I-D.reschke-http-jfv">[I-D.reschke-http-jfv]</b></td>
+<td class="top">
+<a>Reschke, J.</a>, "<a href="https://tools.ietf.org/html/draft-reschke-http-jfv-06">A JSON Encoding for HTTP Header Field Values</a>", Internet-Draft draft-reschke-http-jfv-06, June 2017.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC2046">[RFC2046]</b></td>
+<td class="top">
+<a>Freed, N.</a> and <a>N. Borenstein</a>, "<a href="https://tools.ietf.org/html/rfc2046">Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types</a>", RFC 2046, DOI 10.17487/RFC2046, November 1996.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC4151">[RFC4151]</b></td>
+<td class="top">
+<a>Kindberg, T.</a> and <a>S. Hawke</a>, "<a href="https://tools.ietf.org/html/rfc4151">The 'tag' URI Scheme</a>", RFC 4151, DOI 10.17487/RFC4151, October 2005.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC5789">[RFC5789]</b></td>
+<td class="top">
+<a>Dusseault, L.</a> and <a>J. Snell</a>, "<a href="https://tools.ietf.org/html/rfc5789">PATCH Method for HTTP</a>", RFC 5789, DOI 10.17487/RFC5789, March 2010.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC6068">[RFC6068]</b></td>
+<td class="top">
+<a>Duerst, M.</a>, <a>Masinter, L.</a> and <a>J. Zawinski</a>, "<a href="https://tools.ietf.org/html/rfc6068">The 'mailto' URI Scheme</a>", RFC 6068, DOI 10.17487/RFC6068, October 2010.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC7230">[RFC7230]</b></td>
+<td class="top">
+<a>Fielding, R.</a> and <a>J. Reschke</a>, "<a href="https://tools.ietf.org/html/rfc7230">Hypertext Transfer Protocol (HTTP/1.1): Message Syntax and Routing</a>", RFC 7230, DOI 10.17487/RFC7230, June 2014.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC7231">[RFC7231]</b></td>
+<td class="top">
+<a>Fielding, R.</a> and <a>J. Reschke</a>, "<a href="https://tools.ietf.org/html/rfc7231">Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</a>", RFC 7231, DOI 10.17487/RFC7231, June 2014.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC7807">[RFC7807]</b></td>
+<td class="top">
+<a>Nottingham, M.</a> and <a>E. Wilde</a>, "<a href="https://tools.ietf.org/html/rfc7807">Problem Details for HTTP APIs</a>", RFC 7807, DOI 10.17487/RFC7807, March 2016.</td>
+</tr>
+</tbody></table>
+<h1 id="rfc.appendix.A">
+<a href="#rfc.appendix.A">Appendix A.</a> <a href="#apis" id="apis">Using JSON Hyper-Schema in APIs</a>
+</h1>
+<p id="rfc.section.A.p.1">Hypermedia APIs, which follow the constraints of the REST architectural style, enable the creation of generic user agents.  Such a user agent has no application-specific knowledge.  Rather, it understands pre-defined media types, URI schemes, protocols, and link relations, often by recognizing these and coordinating the use of existing software that implements support for them.  Client applications can then be built on top of such a user agent, focusing on their own semantics and logic rather than the mechanics of the interactions.  </p>
+<p id="rfc.section.A.p.2">Hyper-schema is only concerned with one resource and set of associated links at a time.  Just as a web browser works with only one HTML page at a time, with no concept of whether or how that page functions as part of a "site", a hyper-schema-aware user agent works with one resource at a time, without any concept of whether or how that resource fits into an API.  </p>
+<p id="rfc.section.A.p.3">Therefore, hyper-schema is suitable for use within an API, but is not suitable for the description of APIs as complete entities in their own right.  There is no way to describe concepts at the API scope, rather than the resource and link scope, and such descriptions are outside of the boundaries of JSON Hyper-Schema.  </p>
+<h1 id="rfc.appendix.A.1">
+<a href="#rfc.appendix.A.1">A.1.</a> Resource Evolution With Hyper-Schema</h1>
+<p id="rfc.section.A.1.p.1">Since a given JSON Hyper-Schema is used with a single resource at a single point in time, it has no inherent notion of versioning.  However, a given resource can change which schema or schemas it uses over time, and the URIs of these schemas can be used to indicate versioning information.  When used with a media type that supports indicating a schema with a media type parameter, these versioned schema URIs can be used in content negotiation.  </p>
+<p id="rfc.section.A.1.p.2">A resource can indicate that it is an instance of multiple schemas, which allows supporting multiple compatible versions simultaneously.  A client application can then make use of the hyper-schema that it recognizes, and ignore newer or older versions.  </p>
+<h1 id="rfc.appendix.A.2">
+<a href="#rfc.appendix.A.2">A.2.</a> <a href="#responses" id="responses">Responses and Errors</a>
+</h1>
+<p id="rfc.section.A.2.p.1">Because a hyper-schema represents a single resource at a time, it does not provide for an enumeration of all possible responses to protocol operations performed with links.  Each response, including errors, is considered its own (possibly anonymous) resource, and should identify its own hyper-schema, and optionally use an appropriate media type such as <a href="#RFC7807" class="xref">RFC 7807's "application/problem+json"</a>, to allow the user agent or client application to interpret any information that is provided beyond the protocol's own status reporting.  </p>
+<h1 id="rfc.appendix.A.3">
+<a href="#rfc.appendix.A.3">A.3.</a> <a href="#staticAnalysis" id="staticAnalysis">Static Analysis of an API's Hyper-Schemas</a>
+</h1>
+<p id="rfc.section.A.3.p.1">It is possible to statically analyze a set of hyper-schemas without instance data in order to generate output such as documentation or code.  However, the full feature set of both validation and hyper-schema cannot be accessed without runtime instance data.  </p>
+<p id="rfc.section.A.3.p.2">This is an intentional design choice to provide the maximum runtime flexibility for hypermedia systems.  JSON Schema as a media type allows for establishing additional vocabularies for static analysis and content generation, which are not addressed in this specification.  Additionally, individual systems may restrict their usage to subsets that can be analyzed statically if full design-time description is a goal.  <a id="CREF12" class="info">[CREF12]<span class="info">Vocabularies for API documentation and other purposes have been proposed, and contributions are welcome at https://github.com/json-schema-org/json-schema-vocabularies </span></a> </p>
+<h1 id="rfc.appendix.B">
+<a href="#rfc.appendix.B">Appendix B.</a> ChangeLog</h1>
+<p><a id="CREF13" class="info">[CREF13]<span class="info">This section to be removed before leaving Internet-Draft status.</span></a> </p>
+<p></p>
+
+<dl>
+<dt>draft-handrews-json-schema-hyperschema-02</dt>
+<dd style="margin-left: 8">
+<ul>
+<li>Allow multiple values for "rel"</li>
+<li>Clarify that "headerSchema", like "targetHints", should use array values</li>
+<li>Clarified link behavior with conditional applicator keywords such as "if"</li>
+<li>Added and clarified various examples</li>
+<li>Avoid accidentally implying that only POST can be used to create in HTTP</li>
+</ul>
+<p> </p>
+</dd>
+<dt>draft-handrews-json-schema-hyperschema-01</dt>
+<dd style="margin-left: 8">
+<ul>
+<li>This draft is purely a bug fix with no functional changes</li>
+<li>Fixed erroneous meta-schema URI (draft-07, not draft-07-wip)</li>
+<li>Removed stray "work in progress" language left over from review period</li>
+<li>Fixed missing trailing "/" in various "base" examples</li>
+<li>Fixed incorrect draft name in changelog (luff-*-00, not -01)</li>
+<li>Update relative pointer ref to handrews-*-01, also purely a bug fix</li>
+</ul>
+<p> </p>
+</dd>
+<dt>draft-handrews-json-schema-hyperschema-00</dt>
+<dd style="margin-left: 8">
+<ul>
+<li>Top to bottom reorganization and rewrite</li>
+<li>Group keywords per RFC 8288 context/relation/target/target attributes</li>
+<li>Additional keyword groups for template resolution and describing input</li>
+<li>Clarify implementation requirements with a suggested output format</li>
+<li>Expanded overview to provide context</li>
+<li>Consolidated examples into their own section, illustrate real-world patterns</li>
+<li>Consolidated HTTP guidance in its own section</li>
+<li>Added a subsection on static analysis of hyper-schemas</li>
+<li>Consolidated security concerns in their own section</li>
+<li>Added an appendix on usage in APIs</li>
+<li>Moved "readOnly" to the validation specification</li>
+<li>Moved "media" to validation as "contentMediaType"/"contentEncoding"</li>
+<li>Renamed "submissionEncType" to "submissionMediaType"</li>
+<li>Renamed "mediaType" to "targetMediaType"</li>
+<li>Added "anchor" and "anchorPointer"</li>
+<li>Added "templatePointers" and "templateRequired"</li>
+<li>Clarified how "hrefSchema" is used</li>
+<li>Added "targetHints" and "headerSchema"</li>
+<li>Added guidance on "self", "collection" and "item" link usage</li>
+<li>Added "description" as an LDO keyword</li>
+<li>Added "$comment" in LDOs to match the schema keyword</li>
+</ul>
+<p> </p>
+</dd>
+<dt>draft-wright-json-schema-hyperschema-01</dt>
+<dd style="margin-left: 8">
+<ul>
+<li>Fixed examples</li>
+<li>Added "hrefSchema" for user input to "href" URI Templates</li>
+<li>Removed URI Template pre-processing</li>
+<li>Clarified how links and data submission work</li>
+<li>Clarified how validation keywords apply hyper-schema keywords and links</li>
+<li>Clarified HTTP use with "targetSchema"</li>
+<li>Renamed "schema" to "submissionSchema"</li>
+<li>Renamed "encType" to "submissionEncType"</li>
+<li>Removed "method"</li>
+</ul>
+<p> </p>
+</dd>
+<dt>draft-wright-json-schema-hyperschema-00</dt>
+<dd style="margin-left: 8">
+<ul>
+<li>"rel" is now optional</li>
+<li>rel="self" no longer changes URI base</li>
+<li>Added "base" keyword to change instance URI base</li>
+<li>Removed "root" link relation</li>
+<li>Removed "create" link relation</li>
+<li>Removed "full" link relation</li>
+<li>Removed "instances" link relation</li>
+<li>Removed special behavior for "describedBy" link relation</li>
+<li>Removed "pathStart" keyword</li>
+<li>Removed "fragmentResolution" keyword</li>
+<li>Updated references to JSON Pointer, HTML</li>
+<li>Changed behavior of "method" property to align with hypermedia best current practices</li>
+</ul>
+<p> </p>
+</dd>
+<dt>draft-luff-json-hyper-schema-00</dt>
+<dd style="margin-left: 8">
+<ul><li>Split from main specification.</li></ul>
+<p> </p>
+</dd>
+</dl>
+
+<p> </p>
+<h1 id="rfc.authors"><a href="#rfc.authors">Authors' Addresses</a></h1>
+<div class="avoidbreak">
+  <address class="vcard">
+	<span class="vcardline">
+	  <span class="fn">Henry Andrews</span> (editor)
+	  <span class="n hidden">
+		<span class="family-name">Andrews</span>
+	  </span>
+	</span>
+	<span class="org vcardline">Riverbed Technology</span>
+	<span class="adr">
+	  <span class="vcardline">680 Folsom St.</span>
+
+	  <span class="vcardline">
+		<span class="locality">San Francisco</span>,  
+		<span class="region">CA</span> 
+		<span class="code"></span>
+	  </span>
+	  <span class="country-name vcardline">USA</span>
+	</span>
+	<span class="vcardline">EMail: <a href="mailto:handrews@riverbed.com">handrews@riverbed.com</a></span>
+
+  </address>
+</div><div class="avoidbreak">
+  <address class="vcard">
+	<span class="vcardline">
+	  <span class="fn">Austin Wright</span> (editor)
+	  <span class="n hidden">
+		<span class="family-name">Wright</span>
+	  </span>
+	</span>
+	<span class="org vcardline"></span>
+	<span class="adr">
+	  
+	  <span class="vcardline">
+		<span class="locality"></span> 
+		<span class="region"></span>
+		<span class="code"></span>
+	  </span>
+	  <span class="country-name vcardline"></span>
+	</span>
+	<span class="vcardline">EMail: <a href="mailto:aaa@bzfx.net">aaa@bzfx.net</a></span>
+
+  </address>
+</div>
+
+</body>
+</html>

--- a/work-in-progress/WIP-jsonschema-hyperschema.html
+++ b/work-in-progress/WIP-jsonschema-hyperschema.html
@@ -453,7 +453,7 @@
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Andrews, H., Ed. and A. Wright, Ed." />
-  <meta name="dct.identifier" content="urn:ietf:id:draft-handrews-json-schema-hyperschema-02" />
+  <meta name="dct.identifier" content="urn:ietf:id:draft-handrews-json-schema-hyperschema-WIP" />
   <meta name="dct.issued" scheme="ISO8601" content="2019-25" />
   <meta name="dct.abstract" content="JSON Schema is a JSON-based format for describing JSON data using various vocabularies.  This document specifies a vocabulary for annotating JSON documents with hyperlinks.  These hyperlinks include attributes describing how to manipulate and interact with remote resources through hypermedia environments such as HTTP, as well as determining whether the link is usable based on the instance value.  The hyperlink serialization format described in this document is also usable independent of JSON Schema.  " />
   <meta name="description" content="JSON Schema is a JSON-based format for describing JSON data using various vocabularies.  This document specifies a vocabulary for annotating JSON documents with hyperlinks.  These hyperlinks include attributes describing how to manipulate and interact with remote resources through hypermedia environments such as HTTP, as well as determining whether the link is usable based on the instance value.  The hyperlink serialization format described in this document is also usable independent of JSON Schema.  " />
@@ -487,7 +487,7 @@
   </table>
 
   <p class="title">JSON Hyper-Schema: A Vocabulary for Hypermedia Annotation of JSON <br />
-  <span class="filename">draft-handrews-json-schema-hyperschema-02</span></p>
+  <span class="filename">draft-handrews-json-schema-hyperschema-WIP</span></p>
   
   <h1 id="rfc.abstract"><a href="#rfc.abstract">Abstract</a></h1>
 <p>JSON Schema is a JSON-based format for describing JSON data using various vocabularies.  This document specifies a vocabulary for annotating JSON documents with hyperlinks.  These hyperlinks include attributes describing how to manipulate and interact with remote resources through hypermedia environments such as HTTP, as well as determining whether the link is usable based on the instance value.  The hyperlink serialization format described in this document is also usable independent of JSON Schema.  </p>
@@ -1751,12 +1751,12 @@ Link: &lt;https://example.com/api/trees/1/nodes/456&gt;; rev="up"
 <tr>
 <td class="reference"><b id="json-schema">[json-schema]</b></td>
 <td class="top">
-<a>Wright, A.</a> and <a>H. Andrews</a>, "<a href="https://tools.ietf.org/html/draft-handrews-json-schema-02">JSON Schema: A Media Type for Describing JSON Documents</a>", Internet-Draft draft-handrews-json-schema-02, November 2017.</td>
+<a>Wright, A.</a> and <a>H. Andrews</a>, "<a href="https://tools.ietf.org/html/draft-handrews-json-schema-02">JSON Schema: A Media Type for Describing JSON Documents</a>", Internet-Draft draft-handrews-json-schema-WIP, November 2017.</td>
 </tr>
 <tr>
 <td class="reference"><b id="json-schema-validation">[json-schema-validation]</b></td>
 <td class="top">
-<a>Wright, A.</a>, <a>Andrews, H.</a> and <a>G. Luff</a>, "<a href="https://tools.ietf.org/html/draft-handrews-json-schema-validation-02">JSON Schema Validation: A Vocabulary for Structural Validation of JSON</a>", Internet-Draft draft-handrews-json-schema-validation-02, November 2017.</td>
+<a>Wright, A.</a>, <a>Andrews, H.</a> and <a>G. Luff</a>, "<a href="https://tools.ietf.org/html/draft-handrews-json-schema-validation-02">JSON Schema Validation: A Vocabulary for Structural Validation of JSON</a>", Internet-Draft draft-handrews-json-schema-validation-WIP, November 2017.</td>
 </tr>
 <tr>
 <td class="reference"><b id="relative-json-pointer">[relative-json-pointer]</b></td>
@@ -1868,7 +1868,7 @@ Link: &lt;https://example.com/api/trees/1/nodes/456&gt;; rev="up"
 <p></p>
 
 <dl>
-<dt>draft-handrews-json-schema-hyperschema-02</dt>
+<dt>draft-handrews-json-schema-hyperschema-WIP</dt>
 <dd style="margin-left: 8">
 <ul>
 <li>Allow multiple values for "rel"</li>

--- a/work-in-progress/WIP-jsonschema-hyperschema.txt
+++ b/work-in-progress/WIP-jsonschema-hyperschema.txt
@@ -1,0 +1,3248 @@
+
+
+
+
+Internet Engineering Task Force                          H. Andrews, Ed.
+Internet-Draft                                       Riverbed Technology
+Intended status: Informational                            A. Wright, Ed.
+Expires: November 26, 2019                                  May 25, 2019
+
+
+   JSON Hyper-Schema: A Vocabulary for Hypermedia Annotation of JSON
+               draft-handrews-json-schema-hyperschema-02
+
+Abstract
+
+   JSON Schema is a JSON-based format for describing JSON data using
+   various vocabularies.  This document specifies a vocabulary for
+   annotating JSON documents with hyperlinks.  These hyperlinks include
+   attributes describing how to manipulate and interact with remote
+   resources through hypermedia environments such as HTTP, as well as
+   determining whether the link is usable based on the instance value.
+   The hyperlink serialization format described in this document is also
+   usable independent of JSON Schema.
+
+Note to Readers
+
+   The issues list for this draft can be found at <https://github.com/
+   json-schema-org/json-schema-spec/issues>.
+
+   For additional information, see <http://json-schema.org/>.
+
+   To provide feedback, use this issue tracker, the communication
+   methods listed on the homepage, or email the document editors.
+
+Status of This Memo
+
+   This Internet-Draft is submitted in full conformance with the
+   provisions of BCP 78 and BCP 79.
+
+   Internet-Drafts are working documents of the Internet Engineering
+   Task Force (IETF).  Note that other groups may also distribute
+   working documents as Internet-Drafts.  The list of current Internet-
+   Drafts is at https://datatracker.ietf.org/drafts/current/.
+
+   Internet-Drafts are draft documents valid for a maximum of six months
+   and may be updated, replaced, or obsoleted by other documents at any
+   time.  It is inappropriate to use Internet-Drafts as reference
+   material or to cite them other than as "work in progress."
+
+   This Internet-Draft will expire on November 26, 2019.
+
+
+
+
+
+Andrews & Wright        Expires November 26, 2019               [Page 1]
+
+Internet-Draft              JSON Hyper-Schema                   May 2019
+
+
+Copyright Notice
+
+   Copyright (c) 2019 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (https://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+Table of Contents
+
+   1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   3
+   2.  Notational Conventions  . . . . . . . . . . . . . . . . . . .   4
+   3.  Overview  . . . . . . . . . . . . . . . . . . . . . . . . . .   4
+     3.1.  Terminology . . . . . . . . . . . . . . . . . . . . . . .   5
+     3.2.  Functionality . . . . . . . . . . . . . . . . . . . . . .   6
+   4.  Meta-Schemas and Output Schema  . . . . . . . . . . . . . . .   7
+   5.  Schema Keywords . . . . . . . . . . . . . . . . . . . . . . .   8
+     5.1.  base  . . . . . . . . . . . . . . . . . . . . . . . . . .   8
+     5.2.  links . . . . . . . . . . . . . . . . . . . . . . . . . .   8
+   6.  Link Description Object . . . . . . . . . . . . . . . . . . .   8
+     6.1.  Link Context  . . . . . . . . . . . . . . . . . . . . . .   9
+       6.1.1.  anchor  . . . . . . . . . . . . . . . . . . . . . . .  10
+       6.1.2.  anchorPointer . . . . . . . . . . . . . . . . . . . .  10
+     6.2.  Link Relation Type  . . . . . . . . . . . . . . . . . . .  10
+       6.2.1.  rel . . . . . . . . . . . . . . . . . . . . . . . . .  11
+       6.2.2.  "self" Links  . . . . . . . . . . . . . . . . . . . .  11
+       6.2.3.  "collection" and "item" Links . . . . . . . . . . . .  11
+       6.2.4.  Using Extension Relation Types  . . . . . . . . . . .  12
+     6.3.  Link Target . . . . . . . . . . . . . . . . . . . . . . .  12
+       6.3.1.  href  . . . . . . . . . . . . . . . . . . . . . . . .  12
+     6.4.  Adjusting URI Template Resolution . . . . . . . . . . . .  12
+       6.4.1.  templatePointers  . . . . . . . . . . . . . . . . . .  13
+       6.4.2.  templateRequired  . . . . . . . . . . . . . . . . . .  13
+     6.5.  Link Target Attributes  . . . . . . . . . . . . . . . . .  13
+       6.5.1.  title . . . . . . . . . . . . . . . . . . . . . . . .  13
+       6.5.2.  description . . . . . . . . . . . . . . . . . . . . .  13
+       6.5.3.  targetMediaType . . . . . . . . . . . . . . . . . . .  14
+       6.5.4.  targetSchema  . . . . . . . . . . . . . . . . . . . .  14
+       6.5.5.  targetHints . . . . . . . . . . . . . . . . . . . . .  14
+     6.6.  Link Input  . . . . . . . . . . . . . . . . . . . . . . .  15
+       6.6.1.  hrefSchema  . . . . . . . . . . . . . . . . . . . . .  15
+
+
+
+Andrews & Wright        Expires November 26, 2019               [Page 2]
+
+Internet-Draft              JSON Hyper-Schema                   May 2019
+
+
+       6.6.2.  headerSchema  . . . . . . . . . . . . . . . . . . . .  16
+       6.6.3.  Manipulating the Target Resource Representation . . .  17
+       6.6.4.  Submitting Data for Processing  . . . . . . . . . . .  17
+   7.  Implementation Requirements . . . . . . . . . . . . . . . . .  18
+     7.1.  Link Discovery and Look-Up  . . . . . . . . . . . . . . .  19
+     7.2.  URI Templating  . . . . . . . . . . . . . . . . . . . . .  20
+       7.2.1.  Populating Template Data From the Instance  . . . . .  21
+       7.2.2.  Accepting Input for Template Data . . . . . . . . . .  22
+       7.2.3.  Encoding Data as Strings  . . . . . . . . . . . . . .  23
+     7.3.  Providing Access to LDO Keywords  . . . . . . . . . . . .  24
+     7.4.  Requests  . . . . . . . . . . . . . . . . . . . . . . . .  24
+     7.5.  Responses . . . . . . . . . . . . . . . . . . . . . . . .  25
+     7.6.  Streaming Parsers . . . . . . . . . . . . . . . . . . . .  26
+   8.  JSON Hyper-Schema and HTTP  . . . . . . . . . . . . . . . . .  26
+     8.1.  One Link Per Target and Relation Type . . . . . . . . . .  27
+     8.2.  "targetSchema" and HTTP . . . . . . . . . . . . . . . . .  27
+     8.3.  HTTP POST and the "submission*" keywords  . . . . . . . .  28
+     8.4.  Optimizing HTTP Discoverability With "targetHints"  . . .  28
+     8.5.  Advertising HTTP Features With "headerSchema" . . . . . .  29
+     8.6.  Creating Resources Through Collections  . . . . . . . . .  30
+     8.7.  Content Negotiation and Schema Evolution  . . . . . . . .  30
+   9.  Examples  . . . . . . . . . . . . . . . . . . . . . . . . . .  31
+     9.1.  Entry Point Links, No Templates . . . . . . . . . . . . .  31
+     9.2.  Individually Identified Resources . . . . . . . . . . . .  33
+     9.3.  Submitting a Payload and Accepting URI Input  . . . . . .  34
+     9.4.  "anchor", "base" and URI Template Resolution  . . . . . .  37
+     9.5.  Collections . . . . . . . . . . . . . . . . . . . . . . .  40
+       9.5.1.  Pagination  . . . . . . . . . . . . . . . . . . . . .  45
+       9.5.2.  Creating the First Item . . . . . . . . . . . . . . .  48
+   10. Security Considerations . . . . . . . . . . . . . . . . . . .  49
+     10.1.  Target Attributes  . . . . . . . . . . . . . . . . . . .  49
+     10.2.  "self" Links . . . . . . . . . . . . . . . . . . . . . .  50
+   11. Acknowledgments . . . . . . . . . . . . . . . . . . . . . . .  51
+   12. References  . . . . . . . . . . . . . . . . . . . . . . . . .  51
+     12.1.  Normative References . . . . . . . . . . . . . . . . . .  51
+     12.2.  Informative References . . . . . . . . . . . . . . . . .  52
+   Appendix A.  Using JSON Hyper-Schema in APIs  . . . . . . . . . .  54
+     A.1.  Resource Evolution With Hyper-Schema  . . . . . . . . . .  54
+     A.2.  Responses and Errors  . . . . . . . . . . . . . . . . . .  54
+     A.3.  Static Analysis of an API's Hyper-Schemas . . . . . . . .  55
+   Appendix B.  ChangeLog  . . . . . . . . . . . . . . . . . . . . .  55
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  58
+
+1.  Introduction
+
+   JSON Hyper-Schema is a JSON Schema vocabulary for annotating JSON
+   documents with hyperlinks and instructions for processing and
+
+
+
+
+Andrews & Wright        Expires November 26, 2019               [Page 3]
+
+Internet-Draft              JSON Hyper-Schema                   May 2019
+
+
+   manipulating remote JSON resources through hypermedia environments
+   such as HTTP.
+
+   The term JSON Hyper-Schema is used to refer to a JSON Schema that
+   uses these keywords.  The term "hyper-schema" on its own refers to a
+   JSON Hyper-Schema within the scope of this specification.
+
+   The primary mechanism introduced for specifying links is the Link
+   Description Object (LDO), which is a serialization of the abstract
+   link model defined in RFC 8288, section 2 [RFC8288].
+
+   This specification will use the concepts, syntax, and terminology
+   defined by the JSON Schema core [json-schema] and JSON Schema
+   validation [json-schema-validation] specifications.  It is advised
+   that readers have a copy of these specifications.
+
+2.  Notational Conventions
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in RFC 2119 [RFC2119].
+
+3.  Overview
+
+   JSON Hyper-Schema makes it possible to build hypermedia systems from
+   JSON documents by describing how to construct hyperlinks from
+   instance data.
+
+   The combination of a JSON instance document and a valid application/
+   schema+json hyper-schema for that instance behaves as a single
+   hypermedia representation.  By allowing this separation, hyper-
+   schema-based systems can gracefully support applications that expect
+   plain JSON, while providing full hypermedia capabilities for hyper-
+   schema-aware applications and user agents.
+
+   User agents can detect the presence of hyper-schema by looking for
+   the application/schema+json media type and a "$schema" value that
+   indicates the presence of the hyper-schema vocabulary.  A user agent
+   can then use an implementation of JSON Hyper-Schema to provide an
+   interface to the combination of the schema and instance documents as
+   a single logical representation of a resource, just as with any
+   single-document hypermedia representation format.
+
+   Hyper-schemas allow representations to take up fewer bytes on the
+   wire, and distribute the burden of link construction from the server
+   to each client.  A user agent need not construct a link unless a
+   client application requests that link.  JSON Hyper-Schema can also be
+   used on the server side to generate other link serializations or
+
+
+
+Andrews & Wright        Expires November 26, 2019               [Page 4]
+
+Internet-Draft              JSON Hyper-Schema                   May 2019
+
+
+   representation formats at runtime, or pre-emptively follow links to
+   facilitate server push usage.
+
+   Here is an example hyper-schema that adds a single link, with the
+   IANA-registered link relation type "self", that is built from an
+   instance with one known object field named "id":
+
+   {
+       "type": "object",
+       "properties": {
+           "id": {
+               "type": "number",
+               "readOnly": true
+           }
+       },
+       "links": [
+           {
+               "rel": "self",
+               "href": "thing/{id}"
+           }
+       ]
+   }
+
+   If the instance is {"id": 1234}, and its base URI according to RFC
+   3986 section 5.1 [RFC3986], is "https://example.com/api/", then
+   "https://example.com/api/thing/1234" is the resulting link's target
+   URI.
+
+3.1.  Terminology
+
+   The terms "schema", "instance", and "meta-schema" are to be
+   interpreted as defined in the JSON Schema core specification
+   [json-schema].
+
+   The terms "applicable" and "attached" are to be interpreted as
+   defined in Section 3.1 of the JSON Schema core specification
+   [json-schema].
+
+   The terms "link", "link context" (or "context"), "link target" (or
+   "target"), and "target attributes" are to be interpreted as defined
+   in Section 2 of RFC 8288 [RFC8288].
+
+   The term "user agent" is to be interpreted as defined in Section 2.1
+   of RFC 7230 [RFC7230], generalized to apply to any protocol that may
+   be used in a hypermedia system rather than specifically being an HTTP
+   client.
+
+   This specification defines the following terms:
+
+
+
+Andrews & Wright        Expires November 26, 2019               [Page 5]
+
+Internet-Draft              JSON Hyper-Schema                   May 2019
+
+
+   JSON Hyper-Schema  A JSON Schema using the keywords defined by this
+      specification.
+
+   hyper-schema  Within this document, the term "hyper-schema" always
+      refers to a JSON Hyper-Schema
+
+   link validity  A valid link for an instance is one that is applicable
+      to that instance and does not fail any requirement imposed by the
+      keywords in the Link Description Object.  Note that invalid links
+      can occur when using keywords such as "if" or "oneOf" (from the
+      Core specification) to describe links that are conditional on the
+      representation's structure or value.
+
+   generic user agent  A user agent which can be used to interact with
+      any resource, from any server, from among the standardized link
+      relations, media types, URI schemes, and protocols that it
+      supports; though it may be extendible to specially handle
+      particular profiles of media types.
+
+   client application  An application which uses a hypermedia system for
+      a specific purpose.  Such an application may also be its own user
+      agent, or it may be built on top of a generic user agent.  A
+      client application is programmed with knowledge of link relations,
+      media types, URI schemes, protocols, and data structures that are
+      specific to the application's domain.
+
+   client input  Data provided through a user agent, and most often also
+      through a client application.  Such data may be requested from a
+      user interactively, or provided before interaction in forms such
+      as command-line arguments, configuration files, or hardcoded
+      values in source code.
+
+   operation  A specific use of a hyperlink, such as making a network
+      request (for a URI with a scheme such as "http://" that indicates
+      a protocol) or otherwise taking action based on a link (reading
+      data from a "data:" URI, or constructing an email message based on
+      a "mailto:" link).  For protocols such as HTTP that support
+      multiple methods, each method is considered to be a separate
+      operation on the same link.
+
+3.2.  Functionality
+
+   A JSON Hyper-Schema implementation is able to take a hyper-schema, an
+   instance, and in some cases client input, and produce a set of fully
+   resolved valid links.  As defined by RFC 8288, section 2 [RFC8288], a
+   link consists of a context, a typed relation, a target, and
+   optionally additional target attributes.
+
+
+
+
+Andrews & Wright        Expires November 26, 2019               [Page 6]
+
+Internet-Draft              JSON Hyper-Schema                   May 2019
+
+
+   The relation type and target attributes are taken directly from each
+   link's Link Description Object.  The context and target identifiers
+   are constructed from some combination of URI Templates, instance
+   data, and (in the case of the target identifier) client input.
+
+   The target is always fully identified by a URI.  Due to the lack of a
+   URI fragment identifier syntax for application/json and many other
+   media types that can be used with JSON Hyper-Schema, the context may
+   be only partially identified by a URI.  In such cases, the remaining
+   identification will be provided as a JSON Pointer.
+
+   A few IANA-registered link relation types are given specific
+   semantics in a JSON Hyper-Schema document.  A "self" link is used to
+   interact with the resource that the instance document represents,
+   while "collection" and "item" links identify resources for which
+   collection-specific semantics can be assumed.
+
+4.  Meta-Schemas and Output Schema
+
+   The current URI for the JSON Hyper-Schema meta-schema is
+   <http://json-schema.org/draft/2019-04/hyper-schema#>.
+
+   The current URI for this vocabulary, known as the Hyper-Schema
+   vocabulary, is: <https://json-schema.org/draft/2019-04/vocab/hyper-
+   schema>.
+
+   The current URI for the corresponding meta-schema, which differs from
+   the convenience meta-schema above in that it describes only the
+   hyper-schema keywords ("base" and "link") is: <https://json-
+   schema.org/draft/2019-04/meta/hyper-schema>.
+
+   The link description format (Section 6) can be used without JSON
+   Schema, and use of this format can be declared by referencing the
+   normative link description schema as the schema for the data
+   structure that uses the links.  The URI of the normative link
+   description schema is: <http://json-schema.org/draft/2019-04/links#>.
+
+   JSON Hyper-Schema implementations are free to provide output in any
+   format.  However, a specific format is defined for use in the
+   conformance test suite, which is also used to illustrate points in
+   the "Implementation Requirements" (Section 7), and to show the output
+   generated by examples (Section 9).  It is RECOMMENDED that
+   implementations be capable of producing output in this format to
+   facilitated testing.  The URI of the JSON Schema describing the
+   recommended output format is <http://json-schema.org/draft/2019-
+   04/output/hyper-schema#>.
+
+
+
+
+
+Andrews & Wright        Expires November 26, 2019               [Page 7]
+
+Internet-Draft              JSON Hyper-Schema                   May 2019
+
+
+   Updated vocabulary and meta-schema URIs MAY be published between
+   specification drafts in order to correct errors.  Implementations
+   SHOULD consider URIs dated after this specification draft and before
+   the next to indicate the same syntax and semantics as those listed
+   here.
+
+5.  Schema Keywords
+
+   Hyper-schema keywords from all schemas that are applicable to a
+   position in an instance, as defined by Section 3.1 of JSON Schema
+   core [json-schema], can be used with that instance.
+
+   When multiple subschemas are applicable to a given sub-instance, all
+   "link" arrays MUST be combined, in any order, into a single set.
+   Each object in the resulting set MUST retain its own list of
+   applicable "base" values, in resolution order, from the same schema
+   and any parent schemas.
+
+   As with all JSON Schema keywords, all keywords described in this
+   section are optional.  The minimal valid JSON Hyper-schema is the
+   blank object.
+
+5.1.  base
+
+   If present, this keyword MUST be first resolved as a URI Template
+   (Section 7.2), and then MUST be resolved as a URI Reference against
+   the current URI base of the instance.  The result MUST be set as the
+   new URI base for the instance while processing the sub-schema
+   containing "base" and all sub-schemas within it.
+
+   The process for resolving the "base" template can be different when
+   being resolved for use with "anchor" than when being resolved for use
+   with "href", which is explained in detail in the URI Templating
+   section.
+
+5.2.  links
+
+   The "links" property of schemas is used to associate Link Description
+   Objects with instances.  The value of this property MUST be an array,
+   and the items in the array must be Link Description Objects, as
+   defined below.
+
+6.  Link Description Object
+
+   A Link Description Object (LDO) is a serialization of the abstract
+   link model defined in RFC 8288, section 2 [RFC8288].  As described in
+   that document, a link consists of a context, a relation type, a
+   target, and optionally target attributes.  JSON Hyper-Schema's LDO
+
+
+
+Andrews & Wright        Expires November 26, 2019               [Page 8]
+
+Internet-Draft              JSON Hyper-Schema                   May 2019
+
+
+   provides all of these, along with additional features using JSON
+   Schema to describe input for use with the links in various ways.
+
+   Due to the use of URI Templates to identify link contexts and
+   targets, as well as optional further use of client input when
+   identifying targets, an LDO is a link template that may resolve to
+   multiple links when used with a JSON instance document.
+
+   A specific use of an LDO, typically involving a request and response
+   across a protocol, is referred to as an operation.  For many
+   protocols, multiple operations are possible on any given link.  The
+   protocol is indicated by the target's URI scheme.  Note that not all
+   URI schemes indicate a protocol that can be used for communications,
+   and even resources with URI schemes that do indicate such protocols
+   need not be available over that protocol.
+
+   A Link Description Object MUST be an object, and the "href"
+   (Section 6.3.1) and "rel" (Section 6.2.1) properties MUST be present.
+   Each keyword is covered briefly in this section, with additional
+   usage explanation and comprehensive examples given later in the
+   document.
+
+6.1.  Link Context
+
+   In JSON Hyper-Schema, the link's context resource is, by default, the
+   sub-instance to which it is attached (as defined by Section 3.1 of
+   the JSON Schema core specification [json-schema]).  This is often not
+   the entire instance document.  This default context can be changed
+   using the keywords in this section.
+
+   Depending on the media type of the instance, it may or may not be
+   possible to assign a URI to the exact default context resource.  In
+   particular, application/json does not define a URI fragment
+   resolution syntax, so properties or array elements within a plain
+   JSON document cannot be fully identified by a URI.  When it is not
+   possible to produce a complete URI, the position of the context
+   SHOULD be conveyed by the URI of the instance document, together with
+   a separate plain-string JSON Pointer.
+
+   Implementations MUST be able to construct the link context's URI, and
+   (if necessary for full identification), a JSON Pointer in string
+   representation form as per RFC 6901, section 5 [RFC6901] in place of
+   a URI fragment.  The process for constructing a URI based on a URI
+   template is given in the URI Templating (Section 7.2) section.
+
+
+
+
+
+
+
+Andrews & Wright        Expires November 26, 2019               [Page 9]
+
+Internet-Draft              JSON Hyper-Schema                   May 2019
+
+
+6.1.1.  anchor
+
+   This property sets the context URI of the link.  The value of the
+   property is a URI Template [RFC6570], and the resulting URI-reference
+   [RFC3986] MUST be resolved against the base URI of the instance.
+
+   The URI is computed from the provided URI template using the same
+   process described for the "href" (Section 6.3.1) property, with the
+   exception that "hrefSchema" (Section 6.6.1) MUST NOT be applied.
+   Unlike target URIs, context URIs do not accept user input.
+
+6.1.2.  anchorPointer
+
+   This property changes the point within the instance that is
+   considered to be the context resource of the link.  The value of the
+   property MUST be a valid JSON Pointer in JSON String representation
+   form, or a valid Relative JSON Pointer [relative-json-pointer] which
+   is evaluated relative to the default context.
+
+   While an alternate context with a known URI is best set with the
+   "anchor" (Section 6.1.1) keyword, the lack of a fragment identifier
+   syntax for application/json means that it is usually not possible to
+   change the context within a JSON instance using a URI.
+
+   Even in "+json" media types that define JSON Pointer as a fragment
+   identifier syntax, if the default context is nested within an array,
+   it is not possible to obtain the index of the default context's
+   position in that array in order to construct a pointer to another
+   property in that same nested JSON object.  This will be demonstrated
+   in the examples.
+
+   The result of processing this keyword SHOULD be a URI fragment if the
+   media type of the instance allows for such a fragment.  Otherwise it
+   MUST be a string-encoded JSON Pointer.
+
+6.2.  Link Relation Type
+
+   The link's relation type identifies its semantics.  It is the primary
+   means of conveying how an application can interact with a resource.
+
+   Relationship definitions are not normally media type dependent, and
+   users are encouraged to utilize the most suitable existing accepted
+   relation definitions.
+
+
+
+
+
+
+
+
+Andrews & Wright        Expires November 26, 2019              [Page 10]
+
+Internet-Draft              JSON Hyper-Schema                   May 2019
+
+
+6.2.1.  rel
+
+   The value of this property MUST be either a string or an array of
+   strings.  If the value is an array, it MUST contain at least one
+   string.
+
+   Each string MUST be a single Link Relation Type as defined in RFC
+   8288, Section 2.1, including the restriction that additional
+   semantics SHOULD NOT be inferred based upon the presence or absence
+   of another link relation type.
+
+   This property is required.
+
+6.2.2.  "self" Links
+
+   A "self" link, as originally defined by Section 4.2.7.2 of RFC 4287
+   [RFC4287], indicates that the target URI identifies a resource
+   equivalent to the link context.  In JSON Hyper-Schema, a "self" link
+   MUST be resolvable from the instance, and therefore "hrefSchema" MUST
+   NOT be present.
+
+   Hyper-schema authors SHOULD use "templateRequired" to ensure that the
+   "self" link has all instance data that is needed for use.
+
+   A hyper-schema implementation MUST recognize that a link with
+   relation type "self" that has the entire current instance document as
+   its context describes how a user agent can interact with the resource
+   represented by that instance document.
+
+6.2.3.  "collection" and "item" Links
+
+   RFC 6573 [RFC6573] defines and registers the "item" and "collection"
+   link relation types.  JSON Hyper-Schema imposes additional semantics
+   on collection resources indicated by these types.
+
+   Implementations MUST recognize the target of a "collection" link and
+   the context of an "item" link as collections.
+
+   A well-known design pattern in hypermedia is to use a collection
+   resource to create a member of the collection and give it a server-
+   assigned URI.  If the protocol indicated by the URI scheme defines a
+   specific method that is suited to creating a resource with a server-
+   assigned URI, then a collection resource, as identified by these link
+   relation types, MUST NOT define semantics for that method that
+   conflict with the semantics of creating a collection member.
+   Collection resources MAY implement item creation via such a protocol
+   method, and user agents MAY assume that any such operation, if it
+   exists, has item creation semantics.
+
+
+
+Andrews & Wright        Expires November 26, 2019              [Page 11]
+
+Internet-Draft              JSON Hyper-Schema                   May 2019
+
+
+   As such a method would correspond to JSON Hyper-Schema's data
+   submission concept, the "submissionSchema" (Section 6.6.4.2) field
+   for the link SHOULD be compatible with the schema of the
+   representation of the collection's items, as indicated by the "item"
+   link's target resource or the "self" link of the "collection" link's
+   context resource.
+
+6.2.4.  Using Extension Relation Types
+
+   When no registered relation (aside from "related") applies, users are
+   encouraged to mint their own extension relation types, as described
+   in section 2.1.2 of RFC 8288 [RFC8288].  The simplest approaches for
+   choosing link relation type URIs are to either use a URI scheme that
+   is already in use to identify the system's primary resources, or to
+   use a human-readable, non-dereferenceable URI scheme such as "tag",
+   defined by RFC 4151 [RFC4151].
+
+   Extension relation type URIs need not be dereferenceable, even when
+   using a scheme that allows it.
+
+6.3.  Link Target
+
+   The target URI template is used to identify the link's target,
+   potentially making use of instance data.  Additionally, with
+   "hrefSchema" (Section 6.6.1), this template can identify a set of
+   possible target resources to use based on client input.  The full
+   process of resolving the URI template, with or without client input,
+   is covered in the URI Templating (Section 7.2) section.
+
+6.3.1.  href
+
+   The value of the "href" link description property is a template used
+   to determine the target URI of the related resource.  The value of
+   the instance property MUST be resolved as a URI-reference [RFC3986]
+   against the base URI of the instance.
+
+   This property is REQUIRED.
+
+6.4.  Adjusting URI Template Resolution
+
+   The keywords in this section are used when resolving all URI
+   Templates involved in hyper-schema: "base", "anchor", and "href".
+   See the URI Templating (Section 7.2) section for the complete
+   template resolution algorithm.
+
+   Note that when resolving a "base" template, the attachment point from
+   which resolution begins is the attachment point of the "href" or
+
+
+
+
+Andrews & Wright        Expires November 26, 2019              [Page 12]
+
+Internet-Draft              JSON Hyper-Schema                   May 2019
+
+
+   "anchor" keyword being resolved which requires "base" templates to be
+   resolved, not the attachment point of the "base" keyword itself.
+
+6.4.1.  templatePointers
+
+   The value of the "templatePointers" link description property MUST be
+   an object.  Each property value in the object MUST be a valid JSON
+   Pointer [RFC6901], or a valid Relative JSON Pointer
+   [relative-json-pointer] which is evaluated relative to the attachment
+   point of the link for which the template is being resolved.
+
+   For each property name in the object that matches a variable name in
+   the template being resolved, the value of that property adjusts the
+   starting position of variable resolution for that variable.
+   Properties which do not match template variable names in the template
+   being resolved MUST be ignored.
+
+6.4.2.  templateRequired
+
+   The value of this keyword MUST be an array, and the elements MUST be
+   unique.  Each element SHOULD match a variable in the link's URI
+   Template, without percent-encoding.  After completing the entire URI
+   Template resolution process, if any variable that is present in this
+   array does not have a value, the link MUST NOT be used.
+
+6.5.  Link Target Attributes
+
+   All properties in this section are advisory only.  While keywords
+   such as "title" and "description" are used primarily to present the
+   link to users, those keywords that predict the nature of a link
+   interaction or response MUST NOT be considered authoritative.  The
+   runtime behavior of the target resource MUST be respected whenever it
+   conflicts with the target attributes in the LDO.
+
+6.5.1.  title
+
+   This property defines a title for the link.  The value MUST be a
+   string.
+
+   User agents MAY use this title when presenting the link to the user.
+
+6.5.2.  description
+
+   This property provides additional information beyond what is present
+   in the title.  The value MUST be a string.  While a title is
+   preferably short, a description can be used to go into more detail
+   about the purpose and usage of the link.
+
+
+
+
+Andrews & Wright        Expires November 26, 2019              [Page 13]
+
+Internet-Draft              JSON Hyper-Schema                   May 2019
+
+
+   User agents MAY use this description when presenting the link to the
+   user.
+
+6.5.3.  targetMediaType
+
+   The value of this property represents the media type RFC 2046
+   [RFC2046], that is expected to be returned when fetching this
+   resource.  This property value MAY be a media range instead, using
+   the same pattern defined in RFC 7231, section 5.3.2 - HTTP "Accept"
+   header [RFC7231].
+
+   This property is analogous to the "type" property of other link
+   serialization formats.  User agents MAY use this information to
+   inform the interface they present to the user before the link is
+   followed, but MUST NOT use this information in the interpretation of
+   the resulting data.  Instead, a user agent MUST use the media type
+   given by the response for run-time interpretation.  See the section
+   on "Security Concerns" (Section 10) for a detailed examination of
+   mis-use of "targetMediaType".
+
+   For protocols supporting content-negotiation, implementations MAY
+   choose to describe possible target media types using protocol-
+   specific information in "headerSchema" (Section 6.6.2).  If both
+   protocol-specific information and "targetMediaType" are present, then
+   the value of "targetMediaType" MUST be compatible with the protocol-
+   specific information, and SHOULD indicate the media type that will be
+   returned in the absence of content negotiation.
+
+   When no such protocol-specific information is available, or when the
+   implementation does not recognize the protocol involved, then the
+   value SHOULD be taken to be "application/json".
+
+6.5.4.  targetSchema
+
+   This property provides a schema that is expected to describe the link
+   target's representation.  Depending on the protocol, the schema may
+   or may not describe the request or response to any particular
+   operation performed with the link.  See the JSON Hyper-Schema and
+   HTTP (Section 8) section for an in-depth discussion of how this
+   keyword is used with HTTP.
+
+6.5.5.  targetHints
+
+   [[CREF1: This section attempts to strike a balance between
+   comprehensiveness and flexibility by deferring most of its structure
+   to the protocol indicated by the URI scheme.  Note that a resource
+   can be identified by a URI with a dereferenceable scheme, yet not be
+   accessible over that protocol.  While currently very loose, this
+
+
+
+Andrews & Wright        Expires November 26, 2019              [Page 14]
+
+Internet-Draft              JSON Hyper-Schema                   May 2019
+
+
+   section is expected to become more well-defined based on draft
+   feedback, and may change significantly in future drafts.  ]]
+
+   The value of this property is advisory only.  It represents
+   information that is expected to be discoverable through interacting
+   with the target resource, typically in the form of protocol-specific
+   control information or meta-data such as headers returned in response
+   to an HTTP HEAD or OPTIONS request.  The protocol is determined by
+   the "href" URI scheme, although note that resources are not
+   guaranteed to be accessible over such a protocol.
+
+   The value of this property SHOULD be an object.  The keys to this
+   object SHOULD be lower-cased forms of the control data field names.
+   Each value SHOULD be an array, in order to uniformly handle multi-
+   valued fields.  Multiple values MUST be presented as an array, and
+   not as a single string.
+
+   Protocols with control information not suitable for representation as
+   a JSON object MAY be represented by another data type, such as an
+   array.
+
+   Values that cannot be understood as part of the indicated protocol
+   MUST be ignored by a JSON Hyper-Schema implementation.  Applications
+   MAY make use of such values, but MUST NOT assume interoperability
+   with other implementations.
+
+   Implementations MUST NOT assume that all discoverable information is
+   accounted for in this object.  Client applications MUST properly
+   handle run-time responses that contradict this property's values.
+
+   Client applications MUST NOT assume that an implementation will
+   automatically take any action based on the value of this property.
+
+   See "JSON Hyper-Schema and HTTP" (Section 8) for guidance on using
+   this keyword with HTTP and analogous protocols.
+
+6.6.  Link Input
+
+   There are four ways to use client input with a link, and each is
+   addressed by a separate link description object keyword.  When
+   performing operations, user agents SHOULD ignore schemas that are not
+   relevant to their semantics.
+
+6.6.1.  hrefSchema
+
+   The value of the "hrefSchema" link description property MUST be a
+   valid JSON Schema.  This schema is used to validate user input or
+
+
+
+
+Andrews & Wright        Expires November 26, 2019              [Page 15]
+
+Internet-Draft              JSON Hyper-Schema                   May 2019
+
+
+   other user agent data for filling out the URI Template in "href"
+   (Section 6.3.1).
+
+   Omitting "hrefSchema" or setting the entire schema to "false"
+   prevents any user agent data from being accepted.
+
+   Setting any subschema that applies to a particular variable to the
+   JSON literal value "false" prevents any user agent data from being
+   accepted for that single variable.
+
+   For template variables that can be resolved from the instance data,
+   if the instance data is valid against all applicable subschemas in
+   "hrefSchema", then it MUST be used to pre-populate the input data set
+   for that variable.
+
+   Note that even when data is pre-populated from the instance, the
+   validation schema for that variable in "hrefSchema" need not be
+   identical to the validation schema(s) that apply to the instance
+   data's location.  This allows for different validation rules for user
+   agent data, such as supporting spelled-out months for date-time
+   input, but using the standard date-time format for storage.
+
+   After input is accepted, potentially overriding the pre-populated
+   instance data, the resulting data set MUST successfully validate
+   against the value of "hrefSchema".  If it does not then the link MUST
+   NOT be used.  If it is valid, then the process given in the "URI
+   Templating" section continues with this updated data set.
+
+6.6.2.  headerSchema
+
+   [[CREF2: As with "targetHints", this keyword is somewhat under-
+   specified to encourage experimentation and feedback as we try to
+   balance flexibility and clarity.  ]]
+
+   If present, this property is a schema for protocol-specific request
+   headers or analogous control and meta-data.  The value of this object
+   MUST be a valid JSON Schema.  The protocol is determined by the
+   "href" URI scheme, although note that resources are not guaranteed to
+   be accessible over such a protocol.  The schema is advisory only; the
+   target resource's behavior is not constrained by its presence.
+
+   The purpose of this keyword is to advertise target resource
+   interaction features, and indicate to user agents and client
+   applications what headers and header values are likely to be useful.
+   User agents and client applications MAY use the schema to validate
+   relevant headers, but MUST NOT assume that missing headers or values
+   are forbidden from use.  While schema authors MAY set
+   "additionalProperties" to false, this is NOT RECOMMENDED and MUST NOT
+
+
+
+Andrews & Wright        Expires November 26, 2019              [Page 16]
+
+Internet-Draft              JSON Hyper-Schema                   May 2019
+
+
+   prevent client applications or user agents from supplying additional
+   headers when requests are made.
+
+   The exact mapping of the JSON data model into the headers is
+   protocol-dependent.  However, in most cases this schema SHOULD
+   specify a type of "object", and the property names SHOULD be lower-
+   cased forms of the control data field names.  As with "targetHints",
+   the values SHOULD be described as arrays to allow for multiple
+   values, even if only one value is expected.
+
+   See the "JSON Hyper-Schema and HTTP" (Section 8) section for detailed
+   guidance on using this keyword with HTTP and analogous protocols.
+
+   "headerSchema" is applicable to any request method or command that
+   the protocol supports.  When generating a request, user agents and
+   client applications SHOULD ignore schemas for headers that are not
+   relevant to that request.
+
+6.6.3.  Manipulating the Target Resource Representation
+
+   In JSON Hyper-Schema, "targetSchema" (Section 6.5.4) supplies a non-
+   authoritative description of the target resource's representation.  A
+   client application can use "targetSchema" to structure input for
+   replacing or modifying the representation, or as the base
+   representation for building a patch document based on a patch media
+   type.
+
+   Alternatively, if "targetSchema" is absent or if the client
+   application prefers to only use authoritative information, it can
+   interact with the target resource to confirm or discover its
+   representation structure.
+
+   "targetSchema" is not intended to describe link operation responses,
+   except when the response semantics indicate that it is a
+   representation of the target resource.  In all cases, the schema
+   indicated by the response itself is authoritative.  See "JSON Hyper-
+   Schema and HTTP" (Section 8) for detailed examples.
+
+6.6.4.  Submitting Data for Processing
+
+   The "submissionSchema" (Section 6.6.4.2) and "submissionMediaType"
+   (Section 6.6.4.1) keywords describe the domain of the processing
+   function implemented by the target resource.  Otherwise, as noted
+   above, the submission schema and media type are ignored for
+   operations to which they are not relevant.
+
+
+
+
+
+
+Andrews & Wright        Expires November 26, 2019              [Page 17]
+
+Internet-Draft              JSON Hyper-Schema                   May 2019
+
+
+6.6.4.1.  submissionMediaType
+
+   If present, this property indicates the media type format the client
+   application and user agent should use for the request payload
+   described by "submissionSchema" (Section 6.6.4.2).
+
+   Omitting this keyword has the same behavior as a value of
+   application/json.
+
+   Note that "submissionMediaType" and "submissionSchema" are not
+   restricted to HTTP URIs.  [[CREF3: This statement might move to
+   wherever the example ends up.]]
+
+6.6.4.2.  submissionSchema
+
+   This property contains a schema which defines the acceptable
+   structure of the document to be encoded according to the
+   "submissionMediaType" property and sent to the target resource for
+   processing.  This can be viewed as describing the domain of the
+   processing function implemented by the target resource.
+
+   This is a separate concept from the "targetSchema" (Section 6.5.4)
+   property, which describes the target information resource (including
+   for replacing the contents of the resource in a PUT request), unlike
+   "submissionSchema" which describes the user-submitted request data to
+   be evaluated by the resource.  "submissionSchema" is intended for use
+   with requests that have payloads that are not necessarily defined in
+   terms of the target representation.
+
+   Omitting "submissionSchema" has the same behavior as a value of
+   "true".
+
+7.  Implementation Requirements
+
+   At a high level, a conforming implementation will meet the following
+   requirements.  Each of these requirements is covered in more detail
+   in the individual keyword sections and keyword group overviews.
+
+   Note that the requirements around how an implementation MUST
+   recognize "self", "collection", and "item" links are thoroughly
+   covered in the link relation type (Section 6.2) section and are not
+   repeated here.
+
+   While it is not a mandatory format for implementations, the output
+   format used in the test suite summarizes what needs to be computed
+   for each link before it can be used:
+
+
+
+
+
+Andrews & Wright        Expires November 26, 2019              [Page 18]
+
+Internet-Draft              JSON Hyper-Schema                   May 2019
+
+
+   contextUri  The fully resolved URI (with scheme) of the context
+      resource.  If the context is not the entire resource and there is
+      a usable fragment identifier syntax, then the URI includes a
+      fragment.  Note that there is no such syntax for application/json.
+
+   contextPointer  The JSON Pointer for the location within the instance
+      of the context resource.  If the instance media type supports JSON
+      Pointers as fragment identifiers, this pointer will be the same as
+      the one encoded in the fragment of the "contextUri" field.
+
+   rel  The link relation type.  When multiple link relation types
+      appear in the LDO, for the purpose of producing output, they are
+      to be treated as multiple LDOs, each with a single link relation
+      type but otherwise identical.
+
+   targetUri  The fully resolved URI (with a scheme) of the target
+      resource.  If the link accepts input, this can only be produced
+      once the input has been supplied.
+
+   hrefInputTemplates  The list of partially resolved URI references for
+      a link that accepts input.  The first entry in the list is the
+      partially resolved "href".  The additional entries, if any, are
+      the partially resolved "base" values ordered from the most
+      immediate out to the root of the schema.  Template variables that
+      are pre-populated in the input are not resolved at this stage, as
+      the pre-populated value can be overridden.
+
+   hrefPrepopulatedInput  The data set that the user agent should use to
+      prepopulate any input mechanism before accepting client input.  If
+      input is to be accepted but no fields are to be pre-populated,
+      then this will be an empty object.
+
+   attachmentPointer  The JSON Pointer for the location within the
+      instance to which the link is attached.  By default, "contextUri"
+      and "attachmentPointer" are the same, but "contextUri" can be
+      changed by LDO keywords, while "attachmentPointer" cannot.
+
+   Other LDO keywords that are not involved in producing the above
+   information are included exactly as they appear when producing output
+   for the test suite.  Those fields will not be further discussed here
+   unless specifically relevant.
+
+7.1.  Link Discovery and Look-Up
+
+   Before links can be used, they must be discovered by applying the
+   hyper-schema to the instance and finding all applicable and valid
+   links.  Note that in addition to collecting valid links, any "base"
+   (Section 5.1) values necessary to resolve each LDO's URI Templates
+
+
+
+Andrews & Wright        Expires November 26, 2019              [Page 19]
+
+Internet-Draft              JSON Hyper-Schema                   May 2019
+
+
+   must also be located and associated with the LDO through whatever
+   mechanism is most useful for the implementation's URI Template
+   resolution process.
+
+   And implementation MUST support looking up links by either their
+   attachment pointer or context pointer, either by performing the look-
+   up or by providing the set of all links with both pointers determined
+   so that user agents can implement the look-up themselves.
+
+   When performing look-ups by context pointer, links that are attached
+   to elements of the same array MUST be returned in the same order as
+   the array elements to which they are attached.
+
+7.2.  URI Templating
+
+   Three hyper-schema keywords are URI Templates [RFC6570]: "base",
+   "anchor", and "href".  Each are resolved separately to URI-
+   references, and then the anchor or href URI-reference is resolved
+   against the base (which is itself resolved against earlier bases as
+   needed, each of which was first resolved from a URI Template to a
+   URI-reference).
+
+   All three keywords share the same algorithm for resolving variables
+   from instance data, which makes use of the "templatePointers" and
+   "templateRequired" keywords.  When resolving "href", both it and any
+   "base" templates needed for resolution to an absolute URI, the
+   algorithm is modified to optionally accept user input based on the
+   "hrefSchema" keyword.
+
+   For each URI Template (T), the following pseudocode describes an
+   algorithm for resolving T into a URI-reference (R).  For the purpose
+   of this algorithm:
+
+   o  "ldo.templatePointers" is an empty object if the keyword was not
+      present and "ldo.templateRequired" is likewise an empty array.
+
+   o  "attachmentPointer" is the absolute JSON Pointer for the
+      attachment location of the LDO.
+
+   o  "getApplicableSchemas()" returns an iterable set of all
+      (sub)schemas that apply to the attachment point in the instance.
+
+   This algorithm should be applied first to either "href" or "anchor",
+   and then as needed to each successive "base".  The order is
+   important, as it is not always possible to tell whether a template
+   will resolve to a full URI or a URI-reference.
+
+   In English, the high-level algorithm is:
+
+
+
+Andrews & Wright        Expires November 26, 2019              [Page 20]
+
+Internet-Draft              JSON Hyper-Schema                   May 2019
+
+
+   1.  Populate template variable data from the instance
+
+   2.  If input is desired, accept input
+
+   3.  Check that all required variables have a value
+
+   4.  Encode values into strings and fill out the template
+
+   This is the high-level algorithm as pseudocode.  "T" comes from
+   either "href" or "anchor" within the LDO, or from "base" in a
+   containing schema.  Pseudocode for each step follows.
+   "initialTemplateKeyword" indicates which of the two started the
+   process (since "base" is always resolved in order to finish resolving
+   one or the other of those keywords).
+
+
+   templateData = populateDataFromInstance(T, ldo, instance)
+
+   if initialTemplateKeyword == "href" and ldo.hrefSchema exists:
+       inputData = acceptInput(ldo, instance, templateData)
+       for varname in inputData:
+           templateData[varname] = inputData[varname]
+
+   for varname in ldo.templateRequired:
+       if not exists templateData[varname]
+           fatal("Missing required variable(s)")
+
+   templateData = stringEncode(templateData)
+   R = rfc6570ResolutionAlgorithm(T, templateData)
+
+
+7.2.1.  Populating Template Data From the Instance
+
+   This step looks at various locations in the instance for variable
+   values.  For each variable:
+
+   1.  Use "templatePointers" to find a value if the variable appears in
+       that keyword's value
+
+   2.  Otherwise, look for a property name matching the variable in the
+       instance location to which the link is attached
+
+   3.  In either case, if there is a value at the location, put it in
+       the template resolution data set
+
+
+
+
+
+
+
+Andrews & Wright        Expires November 26, 2019              [Page 21]
+
+Internet-Draft              JSON Hyper-Schema                   May 2019
+
+
+   for varname in T:
+       varname = rfc3986PercentDecode(varname)
+       if varname in ldo.templatePointers:
+           valuePointer = templatePointers[varname]
+           if valuePointer is relative:
+               valuePointer = resolveRelative(attachmentPointer,
+                                              valuePointer)
+       else
+           valuePointer = attachmentPointer + "/" + varname
+
+       value = instance.valueAt(valuePointer)
+       if value is defined:
+           templateData[varname] = value
+
+
+7.2.2.  Accepting Input for Template Data
+
+   This step is relatively complex, as there are several cases to
+   support.  Some variables will forbid input and some will allow it.
+   Some will have initial values that need to be presented in the input
+   interface, and some will not.
+
+   1.  Determine which variables can accept input
+
+   2.  Pre-populate the input data set if the template resolution data
+       set has a value
+
+   3.  Accept input (present a web form, make a callback, etc.)
+
+   4.  Validate the input data set, (not the template resolution data
+       set)
+
+   5.  Put the input in the template resolution data set, overriding any
+       existing values
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Andrews & Wright        Expires November 26, 2019              [Page 22]
+
+Internet-Draft              JSON Hyper-Schema                   May 2019
+
+
+   "InputForm" represents whatever sort of input mechanism is
+   appropriate.  This may be a literal web form, or may be a more
+   programmatic construct such as a callback function accepting specific
+   fields and data types, with the given initial values, if any.
+
+
+   form = new InputForm()
+   for varname in T:
+       useField = true
+       useInitialData = true
+       for schema in getApplicableSchemas(ldo.hrefSchema,
+                                          "/" + varname):
+           if schema is false:
+               useField = false
+               break
+
+           if varname in templateData and
+              not isValid(templateData[varname], schema)):
+               useInitialData = false
+               break
+
+       if useField:
+           if useInitialData:
+               form.addInputFieldFor(varname, ldo.hrefSchema,
+                                     templateData[varname])
+           else:
+               form.addInputFieldFor(varname, ldo.hrefSchema)
+
+   inputData = form.acceptInput()
+
+   if not isValid(inputData, hrefSchema):
+       fatal("Input invalid, link is not usable")
+
+   return inputData:
+
+
+7.2.3.  Encoding Data as Strings
+
+   This section is straightforward, converting literals to their names
+   as strings, and converting numbers to strings in the most obvious
+   manner, and percent-encoding as needed for use in the URI.
+
+
+
+
+
+
+
+
+
+
+Andrews & Wright        Expires November 26, 2019              [Page 23]
+
+Internet-Draft              JSON Hyper-Schema                   May 2019
+
+
+   for varname in templateData:
+       value = templateData[varname]
+       if value is true:
+           templateData[varname] = "true"
+       else if value is false:
+           temlateData[varname] = "false"
+       else if value is null:
+           templateData[varname] = "null"
+       else if value is a number:
+           templateData[varname] =
+               bestEffortOriginalJsonString(value)
+       else:
+           templateData[varname] = rfc3986PercentEncode(value)
+
+
+   In some software environments the original JSON representation of a
+   number will not be available (there is no way to tell the difference
+   between 1.0 and 1), so any reasonable representation should be used.
+   Schema and API authors should bear this in mind, and use other types
+   (such as string or boolean) if the exact representation is important.
+   If the number was provide as input in the form of a string, the
+   string used as input SHOULD be used.
+
+7.3.  Providing Access to LDO Keywords
+
+   For a given link, an implementation MUST make the values of all
+   target attribute keywords directly available to the user agent.
+   Implementations MAY provide additional interfaces for using this
+   information, as discussed in each keyword's section.
+
+   For a given link, an implementation MUST make the value of each input
+   schema keyword directly available to the user agent.
+
+   To encourage encapsulation of the URI Template resolution process,
+   implementations MAY omit the LDO keywords that are used only to
+   construct URIs.  However, implementations MUST provide access to the
+   link relation type.
+
+   Unrecognized keywords SHOULD be made available to the user agent, and
+   MUST otherwise be ignored.
+
+7.4.  Requests
+
+   A hyper-schema implementation SHOULD provide access to all
+   information needed to construct any valid request to the target
+   resource.
+
+
+
+
+
+Andrews & Wright        Expires November 26, 2019              [Page 24]
+
+Internet-Draft              JSON Hyper-Schema                   May 2019
+
+
+   The LDO can express all information needed to perform any operation
+   on a link.  This section explains what hyper-schema fields a user
+   agent should examine to build requests from any combination of
+   instance data and client input.  A hyper-schema implementation is not
+   itself expected to construct and send requests.
+
+   Target URI construction rules, including "hrefSchema" for accepting
+   input, are identical for all possible requests.
+
+   Requests that do not carry a body payload do not require additional
+   keyword support.
+
+   Requests that take a target representation as a payload SHOULD use
+   the "targetSchema" and "targetMediaType" keywords for input
+   description and payload validation.  If a protocol allows an
+   operation taking a payload that is based on the representation as
+   modified by a media type (such as a patch media type), then such a
+   media type SHOULD be indicated through "targetHints" in a protocol-
+   specific manner.
+
+   Requests that take a payload that is not derived from the target
+   resource's representation SHOULD use the "submissionSchema" and
+   "submissionMediaType" keywords for input description and payload
+   validation.  Protocols used in hypermedia generally only support one
+   such non-representation operation per link.
+
+   RPC systems that pipe many application operations with arbitrarily
+   different request structures through a single hypermedia protocol
+   operation are outside of the scope of a hypermedia format such as
+   JSON Hyper-Schema.
+
+7.5.  Responses
+
+   As a hypermedia format, JSON Hyper-Schema is concerned with
+   describing a resource, including describing its links in sufficient
+   detail to make all valid requests.  It is not concerned with directly
+   describing all possible responses for those requests.
+
+   As in any hypermedia system, responses are expected to be self-
+   describing.  In the context of hyper-schema, this means that each
+   response MUST link its own hyper-schema(s).  While responses that
+   consist of a representation of the target resource are expected to be
+   valid against "targetSchema" and "targetMediaType", those keywords
+   are advisory only and MUST be ignored if contradicted by the response
+   itself.
+
+   Other responses, including error responses, complex redirections, and
+   processing status representations SHOULD also link to their own
+
+
+
+Andrews & Wright        Expires November 26, 2019              [Page 25]
+
+Internet-Draft              JSON Hyper-Schema                   May 2019
+
+
+   schemas and use appropriate media types (e.g. "application/
+   problem+json" [RFC7807] for errors).  Certain errors might not link a
+   schema due to being generated by an intermediary that is not aware of
+   hyper-schema, rather than by the origin.
+
+   User agents are expected to understand protocol status codes and
+   response media types well enough to handle common situations, and
+   provide enough information to client applications to handle domain-
+   specific responses.
+
+   Statically mapping all possible responses and their schemas at design
+   time is outside of the scope of JSON Hyper-Schema, but may be within
+   the scope of other JSON Schema vocabularies which build on hyper-
+   schema (see Appendix A.3).
+
+7.6.  Streaming Parsers
+
+   The requirements around discovering links based on their context, or
+   using the context of links to identify collections, present unique
+   challenges when used with streaming parsers.  It is not possible to
+   authoritatively fulfill these requirements without processing the
+   entire schema and instance documents.
+
+   Such implementations MAY choose to return non-authoritative answers
+   based on data processed to date.  When offering this approach,
+   implementations MUST be clear on the nature of the response, and MUST
+   offer an option to block and wait until all data is processed and an
+   authoritative answer can be returned.
+
+8.  JSON Hyper-Schema and HTTP
+
+   While JSON Hyper-Schema is a hypermedia format and therefore
+   protocol-independent, it is expected that its most common use will be
+   in HTTP systems, or systems using protocols such as CoAP that are
+   explicitly analogous to HTTP.
+
+   This section provides guidance on how to use each common HTTP method
+   with a link, and how collection resources impose additional
+   constraints on HTTP POST.  Additionally, guidance is provided on
+   hinting at HTTP response header values and describing possible HTTP
+   request headers that are relevant to the given resource.
+
+   Section 13 of the JSON Schema core specification [json-schema]
+   provides guidance on linking instances in a hypermedia system to
+   their schemas.  This may be done with network-accessible schemas, or
+   may simply identify schemas which were pre-packaged within the client
+   application.  JSON Hyper-Schema intentionally does not constrain this
+
+
+
+
+Andrews & Wright        Expires November 26, 2019              [Page 26]
+
+Internet-Draft              JSON Hyper-Schema                   May 2019
+
+
+   mechanism, although it is RECOMMENDED that the techniques outlined in
+   the core specification be used to whatever extent is possible.
+
+8.1.  One Link Per Target and Relation Type
+
+   Link Description Objects do not directly indicate what operations,
+   such as HTTP methods, are supported by the target resource.  Instead,
+   operations should be inferred primarily from link relation types
+   (Section 6.2.1) and URI schemes.
+
+   This means that for each target resource and link relation type pair,
+   schema authors SHOULD only define a single LDO.  While it is possible
+   to use "allow" with "targetHints" to repeat a relation type and
+   target pair with different HTTP methods marked as allowed, this is
+   NOT RECOMMENDED and may not be well-supported by conforming
+   implementations.
+
+   All information necessary to use each HTTP method can be conveyed in
+   a single LDO as explained in this section.  The "allow" field in
+   "targetHints" is intended simply to hint at which operations are
+   supported, not to separately define each operation.
+
+   Note, however, that a resource may always decline an operation at
+   runtime, for instance due to authorization failure, or due to other
+   application state that controls the operation's availability.
+
+8.2.  "targetSchema" and HTTP
+
+   "targetSchema" describes the resource on the target end of the link,
+   while "targetMediaType" defines that resource's media type.  With
+   HTTP links, "headerSchema" can also be used to describe valid values
+   for use in an "Accept" request header, which can support multiple
+   media types or media ranges.  When both ways of indicating the target
+   media type are present, "targetMediaType" SHOULD indicate the default
+   representation media type, while the schema for "accept" in
+   "headerSchema" SHOULD include the default as well as any alternate
+   media types or media ranges that can be requested.
+
+   Since the semantics of many HTTP methods are defined in terms of the
+   target resource, "targetSchema" is used for requests and/or responses
+   for several HTTP methods.  In particular, "targetSchema" suggests
+   what a client application can expect for the response to an HTTP GET
+   or any response for which the "Content-Location" header is equal to
+   the request URI, and what a client application should send if it
+   creates or replaces the resource with an HTTP PUT request.  These
+   correlations are defined by RFC 7231, section 4.3.1 - "GET", section
+   4.3.4 "PUT", and section 3.1.4.2, "Content-Location" [RFC7231].
+
+
+
+
+Andrews & Wright        Expires November 26, 2019              [Page 27]
+
+Internet-Draft              JSON Hyper-Schema                   May 2019
+
+
+   Per RFC 5789 [RFC5789], the request structure for an HTTP PATCH is
+   determined by the combination of "targetSchema" and the request media
+   type, which is conveyed by the "Accept-Patch" header, which may be
+   included in "targetHints".  Media types that are suitable for PATCH-
+   ing define a syntax for expressing changes to a document, which can
+   be applied to the representation described by "targetSchema" to
+   determine the set of syntactically valid request payloads.  Often,
+   the simplest way to validate a PATCH request is to apply it and
+   validate the result as a normal representation.
+
+8.3.  HTTP POST and the "submission*" keywords
+
+   JSON Hyper-Schema allows for resources that process arbitrary data in
+   addition to or instead of working with the target's representation.
+   This arbitrary data is described by the "submissionSchema" and
+   "submissionMediaType" keywords.  In the case of HTTP, the POST method
+   is the only one that handles such data.  While there are certain
+   conventions around using POST with collections, the semantics of a
+   POST request are defined by the target resource, not HTTP.
+
+   In addition to the protocol-neutral "submission*" keywords (see
+   Section 9.3 for a non-HTTP example), the "Accept-Post" header can be
+   used to specify the necessary media type, and MAY be advertised via
+   the "targetHints" field.  [[CREF4: What happens if both are used?
+   Also, "submissionSchema" is a MUST to support, while "targetHints"
+   are at most a SHOULD.  But forbidding the use of "Accept-Post" in
+   "targetHints" seems incorrect.  ]]
+
+   Successful responses to POST other than a 201 or a 200 with "Content-
+   Location" set likewise have no HTTP-defined semantics.  As with all
+   HTTP responses, any representation in the response should link to its
+   own hyper-schema to indicate how it may be processed.  As noted in
+   Appendix A.2, connecting hyperlinks with all possible operation
+   responses is not within the scope of JSON Hyper-Schema.
+
+8.4.  Optimizing HTTP Discoverability With "targetHints"
+
+   [[CREF5: It would be good to also include a section with CoAP
+   examples.]]
+
+   JSON serializations of HTTP response header information SHOULD follow
+   the guidelines established by the work in progress "A JSON Encoding
+   for HTTP Header Field Values" [I-D.reschke-http-jfv].  Approaches
+   shown in that document's examples SHOULD be applied to other
+   similarly structured headers wherever possible.
+
+   Headers for all possible HTTP method responses all share
+   "headerSchema".  In particular, both headers that appear in a HEAD
+
+
+
+Andrews & Wright        Expires November 26, 2019              [Page 28]
+
+Internet-Draft              JSON Hyper-Schema                   May 2019
+
+
+   response and those that appear in an OPTIONS response can appear.  No
+   distinction is made within "headerSchema" as to which method response
+   contains which header.
+
+   It is RECOMMENDED that schema authors provide hints for the values of
+   the following types of HTTP headers whenever applicable:
+
+   o  Method allowance
+
+   o  Method-specific request media types
+
+   o  Authentication challenges
+
+   In general, headers that are likely to have different values at
+   different times SHOULD NOT be included in "targetHints".
+
+   As an example, an Allow header allowing HEAD, GET, and POST would be
+   shown as follows:
+
+
+   {
+       "targetHints": {
+           "allow": ["HEAD", "GET", "POST"]
+       }
+   }
+
+
+   Note that this is represented identically whether there is a single-
+   line Allow header with comma-separated values, multiple Allow headers
+   on separate lines, each with one value, or any combination of such
+   arrangements.  As is generally true with HTTP headers, comma-
+   separated values and multiple occurrences of the header are treated
+   the same way.
+
+8.5.  Advertising HTTP Features With "headerSchema"
+
+   Schemas SHOULD be written to describe JSON serializations that follow
+   guidelines established by the work in progress "A JSON Encoding for
+   HTTP Header Field Values" [I-D.reschke-http-jfv] Approaches shown in
+   that document's examples SHOULD be applied to other similarly
+   structured headers wherever possible.
+
+   It is RECOMMENDED that schema authors describe the available usage of
+   the following types of HTTP headers whenever applicable:
+
+   o  Content negotiation
+
+   o  Authentication and authorization
+
+
+
+Andrews & Wright        Expires November 26, 2019              [Page 29]
+
+Internet-Draft              JSON Hyper-Schema                   May 2019
+
+
+   o  Range requests
+
+   o  The "Prefer" header
+
+   Headers such as cache control and conditional request headers are
+   generally implemented by intermediaries rather than the resource, and
+   are therefore not generally useful to describe.  While the resource
+   must supply the information needed to use conditional requests, the
+   runtime handling of such headers and related responses is not
+   resource-specific.
+
+8.6.  Creating Resources Through Collections
+
+   When using HTTP, or a protocol such as CoAP that is explicitly
+   analogous to HTTP, this is done by POST-ing a representation of the
+   individual resource to be created to the collection resource.  The
+   process for recognizing collection and item resources is described in
+   Section 6.2.3.
+
+8.7.  Content Negotiation and Schema Evolution
+
+   JSON Hyper-Schema facilitates HTTP content negotiation, and allows
+   for a hybrid of the proactive and reactive strategies.  As mentioned
+   above, a hyper-schema can include a schema for HTTP headers such as
+   "Accept", "Accept-Charset", "Accept-Language", etc with the
+   "headerSchema" keyword.  A user agent or client application can use
+   information in this schema, such as an enumerated list of supported
+   languages, in lieu of making an initial request to start the reactive
+   negotiation process.
+
+   In this way, the proactive content negotiation technique of setting
+   these headers can be informed by server information about what values
+   are possible, similar to examining a list of alternatives in reactive
+   negotiation.
+
+   For media types that allow specifying a schema as a media type
+   parameter, the "Accept" values sent in a request or advertised in
+   "headerSchema" can include the URI(s) of the schema(s) to which the
+   negotiated representation is expected to conform.  One possible use
+   for schema parameters in content negotiation is if the resource has
+   conformed to several different schema versions over time.  The client
+   application can indicate what version(s) it understands in the
+   "Accept" header in this way.
+
+
+
+
+
+
+
+
+Andrews & Wright        Expires November 26, 2019              [Page 30]
+
+Internet-Draft              JSON Hyper-Schema                   May 2019
+
+
+9.  Examples
+
+   This section shows how the keywords that construct URIs and JSON
+   Pointers are used.  The results are shown in the format used by the
+   test suite.  [[CREF6: Need to post that and link it, but it should be
+   pretty self-explanatory to those of you reviewing things at this
+   stage.  ]]
+
+   Most other keywords are either straightforward ("title" and
+   "description"), apply validation to specific sorts of input,
+   requests, or responses, or have protocol-specific behavior.  Examples
+   demonstrating HTTP usage are available in an Appendix (Section 8).
+
+9.1.  Entry Point Links, No Templates
+
+   For this example, we will assume an example API with a documented
+   entry point URI of https://example.com/api, which is an empty JSON
+   object with a link to a schema.  Here, the entry point has no data of
+   its own and exists only to provide an initial set of links:
+
+
+   GET https://example.com/api HTTP/1.1
+
+   200 OK
+   Content-Type: application/json
+   Link: <https://schema.example.com/entry>; rel="describedBy"
+   {}
+
+
+   The linked hyper-schema defines the API's base URI and provides two
+   links: an "about" link to API documentation, and a "self" link
+   indicating that this is a schema for the base URI.
+
+
+   {
+       "$id": "https://schema.example.com/entry",
+       "$schema": "http://json-schema.org/draft/2019-04/hyper-schema#",
+       "base": "https://example.com/api/",
+       "links": [
+           {
+               "rel": "self",
+               "href": "../api",
+           }, {
+               "rel": "about",
+               "href": "docs"
+           }
+       ]
+   }
+
+
+
+Andrews & Wright        Expires November 26, 2019              [Page 31]
+
+Internet-Draft              JSON Hyper-Schema                   May 2019
+
+
+   These are the simplest possible links, with only a relation type and
+   an "href" with no template variables.  They resolve as follows:
+
+   The duplication of "api" in both the base and the "../api" href in
+   the "self" link is due to quirks of the RFC 3986 URI-reference
+   resolution algorithm.  In order for relative URI-references to work
+   well in general, the base URI needs to include a trailing slash.  The
+   "about" link with its "docs" href shows the common case of relative
+   references, which is used in the other examples in this document.
+
+   However, if an API uses URIs without trailing slashes for its
+   resources, there is no way to provide a relative reference that just
+   removes a trailing slash without duplicating the path component above
+   it.  Which makes the case of the entry point resource, which differs
+   from the base URI only in terms of the trailing slash, somewhat
+   awkward.
+
+   Resource URIs, of course, may have trailing slashes, but this example
+   is intended to highlight this frequently confusing special case.
+
+   [
+       {
+           "contextUri": "https://example.com/api",
+           "contextPointer": "",
+           "rel": "self",
+           "targetUri": "https://example.com/api",
+           "attachmentPointer": ""
+       },
+       {
+           "contextUri": "https://example.com/api",
+           "contextPointer": "",
+           "rel": "about",
+           "targetUri": "https://example.com/api/docs",
+           "attachmentPointer": ""
+       }
+   ]
+
+   The attachment pointer is the root pointer (the only possibility with
+   an empty object for the instance).  The context URI is the default,
+   which is the requested document.  Since application/json does not
+   allow for fragments, the context pointer is necessary to fully
+   describe the context.  Its default behavior is to be the same as the
+   attachment pointer.
+
+
+
+
+
+
+
+
+Andrews & Wright        Expires November 26, 2019              [Page 32]
+
+Internet-Draft              JSON Hyper-Schema                   May 2019
+
+
+9.2.  Individually Identified Resources
+
+   Let's add "things" to our system, starting with an individual thing:
+
+   {
+       "$id": "https://schema.example.com/thing",
+       "$schema": "http://json-schema.org/draft/2019-04/hyper-schema#",
+       "base": "https://example.com/api/",
+       "type": "object",
+       "required": ["data"],
+       "properties": {
+           "id": {"$ref": "#/$defs/id"},
+           "data": true
+       },
+       "links": [
+           {
+               "rel": "self",
+               "href": "things/{id}",
+               "templateRequired": ["id"],
+               "targetSchema": {"$ref": "#"}
+           }
+       ],
+       "$defs": {
+           "id": {
+               "type": "integer",
+               "minimum": 1,
+               "readOnly": true
+           }
+       }
+   }
+
+   Our "thing" has a server-assigned id, which is required in order to
+   construct the "self" link.  It also has a "data" field which can be
+   of any type.  The reason for the "$defs" section will be clear in the
+   next example.
+
+   Note that "id" is not required by the validation schema, but is
+   required by the self link.  This makes sense: a "thing" only has a
+   URI if it has been created, and the server has assigned an id.
+   However, you can use this schema with an instance containing only the
+   data field, which allows you to validate "thing" instances that you
+   are about to create.
+
+   Let's add a link to our entry point schema that lets you jump
+   directly to a particular thing if you can supply it's id as input.
+   To save space, only the new LDO is shown.  Unlike "self" and "about",
+   there is no IANA-registered relationship about hypothetical things,
+
+
+
+
+Andrews & Wright        Expires November 26, 2019              [Page 33]
+
+Internet-Draft              JSON Hyper-Schema                   May 2019
+
+
+   so an extension relationship is defined using the "tag:" URI scheme
+   [RFC4151]:
+
+   {
+       "rel": "tag:rel.example.com,2017:thing",
+       "href": "things/{id}",
+       "hrefSchema": {
+           "required": ["id"],
+           "properties": {
+               "id": {"$ref": "thing#/$defs/id"}
+           }
+       },
+       "targetSchema": {"$ref": "thing#"}
+   }
+
+   The "href" value here is the same, but everything else is different.
+   Recall that the instance is an empty object, so "id" cannot be
+   resolved from instance data.  Instead it is required as client input.
+   This LDO could also have used "templateRequired" but with "required"
+   in "hrefSchema" it is not strictly necessary.  Providing
+   "templateRequired" without marking "id" as required in "hrefSchema"
+   would lead to errors, as client input is the only possible source for
+   resolving this link.
+
+9.3.  Submitting a Payload and Accepting URI Input
+
+   This example covers using the "submission" fields for non-
+   representation input, as well as using them alongside of resolving
+   the URI Template with input.  Unlike HTML forms, which require either
+   constructing a URI or sending a payload, but do not allow not both at
+   once, JSON Hyper-Schema can describe both sorts of input for the same
+   operation on the same link.
+
+   The "submissionSchema" and "submissionMediaType" fields are for
+   describing payloads that are not representations of the target
+   resource.  When used with "http(s)://" URIs, they generally refer to
+   a POST request payload, as seen in the appendix on HTTP usage
+   (Section 8).
+
+   In this case, we use a "mailto:" URI, which, per RFC 6068, Section 3"
+   [RFC6068], does not provide any operation for retrieving a resource.
+   It can only be used to construct a message for sending.  Since there
+   is no concept of a retrievable, replaceable, or deletable target
+   resource, "targetSchema" and "targetMediaType" are not used.  Non-
+   representation payloads are described by "submissionSchema" and
+   "submissionMediaType".
+
+
+
+
+
+Andrews & Wright        Expires November 26, 2019              [Page 34]
+
+Internet-Draft              JSON Hyper-Schema                   May 2019
+
+
+   We use "submissionMediaType" to indicate a multipart/alternative
+   payload format, providing two representations of the same data (HTML
+   and plain text).  Since a multipart/alternative message is an ordered
+   sequence (the last part is the most preferred alternative), we model
+   the sequence as an array in "submissionSchema".  Since each part is
+   itself a document with a media type, we model each item in the array
+   as a string, using "contentMediaType" to indicate the format within
+   the string.
+
+   Note that media types such as multipart/form-data, which associate a
+   name with each part and are not ordered, should be modeled as JSON
+   objects rather than arrays.
+
+   Note that some lines are wrapped to fit this document's width
+   restrictions.
+
+   {
+       "$id": "https://schema.example.com/interesting-stuff",
+       "$schema": "http://json-schema.org/draft/2019-04/hyper-schema#",
+       "required": ["stuffWorthEmailingAbout", "email", "title"],
+       "properties": {
+           "title": {
+               "type": "string"
+           },
+           "stuffWorthEmailingAbout": {
+               "type": "string"
+           },
+           "email": {
+               "type": "string",
+               "format": "email"
+           },
+           "cc": false
+       },
+       "links": [
+           {
+               "rel": "author",
+               "href": "mailto:{email}?subject={title}{&cc}",
+               "templateRequired": ["email"],
+               "hrefSchema": {
+                   "required": ["title"],
+                   "properties": {
+                       "title": {
+                           "type": "string"
+                       },
+                       "cc": {
+                           "type": "string",
+                           "format": "email"
+                       },
+
+
+
+Andrews & Wright        Expires November 26, 2019              [Page 35]
+
+Internet-Draft              JSON Hyper-Schema                   May 2019
+
+
+                       "email": false
+                   }
+               },
+               "submissionMediaType":
+                       "multipart/alternative; boundary=ab2",
+               "submissionSchema": {
+                   "type": "array",
+                   "items": [
+                       {
+                           "type": "string",
+                           "contentMediaType":
+                                   "text/plain; charset=utf8"
+                       },
+                       {
+                           "type": "string",
+                           "contentMediaType": "text/html"
+                       }
+                   ],
+                   "minItems": 2
+               }
+           }
+       ]
+   }
+
+   For the URI parameters, each of the three demonstrates a different
+   way of resolving the input:
+
+   email:  This variable's presence in "templateRequired" means that it
+      must be resolved for the template to be used.  Since the "false"
+      schema assigned to it in "hrefSchema" excludes it from the input
+      data set, it must be resolved from the instance.
+
+   title:  The instance field matching this variable is required, and it
+      is also allowed in the input data.  So its instance value is used
+      to pre-populate the input data set before accepting client input.
+      The client application can opt to leave the instance value in
+      place.  Since this field is required in "hrefSchema", the client
+      application cannot delete it (although it could set it to an empty
+      string).
+
+   cc:  The "false" schema set for this in the main schema prevents this
+      field from having an instance value.  If it is present at all, it
+      must come from client input.  As it is not required in
+      "hrefSchema", it may not be used at all.
+
+   So, given the following instance retrieved from
+   "https://example.com/api/stuff":
+
+
+
+
+Andrews & Wright        Expires November 26, 2019              [Page 36]
+
+Internet-Draft              JSON Hyper-Schema                   May 2019
+
+
+   {
+       "title": "The Awesome Thing",
+       "stuffWorthEmailingAbout": "Lots of text here...",
+       "email": "someone@example.com"
+   }
+
+   We can partially resolve the link as follows, before asking the
+   client application for input.
+
+   {
+       "contextUri": "https://example.com/api/stuff",
+       "contextPointer": "",
+       "rel": "author",
+       "hrefInputTemplates": [
+         "mailto:someone@example.com?subject={title}{&cc}"
+       ],
+       "hrefPrepopulatedInput": {
+           "title": "The Awesome Thing"
+       },
+       "attachmentPointer": ""
+   }
+
+   Notice the "href*" keywords in place of "targetUri".  These are three
+   possible kinds of "targetUri" values covering different sorts of
+   input.  Here are examples of each:
+
+   No additional or changed input:  "mailto:someone@example.com?subject=
+      The%20Awesome%20Thing"
+
+   Change "title" to "your work":  "mailto:someone@example.com?subject=y
+      our%20work"
+
+   Change title and add a "cc" of "other@elsewhere.org":
+      "mailto:someone@example.com?subject=your%20work&cc=other@elsewhere
+      .org"
+
+9.4.  "anchor", "base" and URI Template Resolution
+
+   A link is a typed connection from a context resource to a target
+   resource.  Older link serializations support a "rev" keyword that
+   takes a link relation type as "rel" does, but reverses the semantics.
+   This has long been deprecated, so JSON Hyper-Schema does not support
+   it.  Instead, "anchor"'s ability to change the context URI can be
+   used to reverse the direction of a link.  It can also be used to
+   describe a link between two resources, neither of which is the
+   current resource.
+
+
+
+
+
+Andrews & Wright        Expires November 26, 2019              [Page 37]
+
+Internet-Draft              JSON Hyper-Schema                   May 2019
+
+
+   As an example, there is an IANA-registered "up" relation, but there
+   is no "down".  In an HTTP Link header, you could implement "down" as
+   ""rev": "up"".
+
+   First let's look at how this could be done in HTTP, showing a "self"
+   link and two semantically identical links, one with "rev": "up" and
+   the other using "anchor" with "rel": "up" (line wrapped due to
+   formatting limitations).
+
+
+   GET https://example.com/api/trees/1/nodes/123 HTTP/1.1
+
+   200 OK
+   Content-Type: application/json
+   Link: <https://example.com/api/trees/1/nodes/123>; rel="self"
+   Link: <https://example.com/api/trees/1/nodes/123>; rel="up";
+           anchor="https://example.com/api/trees/1/nodes/456"
+   Link: <https://example.com/api/trees/1/nodes/456>; rev="up"
+   {
+       "id": 123,
+       "treeId": 1,
+       "childIds": [456]
+   }
+
+
+   Note that the "rel=up" link has a target URI identical to the
+   "rel=self" link, and sets "anchor" (which identifies the link's
+   context) to the child's URI.  This sort of reversed link is easily
+   detectable by tools when a "self" link is also present.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Andrews & Wright        Expires November 26, 2019              [Page 38]
+
+Internet-Draft              JSON Hyper-Schema                   May 2019
+
+
+   The following hyper-schema, applied to the instance in the response
+   above, would produce the same "self" link and "up" link with
+   "anchor".  It also shows the use of a templated "base" URI, plus both
+   absolute and relative JSON Pointers in "templatePointers".
+
+   {
+       "$id": "https://schema.example.com/tree-node",
+       "$schema": "http://json-schema.org/draft/2019-04/hyper-schema#",
+       "base": "trees/{treeId}/",
+       "properties": {
+           "id": {"type": "integer"},
+           "treeId": {"type": "integer"},
+           "childIds": {
+               "type": "array",
+               "items": {
+                   "type": "integer",
+                   "links": [
+                       {
+                           "anchor": "nodes/{thisNodeId}",
+                           "rel": "up",
+                           "href": "nodes/{childId}",
+                           "templatePointers": {
+                               "thisNodeId": "/id",
+                               "childId": "0"
+                           }
+                       }
+                   ]
+               }
+           }
+       },
+       "links": [
+           {
+               "rel": "self",
+               "href": "nodes/{id}"
+           }
+       ]
+   }
+
+   The "base" template is evaluated identically for both the target
+   ("href") and context ("anchor") URIs.
+
+   Note the two different sorts of templatePointers used.  "thisNodeId"
+   is mapped to an absolute JSON Pointer, "/id", while "childId" is
+   mapped to a relative pointer, "0", which indicates the value of the
+   current item.  Absolute JSON Pointers do not support any kind of
+   wildcarding, so there is no way to specify a concept like "current
+   item" without a relative JSON Pointer.
+
+
+
+
+Andrews & Wright        Expires November 26, 2019              [Page 39]
+
+Internet-Draft              JSON Hyper-Schema                   May 2019
+
+
+9.5.  Collections
+
+   In many systems, individual resources are grouped into collections.
+   Those collections also often provide a way to create individual item
+   resources with server-assigned identifiers.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Andrews & Wright        Expires November 26, 2019              [Page 40]
+
+Internet-Draft              JSON Hyper-Schema                   May 2019
+
+
+   For this example, we will re-use the individual thing schema as shown
+   in an earlier section.  It is repeated here for convenience, with an
+   added "collection" link with a "targetSchema" reference pointing to
+   the collection schema we will introduce next.
+
+   {
+       "$id": "https://schema.example.com/thing",
+       "$schema": "http://json-schema.org/draft/2019-04/hyper-schema#",
+       "base": "https://example.com/api/",
+       "type": "object",
+       "required": ["data"],
+       "properties": {
+           "id": {"$ref": "#/$defs/id"},
+           "data": true
+       },
+       "links": [
+           {
+               "rel": "self",
+               "href": "things/{id}",
+               "templateRequired": ["id"],
+               "targetSchema": {"$ref": "#"}
+           }, {
+               "rel": "collection",
+               "href": "/things",
+               "targetSchema": {"$ref": "thing-collection#"},
+               "submissionSchema": {"$ref": "#"}
+           }
+       ],
+       "$defs": {
+           "id": {
+               "type": "integer",
+               "minimum": 1,
+               "readOnly": true
+           }
+       }
+   }
+
+   The "collection" link is the same for all items, so there are no URI
+   Template variables.  The "submissionSchema" is that of the item
+   itself.  As described in Section 6.2.3, if a "collection" link
+   supports a submission mechanism (POST in HTTP) then it MUST implement
+   item creation semantics.  Therefore "submissionSchema" is the schema
+   for creating a "thing" via this link.
+
+
+
+
+
+
+
+
+Andrews & Wright        Expires November 26, 2019              [Page 41]
+
+Internet-Draft              JSON Hyper-Schema                   May 2019
+
+
+   Now we want to describe collections of "thing"s.  This schema
+   describes a collection where each item representation is identical to
+   the individual "thing" representation.  While many collection
+   representations only include subset of the item representations, this
+   example uses the entirety to minimize the number of schemas involved.
+   The actual collection items appear as an array within an object, as
+   we will add more fields to the object in the next example.
+
+   {
+       "$id": "https://schema.example.com/thing-collection",
+       "$schema": "http://json-schema.org/draft/2019-04/hyper-schema#",
+       "base": "https://example.com/api/",
+       "type": "object",
+       "required": ["elements"],
+       "properties": {
+           "elements": {
+               "type": "array",
+               "items": {
+                   "allOf": [{"$ref": "thing#"}],
+                   "links": [
+                       {
+                           "anchorPointer": "",
+                           "rel": "item",
+                           "href": "things/{id}",
+                           "templateRequired": ["id"],
+                           "targetSchema": {"$ref": "thing#"}
+                       }
+                   ]
+               }
+           }
+       },
+       "links": [
+           {
+               "rel": "self",
+               "href": "things",
+               "targetSchema": {"$ref": "#"},
+               "submissionSchema": {"$ref": "thing"}
+           }
+       ]
+   }
+
+
+
+
+
+
+
+
+
+
+
+Andrews & Wright        Expires November 26, 2019              [Page 42]
+
+Internet-Draft              JSON Hyper-Schema                   May 2019
+
+
+   Here is a simple two-element collection instance:
+
+   {
+       "elements": [
+           {"id": 12345, "data": {}},
+           {"id": 67890, "data": {}}
+       ]
+   }
+
+   Here are all of the links that apply to this instance, including
+   those that are defined in the referenced individual "thing" schema:
+
+   [
+       {
+           "contextUri": "https://example.com/api/things",
+           "contextPointer": "",
+           "rel": "self",
+           "targetUri": "https://example.com/api/things",
+           "attachmentPointer": ""
+       },
+       {
+           "contextUri": "https://example.com/api/things",
+           "contextPointer": "/elements/0",
+           "rel": "self",
+           "targetUri": "https://example.com/api/things/12345",
+           "attachmentPointer": "/elements/0"
+       },
+       {
+           "contextUri": "https://example.com/api/things",
+           "contextPointer": "/elements/1",
+           "rel": "self",
+           "targetUri": "https://example.com/api/things/67890",
+           "attachmentPointer": "/elements/1"
+       },
+       {
+           "contextUri": "https://example.com/api/things",
+           "contextPointer": "",
+           "rel": "item",
+           "targetUri": "https://example.com/api/things/12345",
+           "attachmentPointer": "/elements/0"
+       },
+       {
+           "contextUri": "https://example.com/api/things",
+           "contextPointer": "",
+           "rel": "item",
+           "targetUri": "https://example.com/api/things/67890",
+           "attachmentPointer": "/elements/1"
+       },
+
+
+
+Andrews & Wright        Expires November 26, 2019              [Page 43]
+
+Internet-Draft              JSON Hyper-Schema                   May 2019
+
+
+       {
+           "contextUri": "https://example.com/api/things",
+           "contextPointer": "/elements/0",
+           "rel": "collection",
+           "targetUri": "https://example.com/api/things",
+           "attachmentPointer": "/elements/0"
+       },
+       {
+           "contextUri": "https://example.com/api/things",
+           "contextPointer": "/elements/1",
+           "rel": "collection",
+           "targetUri": "https://example.com/api/things",
+           "attachmentPointer": "/elements/1"
+       }
+   ]
+
+
+   In all cases, the context URI is shown for an instance of media type
+   application/json, which does not support fragments.  If the instance
+   media type was application/instance+json, which supports JSON Pointer
+   fragments, then the context URIs would contain fragments identical to
+   the context pointer field.  For application/json and other media
+   types without fragments, it is critically important to consider the
+   context pointer as well as the context URI.
+
+   There are three "self" links, one for the collection, and one for
+   each item in the "elements" array.  The item "self" links are defined
+   in the individual "thing" schema which is referenced with "$ref".
+   The three links can be distinguished by their context or attachment
+   pointers.  We will revisit the "submissionSchema" of the collection's
+   "self" link in Section 9.5.2.
+
+   There are two "item" links, one for each item in the "elements"
+   array.  Unlike the "self" links, these are defined only in the
+   collection schema.  Each of them have the same target URI as the
+   corresponding "self" link that shares the same attachment pointer.
+   However, each has a different context pointer.  The context of the
+   "self" link is the entry in "elements", while the context of the
+   "item" link is always the entire collection regardless of the
+   specific item.
+
+   Finally, there are two "collection" links, one for each item in
+   "elements".  In the individual item schema, these produce links with
+   the item resource as the context.  When referenced from the
+   collection schema, the context is the location in the "elements"
+   array of the relevant "thing", rather than that "thing"'s own
+   separate resource URI.
+
+
+
+
+Andrews & Wright        Expires November 26, 2019              [Page 44]
+
+Internet-Draft              JSON Hyper-Schema                   May 2019
+
+
+   The collection links have identical target URIs as there is only one
+   relevant collection URI.  While calculating both links as part of a
+   full set of constructed links may not seem useful, when constructing
+   links on an as-needed basis, this arrangement means that there is a
+   "collection" link definition close at hand no matter which "elements"
+   entry you are processing.
+
+9.5.1.  Pagination
+
+   Here we add pagination to our collection.  There is a "meta" section
+   to hold the information about current, next, and previous pages.
+   Most of the schema is the same as in the previous section and has
+   been omitted.  Only new fields and new or (in the case of the main
+   "self" link) changed links are shown in full.
+
+   {
+       "properties": {
+           "elements": {
+               ...
+           },
+           "meta": {
+               "type": "object",
+               "properties": {
+                   "prev": {"$ref": "#/$defs/pagination"},
+                   "current": {"$ref": "#/$defs/pagination"},
+                   "next": {"$ref": "#/$defs/pagination"}
+               }
+           }
+       },
+       "links": [
+           {
+               "rel": "self",
+               "href": "things{?offset,limit}",
+               "templateRequired": ["offset", "limit"],
+               "templatePointers": {
+                   "offset": "/meta/current/offset",
+                   "limit": "/meta/current/limit"
+               },
+               "targetSchema": {"$ref": "#"}
+           }, {
+               "rel": "prev",
+               "href": "things{?offset,limit}",
+               "templateRequired": ["offset", "limit"],
+               "templatePointers": {
+                   "offset": "/meta/prev/offset",
+                   "limit": "/meta/prev/limit"
+               },
+               "targetSchema": {"$ref": "#"}
+
+
+
+Andrews & Wright        Expires November 26, 2019              [Page 45]
+
+Internet-Draft              JSON Hyper-Schema                   May 2019
+
+
+           }, {
+               "rel": "next",
+               "href": "things{?offset,limit}",
+               "templateRequired": ["offset", "limit"],
+               "templatePointers": {
+                   "offset": "/meta/next/offset",
+                   "limit": "/meta/next/limit"
+               },
+               "targetSchema": {"$ref": "#"}
+           }
+       ],
+       "$defs": {
+           "pagination": {
+               "type": "object",
+               "properties": {
+                   "offset": {
+                       "type": "integer",
+                       "minimum": 0,
+                       "default": 0
+                   },
+                   "limit": {
+                       "type": "integer",
+                       "minimum": 1,
+                       "maximum": 100,
+                       "default": 10
+                   }
+               }
+           }
+       }
+   }
+
+   Notice that the "self" link includes the pagination query that
+   produced the exact representation, rather than being a generic link
+   to the collection allowing selecting the page via input.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Andrews & Wright        Expires November 26, 2019              [Page 46]
+
+Internet-Draft              JSON Hyper-Schema                   May 2019
+
+
+   Given this instance:
+
+   {
+       "elements": [
+           {"id": 12345, "data": {}},
+           {"id": 67890, "data": {}}
+       ],
+       "meta": {
+           "current": {
+               "offset": 0,
+               "limit": 2
+           },
+           "next": {
+               "offset": 3,
+               "limit": 2
+           }
+       }
+   }
+
+   Here are all of the links that apply to this instance that either did
+   not appear in the previous example or have been changed with
+   pagination added.
+
+   [
+       {
+           "contextUri": "https://example.com/api/things",
+           "contextPointer": "",
+           "rel": "self",
+           "targetUri":
+               "https://example.com/api/things?offset=0&limit=2",
+           "attachmentPointer": ""
+       },
+       {
+           "contextUri": "https://example.com/api/things",
+           "contextPointer": "",
+           "rel": "next",
+           "targetUri":
+               "https://example.com/api/things?offset=3&limit=2",
+           "attachmentPointer": ""
+       }
+   ]
+
+   Note that there is no "prev" link in the output, as we are looking at
+   the first page.  The lack of a "prev" field under "meta", together
+   with the "prev" link's "templateRequired" values, means that the link
+   is not usable with this particular instance.
+
+
+
+
+
+Andrews & Wright        Expires November 26, 2019              [Page 47]
+
+Internet-Draft              JSON Hyper-Schema                   May 2019
+
+
+   [[CREF7: It's not clear how pagination should work with the link from
+   the "collection" links in the individual "thing" schema.
+   Technically, a link from an item to a paginated or filtered
+   collection should go to a page/filter that contains the item (in this
+   case the "thing") that is the link context.  See GitHub issue #421
+   for more discussion.  ]]
+
+   Let's add a link for this collection to the entry point schema
+   (Section 9.1), including pagination input in order to allow client
+   applications to jump directly to a specific page.  Recall that the
+   entry point schema consists only of links, therefore we only show the
+   newly added link:
+
+   {
+       "rel": "tag:rel.example.com,2017:thing-collection",
+       "href": "/things{?offset,limit}",
+       "hrefSchema": {
+           "$ref": "thing-collection#/$defs/pagination"
+       },
+       "submissionSchema": {
+           "$ref": "thing#"
+       },
+       "targetSchema": {
+           "$ref": "thing-collection#"
+       }
+   }
+
+   Now we see the pagination parameters being accepted as input, so we
+   can jump to any page within the collection.  The link relation type
+   is a custom one as the generic "collection" link can only be used
+   with an item as its context, not an entry point or other resource.
+
+9.5.2.  Creating the First Item
+
+   When we do not have any "thing"s, we do not have any resources with a
+   relevant "collection" link.  Therefore we cannot use a "collection"
+   link's submission keywords to create the first "thing"; hyper-schemas
+   must be evaluated with respect to an instance.  Since the "elements"
+   array in the collection instance would be empty, it cannot provide us
+   with a collection link either.
+
+   However, our entry point link can take us to the empty collection,
+   and we can use the presence of "item" links in the hyper-schema to
+   recognize that it is a collection.  Since the context of the "item"
+   link is the collection, we simply look for a "self" link with the
+   same context, which we can then treat as collection for the purposes
+   of a creation operation.
+
+
+
+
+Andrews & Wright        Expires November 26, 2019              [Page 48]
+
+Internet-Draft              JSON Hyper-Schema                   May 2019
+
+
+   Presumably, our custom link relation type in the entry point schema
+   was sufficient to ensure that we have found the right collection.  A
+   client application that recognizes that custom link relation type may
+   know that it can immediately assume that the target is a collection,
+   but a generic user agent cannot do so.  Despite the presence of a
+   "-collection" suffix in our example, a generic user agent would have
+   no way of knowing whether that substring indicates a hypermedia
+   resource collection, or some other sort of collection.
+
+   Once we have recognized the "self" link as being for the correct
+   collection, we can use its "submissionSchema" and/or
+   "submissionMediaType" keywords to perform an item creation operation.
+   [[CREF8: This works perfectly if the collection is unfiltered and
+   unpaginated.  However, one should generally POST to a collection that
+   will contain the created resource, and a "self" link MUST include any
+   filters, pagination, or other query parameters.  Is it still valid to
+   POST to such a "self" link even if the resulting item would not match
+   the filter or appear within that page?  See GitHub issue #421 for
+   further discussion.  ]] [[CREF9: Draft-04 of Hyper-Schema defined a
+   "create" link relation that had the schema, rather than the instance,
+   as its context.  This did not fit into the instance-based link model,
+   and incorrectly used an operation name for a link relation type.
+   However, defining a more correctly designed link from the schema to
+   the collection instance may be one possible approach to solving this.
+   Again, see GitHub issue #421 for more details.  ]]
+
+10.  Security Considerations
+
+   JSON Hyper-Schema defines a vocabulary for JSON Schema core and
+   concerns all the security considerations listed there.  As a link
+   serialization format, the security considerations of RFC 8288 Web
+   Linking [RFC8288] also apply, with appropriate adjustments (e.g.
+   "anchor" as an LDO keyword rather than an HTTP Link header
+   attribute).
+
+10.1.  Target Attributes
+
+   As stated in Section 6.5, all LDO keywords describing the target
+   resource are advisory and MUST NOT be used in place of the
+   authoritative information supplied by the target resource in response
+   to an operation.  Target resource responses SHOULD indicate their own
+   hyper-schema, which is authoritative.
+
+   If the hyper-schema in the target response matches (by "$id") the
+   hyper-schema in which the current LDO was found, then the target
+   attributes MAY be considered authoritative.  [[CREF10: Need to add
+   something about the risks of spoofing by "$id", but given that other
+
+
+
+
+Andrews & Wright        Expires November 26, 2019              [Page 49]
+
+Internet-Draft              JSON Hyper-Schema                   May 2019
+
+
+   parts of the specification discourage always re-downloading the
+   linked schema, the risk mitigation options are unclear.  ]]
+
+   User agents or client applications MUST NOT use the value of
+   "targetSchema" to aid in the interpretation of the data received in
+   response to following the link, as this leaves "safe" data open to
+   re-interpretation.
+
+   When choosing how to interpret data, the type information provided by
+   the server (or inferred from the filename, or any other usual method)
+   MUST be the only consideration, and the "targetMediaType" property of
+   the link MUST NOT be used.  User agents MAY use this information to
+   determine how they represent the link or where to display it (for
+   example hover-text, opening in a new tab).  If user agents decide to
+   pass the link to an external program, they SHOULD first verify that
+   the data is of a type that would normally be passed to that external
+   program.
+
+   This is to guard against re-interpretation of "safe" data, similar to
+   the precautions for "targetSchema".
+
+   Protocol meta-data values conveyed in "targetHints" MUST NOT be
+   considered authoritative.  Any security considerations defined by the
+   protocol that may apply based on incorrect assumptions about meta-
+   data values apply.
+
+   Even when no protocol security considerations are directly
+   applicable, implementations MUST be prepared to handle responses that
+   do not match the link's "targetHints" values.
+
+10.2.  "self" Links
+
+   When link relation of "self" is used to denote a full representation
+   of an object, the user agent SHOULD NOT consider the representation
+   to be the authoritative representation of the resource denoted by the
+   target URI if the target URI is not equivalent to or a sub-path of
+   the URI used to request the resource representation which contains
+   the target URI with the "self" link.  [[CREF11: It is no longer
+   entirely clear what was intended by the "sub-path" option in this
+   paragraph.  It may have been intended to allow "self" links for
+   embedded item representations in a collection, which usually have
+   target URIs that are sub-paths of that collection's URI, to be
+   considered authoritative.  However, this is simply a common design
+   convention and does not appear to be based in RFC 3986 or any other
+   guidance on URI usage.  See GitHub issue #485 for further discussion.
+   ]]
+
+
+
+
+
+Andrews & Wright        Expires November 26, 2019              [Page 50]
+
+Internet-Draft              JSON Hyper-Schema                   May 2019
+
+
+11.  Acknowledgments
+
+   Thanks to Gary Court, Francis Galiegue, Kris Zyp, and Geraint Luff
+   for their work on the initial drafts of JSON Schema.
+
+   Thanks to Jason Desrosiers, Daniel Perrett, Erik Wilde, Ben Hutton,
+   Evgeny Poberezkin, Brad Bowman, Gowry Sankar, Donald Pipowitch, Dave
+   Finlay, and Denis Laxalde for their submissions and patches to the
+   document.
+
+12.  References
+
+12.1.  Normative References
+
+   [json-schema]
+              Wright, A. and H. Andrews, "JSON Schema: A Media Type for
+              Describing JSON Documents", draft-handrews-json-schema-02
+              (work in progress), November 2017.
+
+   [json-schema-validation]
+              Wright, A., Andrews, H., and G. Luff, "JSON Schema
+              Validation: A Vocabulary for Structural Validation of
+              JSON", draft-handrews-json-schema-validation-02 (work in
+              progress), November 2017.
+
+   [relative-json-pointer]
+              Luff, G. and H. Andrews, "Relative JSON Pointers", draft-
+              handrews-relative-json-pointer-02 (work in progress),
+              January 2018.
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119,
+              DOI 10.17487/RFC2119, March 1997,
+              <https://www.rfc-editor.org/info/rfc2119>.
+
+   [RFC3986]  Berners-Lee, T., Fielding, R., and L. Masinter, "Uniform
+              Resource Identifier (URI): Generic Syntax", STD 66,
+              RFC 3986, DOI 10.17487/RFC3986, January 2005,
+              <https://www.rfc-editor.org/info/rfc3986>.
+
+   [RFC4287]  Nottingham, M., Ed. and R. Sayre, Ed., "The Atom
+              Syndication Format", RFC 4287, DOI 10.17487/RFC4287,
+              December 2005, <https://www.rfc-editor.org/info/rfc4287>.
+
+   [RFC6570]  Gregorio, J., Fielding, R., Hadley, M., Nottingham, M.,
+              and D. Orchard, "URI Template", RFC 6570,
+              DOI 10.17487/RFC6570, March 2012,
+              <https://www.rfc-editor.org/info/rfc6570>.
+
+
+
+Andrews & Wright        Expires November 26, 2019              [Page 51]
+
+Internet-Draft              JSON Hyper-Schema                   May 2019
+
+
+   [RFC6573]  Amundsen, M., "The Item and Collection Link Relations",
+              RFC 6573, DOI 10.17487/RFC6573, April 2012,
+              <https://www.rfc-editor.org/info/rfc6573>.
+
+   [RFC6901]  Bryan, P., Ed., Zyp, K., and M. Nottingham, Ed.,
+              "JavaScript Object Notation (JSON) Pointer", RFC 6901,
+              DOI 10.17487/RFC6901, April 2013,
+              <https://www.rfc-editor.org/info/rfc6901>.
+
+   [RFC8288]  Nottingham, M., "Web Linking", RFC 8288,
+              DOI 10.17487/RFC8288, October 2017,
+              <https://www.rfc-editor.org/info/rfc8288>.
+
+12.2.  Informative References
+
+   [I-D.reschke-http-jfv]
+              Reschke, J., "A JSON Encoding for HTTP Header Field
+              Values", draft-reschke-http-jfv-06 (work in progress),
+              June 2017.
+
+   [RFC2046]  Freed, N. and N. Borenstein, "Multipurpose Internet Mail
+              Extensions (MIME) Part Two: Media Types", RFC 2046,
+              DOI 10.17487/RFC2046, November 1996,
+              <https://www.rfc-editor.org/info/rfc2046>.
+
+   [RFC4151]  Kindberg, T. and S. Hawke, "The 'tag' URI Scheme",
+              RFC 4151, DOI 10.17487/RFC4151, October 2005,
+              <https://www.rfc-editor.org/info/rfc4151>.
+
+   [RFC5789]  Dusseault, L. and J. Snell, "PATCH Method for HTTP",
+              RFC 5789, DOI 10.17487/RFC5789, March 2010,
+              <https://www.rfc-editor.org/info/rfc5789>.
+
+   [RFC6068]  Duerst, M., Masinter, L., and J. Zawinski, "The 'mailto'
+              URI Scheme", RFC 6068, DOI 10.17487/RFC6068, October 2010,
+              <https://www.rfc-editor.org/info/rfc6068>.
+
+   [RFC7230]  Fielding, R., Ed. and J. Reschke, Ed., "Hypertext Transfer
+              Protocol (HTTP/1.1): Message Syntax and Routing",
+              RFC 7230, DOI 10.17487/RFC7230, June 2014,
+              <https://www.rfc-editor.org/info/rfc7230>.
+
+   [RFC7231]  Fielding, R., Ed. and J. Reschke, Ed., "Hypertext Transfer
+              Protocol (HTTP/1.1): Semantics and Content", RFC 7231,
+              DOI 10.17487/RFC7231, June 2014,
+              <https://www.rfc-editor.org/info/rfc7231>.
+
+
+
+
+
+Andrews & Wright        Expires November 26, 2019              [Page 52]
+
+Internet-Draft              JSON Hyper-Schema                   May 2019
+
+
+   [RFC7807]  Nottingham, M. and E. Wilde, "Problem Details for HTTP
+              APIs", RFC 7807, DOI 10.17487/RFC7807, March 2016,
+              <https://www.rfc-editor.org/info/rfc7807>.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Andrews & Wright        Expires November 26, 2019              [Page 53]
+
+Internet-Draft              JSON Hyper-Schema                   May 2019
+
+
+Appendix A.  Using JSON Hyper-Schema in APIs
+
+   Hypermedia APIs, which follow the constraints of the REST
+   architectural style, enable the creation of generic user agents.
+   Such a user agent has no application-specific knowledge.  Rather, it
+   understands pre-defined media types, URI schemes, protocols, and link
+   relations, often by recognizing these and coordinating the use of
+   existing software that implements support for them.  Client
+   applications can then be built on top of such a user agent, focusing
+   on their own semantics and logic rather than the mechanics of the
+   interactions.
+
+   Hyper-schema is only concerned with one resource and set of
+   associated links at a time.  Just as a web browser works with only
+   one HTML page at a time, with no concept of whether or how that page
+   functions as part of a "site", a hyper-schema-aware user agent works
+   with one resource at a time, without any concept of whether or how
+   that resource fits into an API.
+
+   Therefore, hyper-schema is suitable for use within an API, but is not
+   suitable for the description of APIs as complete entities in their
+   own right.  There is no way to describe concepts at the API scope,
+   rather than the resource and link scope, and such descriptions are
+   outside of the boundaries of JSON Hyper-Schema.
+
+A.1.  Resource Evolution With Hyper-Schema
+
+   Since a given JSON Hyper-Schema is used with a single resource at a
+   single point in time, it has no inherent notion of versioning.
+   However, a given resource can change which schema or schemas it uses
+   over time, and the URIs of these schemas can be used to indicate
+   versioning information.  When used with a media type that supports
+   indicating a schema with a media type parameter, these versioned
+   schema URIs can be used in content negotiation.
+
+   A resource can indicate that it is an instance of multiple schemas,
+   which allows supporting multiple compatible versions simultaneously.
+   A client application can then make use of the hyper-schema that it
+   recognizes, and ignore newer or older versions.
+
+A.2.  Responses and Errors
+
+   Because a hyper-schema represents a single resource at a time, it
+   does not provide for an enumeration of all possible responses to
+   protocol operations performed with links.  Each response, including
+   errors, is considered its own (possibly anonymous) resource, and
+   should identify its own hyper-schema, and optionally use an
+   appropriate media type such as RFC 7807's "application/problem+json"
+
+
+
+Andrews & Wright        Expires November 26, 2019              [Page 54]
+
+Internet-Draft              JSON Hyper-Schema                   May 2019
+
+
+   [RFC7807], to allow the user agent or client application to interpret
+   any information that is provided beyond the protocol's own status
+   reporting.
+
+A.3.  Static Analysis of an API's Hyper-Schemas
+
+   It is possible to statically analyze a set of hyper-schemas without
+   instance data in order to generate output such as documentation or
+   code.  However, the full feature set of both validation and hyper-
+   schema cannot be accessed without runtime instance data.
+
+   This is an intentional design choice to provide the maximum runtime
+   flexibility for hypermedia systems.  JSON Schema as a media type
+   allows for establishing additional vocabularies for static analysis
+   and content generation, which are not addressed in this
+   specification.  Additionally, individual systems may restrict their
+   usage to subsets that can be analyzed statically if full design-time
+   description is a goal.  [[CREF12: Vocabularies for API documentation
+   and other purposes have been proposed, and contributions are welcome
+   at https://github.com/json-schema-org/json-schema-vocabularies ]]
+
+Appendix B.  ChangeLog
+
+   [[CREF13: This section to be removed before leaving Internet-Draft
+   status.]]
+
+   draft-handrews-json-schema-hyperschema-02
+
+      *  Allow multiple values for "rel"
+
+      *  Clarify that "headerSchema", like "targetHints", should use
+         array values
+
+      *  Clarified link behavior with conditional applicator keywords
+         such as "if"
+
+      *  Added and clarified various examples
+
+      *  Avoid accidentally implying that only POST can be used to
+         create in HTTP
+
+   draft-handrews-json-schema-hyperschema-01
+
+      *  This draft is purely a bug fix with no functional changes
+
+      *  Fixed erroneous meta-schema URI (draft-07, not draft-07-wip)
+
+
+
+
+
+Andrews & Wright        Expires November 26, 2019              [Page 55]
+
+Internet-Draft              JSON Hyper-Schema                   May 2019
+
+
+      *  Removed stray "work in progress" language left over from review
+         period
+
+      *  Fixed missing trailing "/" in various "base" examples
+
+      *  Fixed incorrect draft name in changelog (luff-*-00, not -01)
+
+      *  Update relative pointer ref to handrews-*-01, also purely a bug
+         fix
+
+   draft-handrews-json-schema-hyperschema-00
+
+      *  Top to bottom reorganization and rewrite
+
+      *  Group keywords per RFC 8288 context/relation/target/target
+         attributes
+
+      *  Additional keyword groups for template resolution and
+         describing input
+
+      *  Clarify implementation requirements with a suggested output
+         format
+
+      *  Expanded overview to provide context
+
+      *  Consolidated examples into their own section, illustrate real-
+         world patterns
+
+      *  Consolidated HTTP guidance in its own section
+
+      *  Added a subsection on static analysis of hyper-schemas
+
+      *  Consolidated security concerns in their own section
+
+      *  Added an appendix on usage in APIs
+
+      *  Moved "readOnly" to the validation specification
+
+      *  Moved "media" to validation as
+         "contentMediaType"/"contentEncoding"
+
+      *  Renamed "submissionEncType" to "submissionMediaType"
+
+      *  Renamed "mediaType" to "targetMediaType"
+
+      *  Added "anchor" and "anchorPointer"
+
+      *  Added "templatePointers" and "templateRequired"
+
+
+
+Andrews & Wright        Expires November 26, 2019              [Page 56]
+
+Internet-Draft              JSON Hyper-Schema                   May 2019
+
+
+      *  Clarified how "hrefSchema" is used
+
+      *  Added "targetHints" and "headerSchema"
+
+      *  Added guidance on "self", "collection" and "item" link usage
+
+      *  Added "description" as an LDO keyword
+
+      *  Added "$comment" in LDOs to match the schema keyword
+
+   draft-wright-json-schema-hyperschema-01
+
+      *  Fixed examples
+
+      *  Added "hrefSchema" for user input to "href" URI Templates
+
+      *  Removed URI Template pre-processing
+
+      *  Clarified how links and data submission work
+
+      *  Clarified how validation keywords apply hyper-schema keywords
+         and links
+
+      *  Clarified HTTP use with "targetSchema"
+
+      *  Renamed "schema" to "submissionSchema"
+
+      *  Renamed "encType" to "submissionEncType"
+
+      *  Removed "method"
+
+   draft-wright-json-schema-hyperschema-00
+
+      *  "rel" is now optional
+
+      *  rel="self" no longer changes URI base
+
+      *  Added "base" keyword to change instance URI base
+
+      *  Removed "root" link relation
+
+      *  Removed "create" link relation
+
+      *  Removed "full" link relation
+
+      *  Removed "instances" link relation
+
+      *  Removed special behavior for "describedBy" link relation
+
+
+
+Andrews & Wright        Expires November 26, 2019              [Page 57]
+
+Internet-Draft              JSON Hyper-Schema                   May 2019
+
+
+      *  Removed "pathStart" keyword
+
+      *  Removed "fragmentResolution" keyword
+
+      *  Updated references to JSON Pointer, HTML
+
+      *  Changed behavior of "method" property to align with hypermedia
+         best current practices
+
+   draft-luff-json-hyper-schema-00
+
+      *  Split from main specification.
+
+Authors' Addresses
+
+   Henry Andrews (editor)
+   Riverbed Technology
+   680 Folsom St.
+   San Francisco, CA
+   USA
+
+   EMail: handrews@riverbed.com
+
+
+   Austin Wright (editor)
+
+   EMail: aaa@bzfx.net
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Andrews & Wright        Expires November 26, 2019              [Page 58]

--- a/work-in-progress/WIP-jsonschema-hyperschema.txt
+++ b/work-in-progress/WIP-jsonschema-hyperschema.txt
@@ -9,7 +9,7 @@ Expires: November 26, 2019                                  May 25, 2019
 
 
    JSON Hyper-Schema: A Vocabulary for Hypermedia Annotation of JSON
-               draft-handrews-json-schema-hyperschema-02
+               draft-handrews-json-schema-hyperschema-WIP
 
 Abstract
 
@@ -2818,13 +2818,13 @@ Internet-Draft              JSON Hyper-Schema                   May 2019
 
    [json-schema]
               Wright, A. and H. Andrews, "JSON Schema: A Media Type for
-              Describing JSON Documents", draft-handrews-json-schema-02
+              Describing JSON Documents", draft-handrews-json-schema-WIP
               (work in progress), November 2017.
 
    [json-schema-validation]
               Wright, A., Andrews, H., and G. Luff, "JSON Schema
               Validation: A Vocabulary for Structural Validation of
-              JSON", draft-handrews-json-schema-validation-02 (work in
+              JSON", draft-handrews-json-schema-validation-WIP (work in
               progress), November 2017.
 
    [relative-json-pointer]
@@ -3052,7 +3052,7 @@ Appendix B.  ChangeLog
    [[CREF13: This section to be removed before leaving Internet-Draft
    status.]]
 
-   draft-handrews-json-schema-hyperschema-02
+   draft-handrews-json-schema-hyperschema-WIP
 
       *  Allow multiple values for "rel"
 

--- a/work-in-progress/WIP-jsonschema-validation.html
+++ b/work-in-progress/WIP-jsonschema-validation.html
@@ -1,0 +1,1380 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" 
+  "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+<head profile="http://www.w3.org/2006/03/hcard http://dublincore.org/documents/2008/08/04/dc-html/">
+  <meta http-equiv="Content-Type" content="text/html; charset=us-ascii" />
+
+  <title>JSON Schema Validation: A Vocabulary for Structural Validation of JSON </title>
+
+  <style type="text/css" title="Xml2Rfc (sans serif)">
+  /*<![CDATA[*/
+	  a {
+	  text-decoration: none;
+	  }
+      /* info code from SantaKlauss at http://www.madaboutstyle.com/tooltip2.html */
+      a.info {
+          /* This is the key. */
+          position: relative;
+          z-index: 24;
+          text-decoration: none;
+      }
+      a.info:hover {
+          z-index: 25;
+          color: #FFF; background-color: #900;
+      }
+      a.info span { display: none; }
+      a.info:hover span.info {
+          /* The span will display just on :hover state. */
+          display: block;
+          position: absolute;
+          font-size: smaller;
+          top: 2em; left: -5em; width: 15em;
+          padding: 2px; border: 1px solid #333;
+          color: #900; background-color: #EEE;
+          text-align: left;
+      }
+	  a.smpl {
+	  color: black;
+	  }
+	  a:hover {
+	  text-decoration: underline;
+	  }
+	  a:active {
+	  text-decoration: underline;
+	  }
+	  address {
+	  margin-top: 1em;
+	  margin-left: 2em;
+	  font-style: normal;
+	  }
+	  body {
+	  color: black;
+	  font-family: verdana, helvetica, arial, sans-serif;
+	  font-size: 10pt;
+	  max-width: 55em;
+	  
+	  }
+	  cite {
+	  font-style: normal;
+	  }
+	  dd {
+	  margin-right: 2em;
+	  }
+	  dl {
+	  margin-left: 2em;
+	  }
+	
+	  ul.empty {
+	  list-style-type: none;
+	  }
+	  ul.empty li {
+	  margin-top: .5em;
+	  }
+	  dl p {
+	  margin-left: 0em;
+	  }
+	  dt {
+	  margin-top: .5em;
+	  }
+	  h1 {
+	  font-size: 14pt;
+	  line-height: 21pt;
+	  page-break-after: avoid;
+	  }
+	  h1.np {
+	  page-break-before: always;
+	  }
+	  h1 a {
+	  color: #333333;
+	  }
+	  h2 {
+	  font-size: 12pt;
+	  line-height: 15pt;
+	  page-break-after: avoid;
+	  }
+	  h3, h4, h5, h6 {
+	  font-size: 10pt;
+	  page-break-after: avoid;
+	  }
+	  h2 a, h3 a, h4 a, h5 a, h6 a {
+	  color: black;
+	  }
+	  img {
+	  margin-left: 3em;
+	  }
+	  li {
+	  margin-left: 2em;
+	  margin-right: 2em;
+	  }
+	  ol {
+	  margin-left: 2em;
+	  margin-right: 2em;
+	  }
+	  ol p {
+	  margin-left: 0em;
+	  }
+	  p {
+	  margin-left: 2em;
+	  margin-right: 2em;
+	  }
+	  pre {
+	  margin-left: 3em;
+	  background-color: lightyellow;
+	  padding: .25em;
+	  }
+	  pre.text2 {
+	  border-style: dotted;
+	  border-width: 1px;
+	  background-color: #f0f0f0;
+	  width: 69em;
+	  }
+	  pre.inline {
+	  background-color: white;
+	  padding: 0em;
+	  }
+	  pre.text {
+	  border-style: dotted;
+	  border-width: 1px;
+	  background-color: #f8f8f8;
+	  width: 69em;
+	  }
+	  pre.drawing {
+	  border-style: solid;
+	  border-width: 1px;
+	  background-color: #f8f8f8;
+	  padding: 2em;
+	  }
+	  table {
+	  margin-left: 2em;
+	  }
+	  table.tt {
+	  vertical-align: top;
+	  }
+	  table.full {
+	  border-style: outset;
+	  border-width: 1px;
+	  }
+	  table.headers {
+	  border-style: outset;
+	  border-width: 1px;
+	  }
+	  table.tt td {
+	  vertical-align: top;
+	  }
+	  table.full td {
+	  border-style: inset;
+	  border-width: 1px;
+	  }
+	  table.tt th {
+	  vertical-align: top;
+	  }
+	  table.full th {
+	  border-style: inset;
+	  border-width: 1px;
+	  }
+	  table.headers th {
+	  border-style: none none inset none;
+	  border-width: 1px;
+	  }
+	  table.left {
+	  margin-right: auto;
+	  }
+	  table.right {
+	  margin-left: auto;
+	  }
+	  table.center {
+	  margin-left: auto;
+	  margin-right: auto;
+	  }
+	  caption {
+	  caption-side: bottom;
+	  font-weight: bold;
+	  font-size: 9pt;
+	  margin-top: .5em;
+	  }
+	
+	  table.header {
+	  border-spacing: 1px;
+	  width: 95%;
+	  font-size: 10pt;
+	  color: white;
+	  }
+	  td.top {
+	  vertical-align: top;
+	  }
+	  td.topnowrap {
+	  vertical-align: top;
+	  white-space: nowrap; 
+	  }
+	  table.header td {
+	  background-color: gray;
+	  width: 50%;
+	  }
+	  table.header a {
+	  color: white;
+	  }
+	  td.reference {
+	  vertical-align: top;
+	  white-space: nowrap;
+	  padding-right: 1em;
+	  }
+	  thead {
+	  display:table-header-group;
+	  }
+	  ul.toc, ul.toc ul {
+	  list-style: none;
+	  margin-left: 1.5em;
+	  margin-right: 0em;
+	  padding-left: 0em;
+	  }
+	  ul.toc li {
+	  line-height: 150%;
+	  font-weight: bold;
+	  font-size: 10pt;
+	  margin-left: 0em;
+	  margin-right: 0em;
+	  }
+	  ul.toc li li {
+	  line-height: normal;
+	  font-weight: normal;
+	  font-size: 9pt;
+	  margin-left: 0em;
+	  margin-right: 0em;
+	  }
+	  li.excluded {
+	  font-size: 0pt;
+	  }
+	  ul p {
+	  margin-left: 0em;
+	  }
+	
+	  .comment {
+	  background-color: yellow;
+	  }
+	  .center {
+	  text-align: center;
+	  }
+	  .error {
+	  color: red;
+	  font-style: italic;
+	  font-weight: bold;
+	  }
+	  .figure {
+	  font-weight: bold;
+	  text-align: center;
+	  font-size: 9pt;
+	  }
+	  .filename {
+	  color: #333333;
+	  font-weight: bold;
+	  font-size: 12pt;
+	  line-height: 21pt;
+	  text-align: center;
+	  }
+	  .fn {
+	  font-weight: bold;
+	  }
+	  .hidden {
+	  display: none;
+	  }
+	  .left {
+	  text-align: left;
+	  }
+	  .right {
+	  text-align: right;
+	  }
+	  .title {
+	  color: #990000;
+	  font-size: 18pt;
+	  line-height: 18pt;
+	  font-weight: bold;
+	  text-align: center;
+	  margin-top: 36pt;
+	  }
+	  .vcardline {
+	  display: block;
+	  }
+	  .warning {
+	  font-size: 14pt;
+	  background-color: yellow;
+	  }
+	
+	
+	  @media print {
+	  .noprint {
+		display: none;
+	  }
+	
+	  a {
+		color: black;
+		text-decoration: none;
+	  }
+	
+	  table.header {
+		width: 90%;
+	  }
+	
+	  td.header {
+		width: 50%;
+		color: black;
+		background-color: white;
+		vertical-align: top;
+		font-size: 12pt;
+	  }
+	
+	  ul.toc a::after {
+		content: leader('.') target-counter(attr(href), page);
+	  }
+	
+	  ul.ind li li a {
+		content: target-counter(attr(href), page);
+	  }
+	
+	  .print2col {
+		column-count: 2;
+		-moz-column-count: 2;
+		column-fill: auto;
+	  }
+	  }
+	
+	  @page {
+	  @top-left {
+		   content: "Internet-Draft"; 
+	  } 
+	  @top-right {
+		   content: "December 2010"; 
+	  } 
+	  @top-center {
+		   content: "Abbreviated Title";
+	  } 
+	  @bottom-left {
+		   content: "Doe"; 
+	  } 
+	  @bottom-center {
+		   content: "Expires June 2011"; 
+	  } 
+	  @bottom-right {
+		   content: "[Page " counter(page) "]"; 
+	  } 
+	  }
+	
+	  @page:first { 
+		@top-left {
+		  content: normal;
+		}
+		@top-right {
+		  content: normal;
+		}
+		@top-center {
+		  content: normal;
+		}
+	  }
+  /*]]>*/
+  </style>
+
+  <link href="#rfc.toc" rel="Contents">
+<link href="#rfc.section.1" rel="Chapter" title="1 Introduction">
+<link href="#rfc.section.2" rel="Chapter" title="2 Conventions and Terminology">
+<link href="#rfc.section.3" rel="Chapter" title="3 Overview">
+<link href="#rfc.section.4" rel="Chapter" title="4 Interoperability Considerations">
+<link href="#rfc.section.4.1" rel="Chapter" title="4.1 Validation of String Instances">
+<link href="#rfc.section.4.2" rel="Chapter" title="4.2 Validation of Numeric Instances">
+<link href="#rfc.section.4.3" rel="Chapter" title="4.3 Regular Expressions">
+<link href="#rfc.section.5" rel="Chapter" title="5 Meta-Schema">
+<link href="#rfc.section.6" rel="Chapter" title="6 A Vocabulary for Structural Validation">
+<link href="#rfc.section.6.1" rel="Chapter" title="6.1 Validation Keywords for Any Instance Type">
+<link href="#rfc.section.6.1.1" rel="Chapter" title="6.1.1 type">
+<link href="#rfc.section.6.1.2" rel="Chapter" title="6.1.2 enum">
+<link href="#rfc.section.6.1.3" rel="Chapter" title="6.1.3 const">
+<link href="#rfc.section.6.2" rel="Chapter" title="6.2 Validation Keywords for Numeric Instances (number and integer)">
+<link href="#rfc.section.6.2.1" rel="Chapter" title="6.2.1 multipleOf">
+<link href="#rfc.section.6.2.2" rel="Chapter" title="6.2.2 maximum">
+<link href="#rfc.section.6.2.3" rel="Chapter" title="6.2.3 exclusiveMaximum">
+<link href="#rfc.section.6.2.4" rel="Chapter" title="6.2.4 minimum">
+<link href="#rfc.section.6.2.5" rel="Chapter" title="6.2.5 exclusiveMinimum">
+<link href="#rfc.section.6.3" rel="Chapter" title="6.3 Validation Keywords for Strings">
+<link href="#rfc.section.6.3.1" rel="Chapter" title="6.3.1 maxLength">
+<link href="#rfc.section.6.3.2" rel="Chapter" title="6.3.2 minLength">
+<link href="#rfc.section.6.3.3" rel="Chapter" title="6.3.3 pattern">
+<link href="#rfc.section.6.4" rel="Chapter" title="6.4 Validation Keywords for Arrays">
+<link href="#rfc.section.6.4.1" rel="Chapter" title="6.4.1 maxItems">
+<link href="#rfc.section.6.4.2" rel="Chapter" title="6.4.2 minItems">
+<link href="#rfc.section.6.4.3" rel="Chapter" title="6.4.3 uniqueItems">
+<link href="#rfc.section.6.4.4" rel="Chapter" title="6.4.4 maxContains">
+<link href="#rfc.section.6.4.5" rel="Chapter" title="6.4.5 minContains">
+<link href="#rfc.section.6.5" rel="Chapter" title="6.5 Validation Keywords for Objects">
+<link href="#rfc.section.6.5.1" rel="Chapter" title="6.5.1 maxProperties">
+<link href="#rfc.section.6.5.2" rel="Chapter" title="6.5.2 minProperties">
+<link href="#rfc.section.6.5.3" rel="Chapter" title="6.5.3 required">
+<link href="#rfc.section.6.5.4" rel="Chapter" title="6.5.4 dependentRequired">
+<link href="#rfc.section.7" rel="Chapter" title='7 A Vocabulary for Semantic Validation With "format"'>
+<link href="#rfc.section.7.1" rel="Chapter" title="7.1 Foreword">
+<link href="#rfc.section.7.2" rel="Chapter" title="7.2 Implementation Requirements">
+<link href="#rfc.section.7.3" rel="Chapter" title="7.3 Defined Formats">
+<link href="#rfc.section.7.3.1" rel="Chapter" title="7.3.1 Dates, Times, and Duration">
+<link href="#rfc.section.7.3.2" rel="Chapter" title="7.3.2 Email Addresses">
+<link href="#rfc.section.7.3.3" rel="Chapter" title="7.3.3 Hostnames">
+<link href="#rfc.section.7.3.4" rel="Chapter" title="7.3.4 IP Addresses">
+<link href="#rfc.section.7.3.5" rel="Chapter" title="7.3.5 Resource Identifiers">
+<link href="#rfc.section.7.3.6" rel="Chapter" title="7.3.6 uri-template">
+<link href="#rfc.section.7.3.7" rel="Chapter" title="7.3.7 JSON Pointers">
+<link href="#rfc.section.7.3.8" rel="Chapter" title="7.3.8 regex">
+<link href="#rfc.section.8" rel="Chapter" title="8 A Vocabulary for the Contents of String-Encoded Data">
+<link href="#rfc.section.8.1" rel="Chapter" title="8.1 Foreword">
+<link href="#rfc.section.8.2" rel="Chapter" title="8.2 Implementation Requirements">
+<link href="#rfc.section.8.3" rel="Chapter" title="8.3 contentEncoding">
+<link href="#rfc.section.8.4" rel="Chapter" title="8.4 contentMediaType">
+<link href="#rfc.section.8.5" rel="Chapter" title="8.5 contentSchema">
+<link href="#rfc.section.8.6" rel="Chapter" title="8.6 Example">
+<link href="#rfc.section.9" rel="Chapter" title="9 A Vocabulary for Basic Meta-Data Annotations">
+<link href="#rfc.section.9.1" rel="Chapter" title='9.1 "title" and "description"'>
+<link href="#rfc.section.9.2" rel="Chapter" title='9.2 "default"'>
+<link href="#rfc.section.9.3" rel="Chapter" title='9.3 "deprecated"'>
+<link href="#rfc.section.9.4" rel="Chapter" title='9.4 "readOnly" and "writeOnly"'>
+<link href="#rfc.section.9.5" rel="Chapter" title='9.5 "examples"'>
+<link href="#rfc.section.10" rel="Chapter" title="10 Security Considerations">
+<link href="#rfc.references" rel="Chapter" title="11 References">
+<link href="#rfc.references.1" rel="Chapter" title="11.1 Normative References">
+<link href="#rfc.references.2" rel="Chapter" title="11.2 Informative References">
+<link href="#rfc.appendix.A" rel="Chapter" title="A Keywords Moved from Validation to Core">
+<link href="#rfc.appendix.B" rel="Chapter" title="B Acknowledgments">
+<link href="#rfc.appendix.C" rel="Chapter" title="C ChangeLog">
+<link href="#rfc.authors" rel="Chapter">
+
+
+  <meta name="generator" content="xml2rfc version 2.20.1 - https://tools.ietf.org/tools/xml2rfc" />
+  <link rel="schema.dct" href="http://purl.org/dc/terms/" />
+
+  <meta name="dct.creator" content="Wright, A., Ed., Andrews, H., Ed., Hutton, B., Ed., and G. Luff" />
+  <meta name="dct.identifier" content="urn:ietf:id:draft-handrews-json-schema-validation-02" />
+  <meta name="dct.issued" scheme="ISO8601" content="2019-25" />
+  <meta name="dct.abstract" content="JSON Schema (application/schema+json) has several purposes, one of which is JSON instance validation.  This document specifies a vocabulary for JSON Schema to describe the meaning of JSON documents, provide hints for user interfaces working with JSON data, and to make assertions about what a valid document must look like.  " />
+  <meta name="description" content="JSON Schema (application/schema+json) has several purposes, one of which is JSON instance validation.  This document specifies a vocabulary for JSON Schema to describe the meaning of JSON documents, provide hints for user interfaces working with JSON data, and to make assertions about what a valid document must look like.  " />
+
+</head>
+
+<body>
+
+  <table class="header">
+    <tbody>
+    
+    	<tr>
+<td class="left">Internet Engineering Task Force</td>
+<td class="right">A. Wright, Ed.</td>
+</tr>
+<tr>
+<td class="left">Internet-Draft</td>
+<td class="right"></td>
+</tr>
+<tr>
+<td class="left">Intended status: Informational</td>
+<td class="right">H. Andrews, Ed.</td>
+</tr>
+<tr>
+<td class="left">Expires: November 26, 2019</td>
+<td class="right">Riverbed Technology</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="right">B. Hutton, Ed.</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="right">Wellcome Sanger Institute</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="right">G. Luff</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="right">May 25, 2019</td>
+</tr>
+
+    	
+    </tbody>
+  </table>
+
+  <p class="title">JSON Schema Validation: A Vocabulary for Structural Validation of JSON <br />
+  <span class="filename">draft-handrews-json-schema-validation-02</span></p>
+  
+  <h1 id="rfc.abstract"><a href="#rfc.abstract">Abstract</a></h1>
+<p>JSON Schema (application/schema+json) has several purposes, one of which is JSON instance validation.  This document specifies a vocabulary for JSON Schema to describe the meaning of JSON documents, provide hints for user interfaces working with JSON data, and to make assertions about what a valid document must look like.  </p>
+<h1><a>Note to Readers</a></h1>
+<p>The issues list for this draft can be found at <span>&lt;</span><a href="https://github.com/json-schema-org/json-schema-spec/issues">https://github.com/json-schema-org/json-schema-spec/issues</a><span>&gt;</span>.  </p>
+<p>For additional information, see <span>&lt;</span><a href="http://json-schema.org/">http://json-schema.org/</a><span>&gt;</span>.  </p>
+<p>To provide feedback, use this issue tracker, the communication methods listed on the homepage, or email the document editors.  </p>
+<h1 id="rfc.status"><a href="#rfc.status">Status of This Memo</a></h1>
+<p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.</p>
+<p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at https://datatracker.ietf.org/drafts/current/.</p>
+<p>Internet-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use Internet-Drafts as reference material or to cite them other than as "work in progress."</p>
+<p>This Internet-Draft will expire on November 26, 2019.</p>
+<h1 id="rfc.copyrightnotice"><a href="#rfc.copyrightnotice">Copyright Notice</a></h1>
+<p>Copyright (c) 2019 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
+<p>This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating to IETF Documents (https://trustee.ietf.org/license-info) in effect on the date of publication of this document.  Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.</p>
+
+  
+  <hr class="noprint" />
+  <h1 class="np" id="rfc.toc"><a href="#rfc.toc">Table of Contents</a></h1>
+  <ul class="toc">
+
+  	<li>1.   <a href="#rfc.section.1">Introduction</a>
+</li>
+<li>2.   <a href="#rfc.section.2">Conventions and Terminology</a>
+</li>
+<li>3.   <a href="#rfc.section.3">Overview</a>
+</li>
+<li>4.   <a href="#rfc.section.4">Interoperability Considerations</a>
+</li>
+<ul><li>4.1.   <a href="#rfc.section.4.1">Validation of String Instances</a>
+</li>
+<li>4.2.   <a href="#rfc.section.4.2">Validation of Numeric Instances</a>
+</li>
+<li>4.3.   <a href="#rfc.section.4.3">Regular Expressions</a>
+</li>
+</ul><li>5.   <a href="#rfc.section.5">Meta-Schema</a>
+</li>
+<li>6.   <a href="#rfc.section.6">A Vocabulary for Structural Validation</a>
+</li>
+<ul><li>6.1.   <a href="#rfc.section.6.1">Validation Keywords for Any Instance Type</a>
+</li>
+<ul><li>6.1.1.   <a href="#rfc.section.6.1.1">type</a>
+</li>
+<li>6.1.2.   <a href="#rfc.section.6.1.2">enum</a>
+</li>
+<li>6.1.3.   <a href="#rfc.section.6.1.3">const</a>
+</li>
+</ul><li>6.2.   <a href="#rfc.section.6.2">Validation Keywords for Numeric Instances (number and integer)</a>
+</li>
+<ul><li>6.2.1.   <a href="#rfc.section.6.2.1">multipleOf</a>
+</li>
+<li>6.2.2.   <a href="#rfc.section.6.2.2">maximum</a>
+</li>
+<li>6.2.3.   <a href="#rfc.section.6.2.3">exclusiveMaximum</a>
+</li>
+<li>6.2.4.   <a href="#rfc.section.6.2.4">minimum</a>
+</li>
+<li>6.2.5.   <a href="#rfc.section.6.2.5">exclusiveMinimum</a>
+</li>
+</ul><li>6.3.   <a href="#rfc.section.6.3">Validation Keywords for Strings</a>
+</li>
+<ul><li>6.3.1.   <a href="#rfc.section.6.3.1">maxLength</a>
+</li>
+<li>6.3.2.   <a href="#rfc.section.6.3.2">minLength</a>
+</li>
+<li>6.3.3.   <a href="#rfc.section.6.3.3">pattern</a>
+</li>
+</ul><li>6.4.   <a href="#rfc.section.6.4">Validation Keywords for Arrays</a>
+</li>
+<ul><li>6.4.1.   <a href="#rfc.section.6.4.1">maxItems</a>
+</li>
+<li>6.4.2.   <a href="#rfc.section.6.4.2">minItems</a>
+</li>
+<li>6.4.3.   <a href="#rfc.section.6.4.3">uniqueItems</a>
+</li>
+<li>6.4.4.   <a href="#rfc.section.6.4.4">maxContains</a>
+</li>
+<li>6.4.5.   <a href="#rfc.section.6.4.5">minContains</a>
+</li>
+</ul><li>6.5.   <a href="#rfc.section.6.5">Validation Keywords for Objects</a>
+</li>
+<ul><li>6.5.1.   <a href="#rfc.section.6.5.1">maxProperties</a>
+</li>
+<li>6.5.2.   <a href="#rfc.section.6.5.2">minProperties</a>
+</li>
+<li>6.5.3.   <a href="#rfc.section.6.5.3">required</a>
+</li>
+<li>6.5.4.   <a href="#rfc.section.6.5.4">dependentRequired</a>
+</li>
+</ul></ul><li>7.   <a href="#rfc.section.7">A Vocabulary for Semantic Validation With "format"</a>
+</li>
+<ul><li>7.1.   <a href="#rfc.section.7.1">Foreword</a>
+</li>
+<li>7.2.   <a href="#rfc.section.7.2">Implementation Requirements</a>
+</li>
+<li>7.3.   <a href="#rfc.section.7.3">Defined Formats</a>
+</li>
+<ul><li>7.3.1.   <a href="#rfc.section.7.3.1">Dates, Times, and Duration</a>
+</li>
+<li>7.3.2.   <a href="#rfc.section.7.3.2">Email Addresses</a>
+</li>
+<li>7.3.3.   <a href="#rfc.section.7.3.3">Hostnames</a>
+</li>
+<li>7.3.4.   <a href="#rfc.section.7.3.4">IP Addresses</a>
+</li>
+<li>7.3.5.   <a href="#rfc.section.7.3.5">Resource Identifiers</a>
+</li>
+<li>7.3.6.   <a href="#rfc.section.7.3.6">uri-template</a>
+</li>
+<li>7.3.7.   <a href="#rfc.section.7.3.7">JSON Pointers</a>
+</li>
+<li>7.3.8.   <a href="#rfc.section.7.3.8">regex</a>
+</li>
+</ul></ul><li>8.   <a href="#rfc.section.8">A Vocabulary for the Contents of String-Encoded Data</a>
+</li>
+<ul><li>8.1.   <a href="#rfc.section.8.1">Foreword</a>
+</li>
+<li>8.2.   <a href="#rfc.section.8.2">Implementation Requirements</a>
+</li>
+<li>8.3.   <a href="#rfc.section.8.3">contentEncoding</a>
+</li>
+<li>8.4.   <a href="#rfc.section.8.4">contentMediaType</a>
+</li>
+<li>8.5.   <a href="#rfc.section.8.5">contentSchema</a>
+</li>
+<li>8.6.   <a href="#rfc.section.8.6">Example</a>
+</li>
+</ul><li>9.   <a href="#rfc.section.9">A Vocabulary for Basic Meta-Data Annotations</a>
+</li>
+<ul><li>9.1.   <a href="#rfc.section.9.1">"title" and "description"</a>
+</li>
+<li>9.2.   <a href="#rfc.section.9.2">"default"</a>
+</li>
+<li>9.3.   <a href="#rfc.section.9.3">"deprecated"</a>
+</li>
+<li>9.4.   <a href="#rfc.section.9.4">"readOnly" and "writeOnly"</a>
+</li>
+<li>9.5.   <a href="#rfc.section.9.5">"examples"</a>
+</li>
+</ul><li>10.   <a href="#rfc.section.10">Security Considerations</a>
+</li>
+<li>11.   <a href="#rfc.references">References</a>
+</li>
+<ul><li>11.1.   <a href="#rfc.references.1">Normative References</a>
+</li>
+<li>11.2.   <a href="#rfc.references.2">Informative References</a>
+</li>
+</ul><li>Appendix A.   <a href="#rfc.appendix.A">Keywords Moved from Validation to Core</a>
+</li>
+<li>Appendix B.   <a href="#rfc.appendix.B">Acknowledgments</a>
+</li>
+<li>Appendix C.   <a href="#rfc.appendix.C">ChangeLog</a>
+</li>
+<li><a href="#rfc.authors">Authors' Addresses</a>
+</li>
+
+
+  </ul>
+
+  <h1 id="rfc.section.1">
+<a href="#rfc.section.1">1.</a> Introduction</h1>
+<p id="rfc.section.1.p.1">JSON Schema can be used to require that a given JSON document (an instance) satisfies a certain number of criteria. These criteria are asserted by using keywords described in this specification. In addition, a set of keywords is also defined to assist in interactive user interface instance generation.  </p>
+<p id="rfc.section.1.p.2">This specification will use the concepts, syntax, and terminology defined by the <a href="#json-schema" class="xref">JSON Schema core</a> specification.  </p>
+<h1 id="rfc.section.2">
+<a href="#rfc.section.2">2.</a> Conventions and Terminology</h1>
+<p id="rfc.section.2.p.1">The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in <a href="#RFC2119" class="xref">RFC 2119</a>.  </p>
+<p id="rfc.section.2.p.2">This specification uses the term "container instance" to refer to both array and object instances. It uses the term "children instances" to refer to array elements or object member values.  </p>
+<p id="rfc.section.2.p.3">Elements in an array value are said to be unique if no two elements of this array are <a href="#json-schema" class="xref">equal</a>.  </p>
+<h1 id="rfc.section.3">
+<a href="#rfc.section.3">3.</a> Overview</h1>
+<p id="rfc.section.3.p.1">JSON Schema validation asserts constraints on the structure of instance data.  An instance location that satisfies all asserted constraints is then annotated with any keywords that contain non-assertion information, such as descriptive metadata and usage hints.  If all locations within the instance satisfy all asserted constraints, then the instance is said to be valid against the schema.  </p>
+<p id="rfc.section.3.p.2">Each schema object is independently evaluated against each instance location to which it applies.  This greatly simplifies the implementation requirements for validators by ensuring that they do not need to maintain state across the document-wide validation process.  </p>
+<p id="rfc.section.3.p.3">This specification defines a set of assertion keywords, as well as a small vocabulary of metadata keywords that can be used to annotate the JSON instance with useful information.  The <a href="#format" class="xref">Section 7</a> and <a href="#content" class="xref">Section 8</a> keywords are also useful as annotations as well as being optional assertions, as they convey additional usage guidance for the instance data.  </p>
+<h1 id="rfc.section.4">
+<a href="#rfc.section.4">4.</a> Interoperability Considerations</h1>
+<h1 id="rfc.section.4.1">
+<a href="#rfc.section.4.1">4.1.</a> Validation of String Instances</h1>
+<p id="rfc.section.4.1.p.1">It should be noted that the nul character (\u0000) is valid in a JSON string. An instance to validate may contain a string value with this character, regardless of the ability of the underlying programming language to deal with such data.  </p>
+<h1 id="rfc.section.4.2">
+<a href="#rfc.section.4.2">4.2.</a> Validation of Numeric Instances</h1>
+<p id="rfc.section.4.2.p.1">The JSON specification allows numbers with arbitrary precision, and JSON Schema does not add any such bounds.  This means that numeric instances processed by JSON Schema can be arbitrarily large and/or have an arbitrarily long decimal part, regardless of the ability of the underlying programming language to deal with such data.  </p>
+<h1 id="rfc.section.4.3">
+<a href="#rfc.section.4.3">4.3.</a> <a href="#regexInterop" id="regexInterop">Regular Expressions</a>
+</h1>
+<p id="rfc.section.4.3.p.1">Keywords that use regular expressions, or constrain the instance value to be a regular expression, are subject to the interoperability considerations for regular expressions in the <a href="#json-schema" class="xref">JSON Schema Core</a> specification.  </p>
+<h1 id="rfc.section.5">
+<a href="#rfc.section.5">5.</a> Meta-Schema</h1>
+<p id="rfc.section.5.p.1">The current URI for the JSON Schema Validation meta-schema is <span>&lt;</span><a href="http://json-schema.org/draft/2019-04/schenma#">http://json-schema.org/draft/2019-04/schenma#</a><span>&gt;</span>.  For schema author convenience, this meta-schema describes all vocabularies defined in this specification and the JSON Schema Core specification.  Individual vocabulary and vocabulary meta-schema URIs are given for each section below.  </p>
+<p id="rfc.section.5.p.2">Updated vocabulary and meta-schema URIs MAY be published between specification drafts in order to correct errors.  Implementations SHOULD consider URIs dated after this specification draft and before the next to indicate the same syntax and semantics as those listed here.  </p>
+<h1 id="rfc.section.6">
+<a href="#rfc.section.6">6.</a> A Vocabulary for Structural Validation</h1>
+<p id="rfc.section.6.p.1">Validation keywords in a schema impose requirements for successful validation of an instance.  These keywords are all assertions without any annotation behavior.  </p>
+<p id="rfc.section.6.p.2">Meta-schemas that do not use "$vocabulary" SHOULD be considered to require this vocabulary as if its URI were present with a value of true.  </p>
+<p id="rfc.section.6.p.3">The current URI for this vocabulary, known as the Validation vocabulary, is: <span>&lt;</span><a href="https://json-schema.org/draft/2019-04/vocab/validation">https://json-schema.org/draft/2019-04/vocab/validation</a><span>&gt;</span>.  </p>
+<p id="rfc.section.6.p.4">The current URI for the corresponding meta-schema is: <span>&lt;</span><a href="https://json-schema.org/draft/2019-04/meta/validation">https://json-schema.org/draft/2019-04/meta/validation</a><span>&gt;</span>.  </p>
+<h1 id="rfc.section.6.1">
+<a href="#rfc.section.6.1">6.1.</a> <a href="#general" id="general">Validation Keywords for Any Instance Type</a>
+</h1>
+<h1 id="rfc.section.6.1.1">
+<a href="#rfc.section.6.1.1">6.1.1.</a> type</h1>
+<p id="rfc.section.6.1.1.p.1">The value of this keyword MUST be either a string or an array. If it is an array, elements of the array MUST be strings and MUST be unique.  </p>
+<p id="rfc.section.6.1.1.p.2">String values MUST be one of the six primitive types ("null", "boolean", "object", "array", "number", or "string"), or "integer" which matches any number with a zero fractional part.  </p>
+<p id="rfc.section.6.1.1.p.3">An instance validates if and only if the instance is in any of the sets listed for this keyword.  </p>
+<h1 id="rfc.section.6.1.2">
+<a href="#rfc.section.6.1.2">6.1.2.</a> <a href="#enum" id="enum">enum</a>
+</h1>
+<p id="rfc.section.6.1.2.p.1">The value of this keyword MUST be an array. This array SHOULD have at least one element. Elements in the array SHOULD be unique.  </p>
+<p id="rfc.section.6.1.2.p.2">An instance validates successfully against this keyword if its value is equal to one of the elements in this keyword's array value.  </p>
+<p id="rfc.section.6.1.2.p.3">Elements in the array might be of any type, including null.  </p>
+<h1 id="rfc.section.6.1.3">
+<a href="#rfc.section.6.1.3">6.1.3.</a> const</h1>
+<p id="rfc.section.6.1.3.p.1">The value of this keyword MAY be of any type, including null.  </p>
+<p id="rfc.section.6.1.3.p.2">Use of this keyword is functionally equivalent to an <a href="#enum" class="xref">"enum"</a> with a single value.  </p>
+<p id="rfc.section.6.1.3.p.3">An instance validates successfully against this keyword if its value is equal to the value of the keyword.  </p>
+<h1 id="rfc.section.6.2">
+<a href="#rfc.section.6.2">6.2.</a> <a href="#numeric" id="numeric">Validation Keywords for Numeric Instances (number and integer)</a>
+</h1>
+<h1 id="rfc.section.6.2.1">
+<a href="#rfc.section.6.2.1">6.2.1.</a> multipleOf</h1>
+<p id="rfc.section.6.2.1.p.1">The value of "multipleOf" MUST be a number, strictly greater than 0.  </p>
+<p id="rfc.section.6.2.1.p.2">A numeric instance is valid only if division by this keyword's value results in an integer.  </p>
+<h1 id="rfc.section.6.2.2">
+<a href="#rfc.section.6.2.2">6.2.2.</a> maximum</h1>
+<p id="rfc.section.6.2.2.p.1">The value of "maximum" MUST be a number, representing an inclusive upper limit for a numeric instance.  </p>
+<p id="rfc.section.6.2.2.p.2">If the instance is a number, then this keyword validates only if the instance is less than or exactly equal to "maximum".  </p>
+<h1 id="rfc.section.6.2.3">
+<a href="#rfc.section.6.2.3">6.2.3.</a> exclusiveMaximum</h1>
+<p id="rfc.section.6.2.3.p.1">The value of "exclusiveMaximum" MUST be number, representing an exclusive upper limit for a numeric instance.  </p>
+<p id="rfc.section.6.2.3.p.2">If the instance is a number, then the instance is valid only if it has a value strictly less than (not equal to) "exclusiveMaximum".  </p>
+<h1 id="rfc.section.6.2.4">
+<a href="#rfc.section.6.2.4">6.2.4.</a> minimum</h1>
+<p id="rfc.section.6.2.4.p.1">The value of "minimum" MUST be a number, representing an inclusive lower limit for a numeric instance.  </p>
+<p id="rfc.section.6.2.4.p.2">If the instance is a number, then this keyword validates only if the instance is greater than or exactly equal to "minimum".  </p>
+<h1 id="rfc.section.6.2.5">
+<a href="#rfc.section.6.2.5">6.2.5.</a> exclusiveMinimum</h1>
+<p id="rfc.section.6.2.5.p.1">The value of "exclusiveMinimum" MUST be number, representing an exclusive lower limit for a numeric instance.  </p>
+<p id="rfc.section.6.2.5.p.2">If the instance is a number, then the instance is valid only if it has a value strictly greater than (not equal to) "exclusiveMinimum".  </p>
+<h1 id="rfc.section.6.3">
+<a href="#rfc.section.6.3">6.3.</a> <a href="#string" id="string">Validation Keywords for Strings</a>
+</h1>
+<h1 id="rfc.section.6.3.1">
+<a href="#rfc.section.6.3.1">6.3.1.</a> maxLength</h1>
+<p id="rfc.section.6.3.1.p.1">The value of this keyword MUST be a non-negative integer.</p>
+<p id="rfc.section.6.3.1.p.2">A string instance is valid against this keyword if its length is less than, or equal to, the value of this keyword.  </p>
+<p id="rfc.section.6.3.1.p.3">The length of a string instance is defined as the number of its characters as defined by <a href="#RFC8259" class="xref">RFC 8259</a>.  </p>
+<h1 id="rfc.section.6.3.2">
+<a href="#rfc.section.6.3.2">6.3.2.</a> minLength</h1>
+<p id="rfc.section.6.3.2.p.1">The value of this keyword MUST be a non-negative integer.  </p>
+<p id="rfc.section.6.3.2.p.2">A string instance is valid against this keyword if its length is greater than, or equal to, the value of this keyword.  </p>
+<p id="rfc.section.6.3.2.p.3">The length of a string instance is defined as the number of its characters as defined by <a href="#RFC8259" class="xref">RFC 8259</a>.  </p>
+<p id="rfc.section.6.3.2.p.4">Omitting this keyword has the same behavior as a value of 0.  </p>
+<h1 id="rfc.section.6.3.3">
+<a href="#rfc.section.6.3.3">6.3.3.</a> <a href="#pattern" id="pattern">pattern</a>
+</h1>
+<p id="rfc.section.6.3.3.p.1">The value of this keyword MUST be a string. This string SHOULD be a valid regular expression, according to the ECMA 262 regular expression dialect.  </p>
+<p id="rfc.section.6.3.3.p.2">A string instance is considered valid if the regular expression matches the instance successfully. Recall: regular expressions are not implicitly anchored.  </p>
+<h1 id="rfc.section.6.4">
+<a href="#rfc.section.6.4">6.4.</a> Validation Keywords for Arrays</h1>
+<h1 id="rfc.section.6.4.1">
+<a href="#rfc.section.6.4.1">6.4.1.</a> maxItems</h1>
+<p id="rfc.section.6.4.1.p.1">The value of this keyword MUST be a non-negative integer.  </p>
+<p id="rfc.section.6.4.1.p.2">An array instance is valid against "maxItems" if its size is less than, or equal to, the value of this keyword.  </p>
+<h1 id="rfc.section.6.4.2">
+<a href="#rfc.section.6.4.2">6.4.2.</a> minItems</h1>
+<p id="rfc.section.6.4.2.p.1">The value of this keyword MUST be a non-negative integer.  </p>
+<p id="rfc.section.6.4.2.p.2">An array instance is valid against "minItems" if its size is greater than, or equal to, the value of this keyword.  </p>
+<p id="rfc.section.6.4.2.p.3">Omitting this keyword has the same behavior as a value of 0.  </p>
+<h1 id="rfc.section.6.4.3">
+<a href="#rfc.section.6.4.3">6.4.3.</a> uniqueItems</h1>
+<p id="rfc.section.6.4.3.p.1">The value of this keyword MUST be a boolean.  </p>
+<p id="rfc.section.6.4.3.p.2">If this keyword has boolean value false, the instance validates successfully. If it has boolean value true, the instance validates successfully if all of its elements are unique.  </p>
+<p id="rfc.section.6.4.3.p.3">Omitting this keyword has the same behavior as a value of false.  </p>
+<h1 id="rfc.section.6.4.4">
+<a href="#rfc.section.6.4.4">6.4.4.</a> maxContains</h1>
+<p id="rfc.section.6.4.4.p.1">The value of this keyword MUST be a non-negative integer.  </p>
+<p id="rfc.section.6.4.4.p.2">An array instance is valid against "maxContains" if the number of elements that are valid against the schema for <a href="#json-schema" class="xref">"contains"</a> is less than, or equal to, the value of this keyword.  </p>
+<p id="rfc.section.6.4.4.p.3">If "contains" is not present within the same schema object, then this keyword has no effect.  </p>
+<h1 id="rfc.section.6.4.5">
+<a href="#rfc.section.6.4.5">6.4.5.</a> minContains</h1>
+<p id="rfc.section.6.4.5.p.1">The value of this keyword MUST be a non-negative integer.  </p>
+<p id="rfc.section.6.4.5.p.2">An array instance is valid against "minContains" if the number of elements that are valid against the schema for <a href="#json-schema" class="xref">"contains"</a> is greater than, or equal to, the value of this keyword.  </p>
+<p id="rfc.section.6.4.5.p.3">A value of 0 is allowed, but is only useful for setting a range of occurrences from 0 to the value of "maxContains".  A value of 0 with no "maxContains" causes "contains" to always pass validation.  </p>
+<p id="rfc.section.6.4.5.p.4">If "contains" is not present within the same schema object, then this keyword has no effect.  </p>
+<p id="rfc.section.6.4.5.p.5">Omitting this keyword has the same behavior as a value of 1.  </p>
+<h1 id="rfc.section.6.5">
+<a href="#rfc.section.6.5">6.5.</a> Validation Keywords for Objects</h1>
+<h1 id="rfc.section.6.5.1">
+<a href="#rfc.section.6.5.1">6.5.1.</a> maxProperties</h1>
+<p id="rfc.section.6.5.1.p.1">The value of this keyword MUST be a non-negative integer.  </p>
+<p id="rfc.section.6.5.1.p.2">An object instance is valid against "maxProperties" if its number of properties is less than, or equal to, the value of this keyword.  </p>
+<h1 id="rfc.section.6.5.2">
+<a href="#rfc.section.6.5.2">6.5.2.</a> minProperties</h1>
+<p id="rfc.section.6.5.2.p.1">The value of this keyword MUST be a non-negative integer.  </p>
+<p id="rfc.section.6.5.2.p.2">An object instance is valid against "minProperties" if its number of properties is greater than, or equal to, the value of this keyword.  </p>
+<p id="rfc.section.6.5.2.p.3">Omitting this keyword has the same behavior as a value of 0.  </p>
+<h1 id="rfc.section.6.5.3">
+<a href="#rfc.section.6.5.3">6.5.3.</a> required</h1>
+<p id="rfc.section.6.5.3.p.1">The value of this keyword MUST be an array.  Elements of this array, if any, MUST be strings, and MUST be unique.  </p>
+<p id="rfc.section.6.5.3.p.2">An object instance is valid against this keyword if every item in the array is the name of a property in the instance.  </p>
+<p id="rfc.section.6.5.3.p.3">Omitting this keyword has the same behavior as an empty array.  </p>
+<h1 id="rfc.section.6.5.4">
+<a href="#rfc.section.6.5.4">6.5.4.</a> dependentRequired</h1>
+<p id="rfc.section.6.5.4.p.1">The value of this keyword MUST be an object.  Properties in this object, if any, MUST be arrays.  Elements in each array, if any, MUST be strings, and MUST be unique.  </p>
+<p id="rfc.section.6.5.4.p.2">This keyword specifies properties that are required if a specific other property is present.  Their requirement is dependent on the presence of the other property.  </p>
+<p id="rfc.section.6.5.4.p.3">Validation succeeds if, for each name that appears in both the instance and as a name within this keyword's value, every item in the corresponding array is also the name of a property in the instance.  </p>
+<p id="rfc.section.6.5.4.p.4">Omitting this keyword has the same behavior as an empty object.  </p>
+<h1 id="rfc.section.7">
+<a href="#rfc.section.7">7.</a> <a href="#format" id="format">A Vocabulary for Semantic Validation With "format"</a>
+</h1>
+<h1 id="rfc.section.7.1">
+<a href="#rfc.section.7.1">7.1.</a> Foreword</h1>
+<p id="rfc.section.7.1.p.1">Structural validation alone may be insufficient to validate that an instance meets all the requirements of an application. The "format" keyword is defined to allow interoperable semantic validation for a fixed subset of values which are accurately described by authoritative resources, be they RFCs or other external specifications.  </p>
+<p id="rfc.section.7.1.p.2">The value of this keyword is called a format attribute. It MUST be a string. A format attribute can generally only validate a given set of instance types. If the type of the instance to validate is not in this set, validation for this format attribute and instance SHOULD succeed.  </p>
+<p id="rfc.section.7.1.p.3">Meta-schemas that do not use "$vocabulary" SHOULD be considered to require this vocabulary as if its URI were present with a value of true, although see the Implementation Requirements below for details.  </p>
+<p id="rfc.section.7.1.p.4">The current URI for this vocabulary, known as the Format vocabulary, is: <span>&lt;</span><a href="https://json-schema.org/draft/2019-04/vocab/format">https://json-schema.org/draft/2019-04/vocab/format</a><span>&gt;</span>.  </p>
+<p id="rfc.section.7.1.p.5">The current URI for the corresponding meta-schema is: <span>&lt;</span><a href="https://json-schema.org/draft/2019-04/meta/format">https://json-schema.org/draft/2019-04/meta/format</a><span>&gt;</span>.  </p>
+<h1 id="rfc.section.7.2">
+<a href="#rfc.section.7.2">7.2.</a> Implementation Requirements</h1>
+<p id="rfc.section.7.2.p.1">The "format" keyword functions as both an annotation and as an assertion.  While no special effort is required to implement it as an annotation conveying semantic meaning, implementing validation is non-trivial.  </p>
+<p id="rfc.section.7.2.p.2">Implementations MAY support the "format" keyword as a validation assertion.  Should they choose to do so: </p>
+
+<ul class="empty">
+<li>they SHOULD implement validation for attributes defined below;</li>
+<li>they SHOULD offer an option to disable validation for this keyword.</li>
+</ul>
+
+<p> </p>
+<p id="rfc.section.7.2.p.3">Implementations MAY add custom format attributes. Save for agreement between parties, schema authors SHALL NOT expect a peer implementation to support this keyword and/or custom format attributes.  </p>
+<h1 id="rfc.section.7.3">
+<a href="#rfc.section.7.3">7.3.</a> Defined Formats</h1>
+<h1 id="rfc.section.7.3.1">
+<a href="#rfc.section.7.3.1">7.3.1.</a> Dates, Times, and Duration</h1>
+<p id="rfc.section.7.3.1.p.1">These attributes apply to string instances.  </p>
+<p id="rfc.section.7.3.1.p.2">Date and time format names are derived from <a href="#RFC3339" class="xref">RFC 3339, section 5.6</a>.  The duration format is from the ISO 8601 ABNF as given in Appendix A of RFC 3339.  </p>
+<p id="rfc.section.7.3.1.p.3">Implementations supporting formats SHOULD implement support for the following attributes: </p>
+
+<dl>
+<dt>date-time:</dt>
+<dd style="margin-left: 8">A string instance is valid against this attribute if it is a valid representation according to the "date-time" production.  </dd>
+<dt>date:</dt>
+<dd style="margin-left: 8">A string instance is valid against this attribute if it is a valid representation according to the "full-date" production.  </dd>
+<dt>time:</dt>
+<dd style="margin-left: 8">A string instance is valid against this attribute if it is a valid representation according to the "full-time" production.  </dd>
+<dt>duration:</dt>
+<dd style="margin-left: 8">A string instance is valid against this attribute if it is a valid representation according to the "duration" production.  </dd>
+</dl>
+
+<p> </p>
+<p id="rfc.section.7.3.1.p.4">Implementations MAY support additional attributes using the other production names defined in that section.  If "full-date" or "full-time" are implemented, the corresponding short form ("date" or "time" respectively) MUST be implemented, and MUST behave identically.  Implementations SHOULD NOT define extension attributes with any name matching an RFC 3339 production unless it validates according to the rules of that production.  <a id="CREF1" class="info">[CREF1]<span class="info">There is not currently consensus on the need for supporting all RFC 3339 formats, so this approach of reserving the namespace will encourage experimentation without committing to the entire set.  Either the format implementation requirements will become more flexible in general, or these will likely either be promoted to fully specified attributes or dropped.  </span></a> </p>
+<h1 id="rfc.section.7.3.2">
+<a href="#rfc.section.7.3.2">7.3.2.</a> Email Addresses</h1>
+<p id="rfc.section.7.3.2.p.1">These attributes apply to string instances.  </p>
+<p id="rfc.section.7.3.2.p.2">A string instance is valid against these attributes if it is a valid Internet email address as follows: </p>
+
+<dl>
+<dt>email:</dt>
+<dd style="margin-left: 8">As defined by <a href="#RFC5322" class="xref">RFC 5322, section 3.4.1</a>.  </dd>
+<dt>idn-email:</dt>
+<dd style="margin-left: 8">As defined by <a href="#RFC6531" class="xref">RFC 6531</a> </dd>
+</dl>
+
+<p> Note that all strings valid against the "email" attribute are also valid against the "idn-email" attribute.  </p>
+<h1 id="rfc.section.7.3.3">
+<a href="#rfc.section.7.3.3">7.3.3.</a> Hostnames</h1>
+<p id="rfc.section.7.3.3.p.1">These attributes apply to string instances.  </p>
+<p id="rfc.section.7.3.3.p.2">A string instance is valid against these attributes if it is a valid representation for an Internet hostname as follows: </p>
+
+<dl>
+<dt>hostname:</dt>
+<dd style="margin-left: 8">As defined by <a href="#RFC1123" class="xref">RFC 1123, section 2.1</a>, including host names produced using the Punycode algorithm specified in <a href="#RFC5891" class="xref">RFC 5891, section 4.4</a>.  </dd>
+<dt>idn-hostname:</dt>
+<dd style="margin-left: 8">As defined by either RFC 1123 as for hostname, or an internationalized hostname as defined by <a href="#RFC5890" class="xref">RFC 5890, section 2.3.2.3</a>.  </dd>
+</dl>
+
+<p> Note that all strings valid against the "hostname" attribute are also valid against the "idn-hostname" attribute.  </p>
+<h1 id="rfc.section.7.3.4">
+<a href="#rfc.section.7.3.4">7.3.4.</a> IP Addresses</h1>
+<p id="rfc.section.7.3.4.p.1">These attributes apply to string instances.  </p>
+<p id="rfc.section.7.3.4.p.2">A string instance is valid against these attributes if it is a valid representation of an IP address as follows: </p>
+
+<dl>
+<dt>ipv4:</dt>
+<dd style="margin-left: 8">An IPv4 address according to the "dotted-quad" ABNF syntax as defined in <a href="#RFC2673" class="xref">RFC 2673, section 3.2</a>.  </dd>
+<dt>ipv6:</dt>
+<dd style="margin-left: 8">An IPv6 address as defined in <a href="#RFC4291" class="xref">RFC 4291, section 2.2</a>.  </dd>
+</dl>
+
+<p> </p>
+<h1 id="rfc.section.7.3.5">
+<a href="#rfc.section.7.3.5">7.3.5.</a> Resource Identifiers</h1>
+<p id="rfc.section.7.3.5.p.1">These attributes apply to string instances.  </p>
+<p></p>
+
+<dl>
+<dt>uri:</dt>
+<dd style="margin-left: 8">A string instance is valid against this attribute if it is a valid URI, according to <a href="#RFC3986" class="xref">[RFC3986]</a>.  </dd>
+<dt>uri-reference:</dt>
+<dd style="margin-left: 8">A string instance is valid against this attribute if it is a valid URI Reference (either a URI or a relative-reference), according to <a href="#RFC3986" class="xref">[RFC3986]</a>.  </dd>
+<dt>iri:</dt>
+<dd style="margin-left: 8">A string instance is valid against this attribute if it is a valid IRI, according to <a href="#RFC3987" class="xref">[RFC3987]</a>.  </dd>
+<dt>iri-reference:</dt>
+<dd style="margin-left: 8">A string instance is valid against this attribute if it is a valid IRI Reference (either an IRI or a relative-reference), according to <a href="#RFC3987" class="xref">[RFC3987]</a>.  </dd>
+<dt>uuid:</dt>
+<dd style="margin-left: 8">A string instance is valid against this attribute if it is a valid string representation of a UUID, according to <a href="#RFC4122" class="xref">[RFC4122]</a>.  </dd>
+</dl>
+
+<p> </p>
+<p id="rfc.section.7.3.5.p.3">Note that all valid URIs are valid IRIs, and all valid URI References are also valid IRI References.  </p>
+<p id="rfc.section.7.3.5.p.4">Note also that the "uuid" format is for plain UUIDs, not UUIDs in URNs.  An example is "f81d4fae-7dec-11d0-a765-00a0c91e6bf6".  For UUIDs as URNs, use the "uri" format, with a "pattern" regular expression of "^urn:uuid:" to indicate the URI scheme and URN namespace.  </p>
+<h1 id="rfc.section.7.3.6">
+<a href="#rfc.section.7.3.6">7.3.6.</a> uri-template</h1>
+<p id="rfc.section.7.3.6.p.1">This attribute applies to string instances.  </p>
+<p id="rfc.section.7.3.6.p.2">A string instance is valid against this attribute if it is a valid URI Template (of any level), according to <a href="#RFC6570" class="xref">[RFC6570]</a>.  </p>
+<p id="rfc.section.7.3.6.p.3">Note that URI Templates may be used for IRIs; there is no separate IRI Template specification.  </p>
+<h1 id="rfc.section.7.3.7">
+<a href="#rfc.section.7.3.7">7.3.7.</a> JSON Pointers</h1>
+<p id="rfc.section.7.3.7.p.1">These attributes apply to string instances.  </p>
+<p></p>
+
+<dl>
+<dt>json-pointer:</dt>
+<dd style="margin-left: 8">A string instance is valid against this attribute if it is a valid JSON string representation of a JSON Pointer, according to <a href="#RFC6901" class="xref">RFC 6901, section 5</a>.  </dd>
+<dt>relative-json-pointer:</dt>
+<dd style="margin-left: 8">A string instance is valid against this attribute if it is a valid <a href="#relative-json-pointer" class="xref">Relative JSON Pointer</a>.  </dd>
+</dl>
+
+<p> To allow for both absolute and relative JSON Pointers, use "anyOf" or "oneOf" to indicate support for either format.  </p>
+<h1 id="rfc.section.7.3.8">
+<a href="#rfc.section.7.3.8">7.3.8.</a> regex</h1>
+<p id="rfc.section.7.3.8.p.1">This attribute applies to string instances.  </p>
+<p id="rfc.section.7.3.8.p.2">A regular expression, which SHOULD be valid according to the <a href="#ecma262" class="xref">ECMA 262</a> regular expression dialect.  </p>
+<p id="rfc.section.7.3.8.p.3">Implementations that validate formats MUST accept at least the subset of ECMA 262 defined in the <a href="#regexInterop" class="xref">Regular Expressions</a> section of this specification, and SHOULD accept all valid ECMA 262 expressions.  </p>
+<h1 id="rfc.section.8">
+<a href="#rfc.section.8">8.</a> <a href="#content" id="content">A Vocabulary for the Contents of String-Encoded Data</a>
+</h1>
+<h1 id="rfc.section.8.1">
+<a href="#rfc.section.8.1">8.1.</a> Foreword</h1>
+<p id="rfc.section.8.1.p.1">Properties defined in this section indicate that an instance contains non-JSON data encoded in a JSON string.  They describe the type of content and how it is encoded.  </p>
+<p id="rfc.section.8.1.p.2">These properties provide additional information required to interpret JSON data as rich multimedia documents.  </p>
+<p id="rfc.section.8.1.p.3">Meta-schemas that do not use "$vocabulary" SHOULD be considered to require this vocabulary as if its URI were present with a value of true, although see the Implementation Requirements below for details.  </p>
+<p id="rfc.section.8.1.p.4">The current URI for this vocabulary, known as the Content vocabulary, is: <span>&lt;</span><a href="https://json-schema.org/draft/2019-04/vocab/content">https://json-schema.org/draft/2019-04/vocab/content</a><span>&gt;</span>.  </p>
+<p id="rfc.section.8.1.p.5">The current URI for the corresponding meta-schema is: <span>&lt;</span><a href="https://json-schema.org/draft/2019-04/meta/content">https://json-schema.org/draft/2019-04/meta/content</a><span>&gt;</span>.  </p>
+<h1 id="rfc.section.8.2">
+<a href="#rfc.section.8.2">8.2.</a> Implementation Requirements</h1>
+<p id="rfc.section.8.2.p.1">The content keywords function as both annotations and as assertions.  While no special effort is required to implement them as annotations conveying how applications can interpret the data in the string, implementing validation of conformance to the media type and encoding is non-trivial.  </p>
+<p id="rfc.section.8.2.p.2">Implementations MAY support the "contentMediaType" and "contentEncoding" keywords as validation assertions.  Should they choose to do so, they SHOULD offer an option to disable validation for these keywords.  </p>
+<h1 id="rfc.section.8.3">
+<a href="#rfc.section.8.3">8.3.</a> contentEncoding</h1>
+<p id="rfc.section.8.3.p.1">If the instance value is a string, this property defines that the string SHOULD be interpreted as binary data and decoded using the encoding named by this property.  </p>
+<p id="rfc.section.8.3.p.2">Possible values for this property are listed in <a href="#RFC2045" class="xref">RFC 2045, Sec 6.1</a> and <a href="#RFC4648" class="xref">RFC 4648</a>.  For "base64", which is defined in both RFCs, the definition in RFC 4648, which removes line length limitations, SHOULD be used, as various other specifications have mandated different lengths.  Note that line lengths within a string can be constrained using the <a href="#pattern" class="xref">"pattern"</a> keyword.  </p>
+<p id="rfc.section.8.3.p.3">If this keyword is absent, but "contentMediaType" is present, this indicates that the media type could be encoded into UTF-8 like any other JSON string value, and does not require additional decoding.  </p>
+<p id="rfc.section.8.3.p.4">The value of this property MUST be a string.  </p>
+<p id="rfc.section.8.3.p.5">The value of this property SHOULD be ignored if the instance described is not a string.  </p>
+<h1 id="rfc.section.8.4">
+<a href="#rfc.section.8.4">8.4.</a> contentMediaType</h1>
+<p id="rfc.section.8.4.p.1">If the instance is a string, this property defines the media type of the contents of the string.  If "contentEncoding" is present, this property describes the decoded string.  </p>
+<p id="rfc.section.8.4.p.2">The value of this property MUST be a string, which MUST be a media type, as defined by <a href="#RFC2046" class="xref">RFC 2046</a>.  </p>
+<p id="rfc.section.8.4.p.3">The value of this property SHOULD be ignored if the instance described is not a string.  </p>
+<h1 id="rfc.section.8.5">
+<a href="#rfc.section.8.5">8.5.</a> contentSchema</h1>
+<p id="rfc.section.8.5.p.1">If the instance is a string, and if "contentMediaType" is present, this property contains a schema which describes the structure of the string.  </p>
+<p id="rfc.section.8.5.p.2">This keyword MAY be used with any media type that can be mapped into JSON Schema's data model.  </p>
+<p id="rfc.section.8.5.p.3">The value of this property SHOULD be ignored if the instance described is not a string, or if "contentMediaType" is not present.  </p>
+<h1 id="rfc.section.8.6">
+<a href="#rfc.section.8.6">8.6.</a> Example</h1>
+<p>Here is an example schema, illustrating the use of "contentEncoding" and "contentMediaType": </p>
+<pre>
+
+{
+    "type": "string",
+    "contentEncoding": "base64",
+    "contentMediaType": "image/png"
+}
+
+                    </pre>
+<p>Instances described by this schema should be strings, and their values should be interpretable as base64-encoded PNG images.  </p>
+<p>Another example: </p>
+<pre>
+
+{
+    "type": "string",
+    "contentMediaType": "text/html"
+}
+
+                    </pre>
+<p>Instances described by this schema should be strings containing HTML, using whatever character set the JSON string was decoded into.  Per section 8.1 of <a href="#RFC8259" class="xref">RFC 8259</a>, outside of an entirely closed system, this MUST be UTF-8.  </p>
+<p>This example describes a JWT that is MACed using the HMAC SHA-256 algorithm, and requires the "iss" and "exp" fields in its claim set.  </p>
+<pre>
+
+{
+    "type": "string",
+    "contentMediaType": "application/jwt",
+    "contentSchema": {
+        "type": "array",
+        "minItems": 2,
+        "items": [
+            {
+                "const": {
+                    "typ": "JWT",
+                    "alg": "HS256"
+                }
+            },
+            {
+                "type": "object",
+                "required": ["iss", "exp"],
+                "properties": {
+                    "iss": {"type": "string"},
+                    "exp": {"type": "integer"}
+                }
+            }
+        ]
+    }
+}
+                    </pre>
+<p>Note that "contentEncoding" does not appear.  While the "application/jwt" media type makes use of base64url encoding, that is defined by the media type, which determines how the JWT string is decoded into a list of two JSON data structures: first the header, and then the payload.  Since the JWT media type ensures that the JWT can be represented in a JSON string, there is no need for further encoding or decoding.  </p>
+<h1 id="rfc.section.9">
+<a href="#rfc.section.9">9.</a> A Vocabulary for Basic Meta-Data Annotations</h1>
+<p id="rfc.section.9.p.1">These general-purpose annotation keywords provide commonly used information for documentation and user interface display purposes.  They are not intended to form a comprehensive set of features.  Rather, additional vocabularies can be defined for more complex annotation-based applications.  </p>
+<p id="rfc.section.9.p.2">Meta-schemas that do not use "$vocabulary" SHOULD be considered to require this vocabulary as if its URI were present with a value of true.  </p>
+<p id="rfc.section.9.p.3">The current URI for this vocabulary, known as the Meta-Data vocabulary, is: <span>&lt;</span><a href="https://json-schema.org/draft/2019-04/vocab/meta-data">https://json-schema.org/draft/2019-04/vocab/meta-data</a><span>&gt;</span>.  </p>
+<p id="rfc.section.9.p.4">The current URI for the corresponding meta-schema is: <span>&lt;</span><a href="https://json-schema.org/draft/2019-04/meta/meta-data">https://json-schema.org/draft/2019-04/meta/meta-data</a><span>&gt;</span>.  </p>
+<h1 id="rfc.section.9.1">
+<a href="#rfc.section.9.1">9.1.</a> "title" and "description"</h1>
+<p id="rfc.section.9.1.p.1">The value of both of these keywords MUST be a string.  </p>
+<p id="rfc.section.9.1.p.2">Both of these keywords can be used to decorate a user interface with information about the data produced by this user interface. A title will preferably be short, whereas a description will provide explanation about the purpose of the instance described by this schema.  </p>
+<h1 id="rfc.section.9.2">
+<a href="#rfc.section.9.2">9.2.</a> "default"</h1>
+<p id="rfc.section.9.2.p.1">There are no restrictions placed on the value of this keyword.  When multiple occurrences of this keyword are applicable to a single sub-instance, implementations SHOULD remove duplicates.  </p>
+<p id="rfc.section.9.2.p.2">This keyword can be used to supply a default JSON value associated with a particular schema. It is RECOMMENDED that a default value be valid against the associated schema.  </p>
+<h1 id="rfc.section.9.3">
+<a href="#rfc.section.9.3">9.3.</a> "deprecated"</h1>
+<p id="rfc.section.9.3.p.1">The value of this keyword MUST be a boolean.  When multiple occurrences of this keyword are applicable to a single sub-instance, the resulting value MUST be true if any occurrence specifies a true value, and MUST be false otherwise.  </p>
+<p id="rfc.section.9.3.p.2">If "deprecated" has a value of boolean true, it indicates that applications SHOULD refrain from usage of the declared property. It MAY mean the property is going to be removed in the future.  </p>
+<p id="rfc.section.9.3.p.3">A root schema containing "deprecated" with a value of true indicates the entire root schema MAY be removed in the future.  </p>
+<p id="rfc.section.9.3.p.4">Omitting this keyword has the same behavior as a value of false.  </p>
+<h1 id="rfc.section.9.4">
+<a href="#rfc.section.9.4">9.4.</a> "readOnly" and "writeOnly"</h1>
+<p id="rfc.section.9.4.p.1">The value of these keywords MUST be a boolean.  When multiple occurrences of these keywords are applicable to a single sub-instance, the resulting value MUST be true if any occurrence specifies a true value, and MUST be false otherwise.  </p>
+<p id="rfc.section.9.4.p.2">If "readOnly" has a value of boolean true, it indicates that the value of the instance is managed exclusively by the owning authority, and attempts by an application to modify the value of this property are expected to be ignored or rejected by that owning authority.  </p>
+<p id="rfc.section.9.4.p.3">An instance document that is marked as "readOnly for the entire document MAY be ignored if sent to the owning authority, or MAY result in an error, at the authority's discretion.  </p>
+<p id="rfc.section.9.4.p.4">If "writeOnly" has a value of boolean true, it indicates that the value is never present when the instance is retrieved from the owning authority.  It can be present when sent to the owning authority to update or create the document (or the resource it represents), but it will not be included in any updated or newly created version of the instance.  </p>
+<p id="rfc.section.9.4.p.5">An instance document that is marked as "writeOnly" for the entire document MAY be returned as a blank document of some sort, or MAY produce an error upon retrieval, or have the retrieval request ignored, at the authority's discretion.  </p>
+<p id="rfc.section.9.4.p.6">For example, "readOnly" would be used to mark a database-generated serial number as read-only, while "writeOnly" would be used to mark a password input field.  </p>
+<p id="rfc.section.9.4.p.7">These keywords can be used to assist in user interface instance generation.  In particular, an application MAY choose to use a widget that hides input values as they are typed for write-only fields.  </p>
+<p id="rfc.section.9.4.p.8">Omitting these keywords has the same behavior as values of false.  </p>
+<h1 id="rfc.section.9.5">
+<a href="#rfc.section.9.5">9.5.</a> "examples"</h1>
+<p id="rfc.section.9.5.p.1">The value of this keyword MUST be an array.  There are no restrictions placed on the values within the array.  When multiple occurrences of this keyword are applicable to a single sub-instance, implementations MUST provide a flat array of all values rather than an array of arrays.  </p>
+<p id="rfc.section.9.5.p.2">This keyword can be used to provide sample JSON values associated with a particular schema, for the purpose of illustrating usage.  It is RECOMMENDED that these values be valid against the associated schema.  </p>
+<p id="rfc.section.9.5.p.3">Implementations MAY use the value(s) of "default", if present, as an additional example.  If "examples" is absent, "default" MAY still be used in this manner.  </p>
+<h1 id="rfc.section.10">
+<a href="#rfc.section.10">10.</a> Security Considerations</h1>
+<p id="rfc.section.10.p.1">JSON Schema validation defines a vocabulary for JSON Schema core and concerns all the security considerations listed there.  </p>
+<p id="rfc.section.10.p.2">JSON Schema validation allows the use of Regular Expressions, which have numerous different (often incompatible) implementations.  Some implementations allow the embedding of arbitrary code, which is outside the scope of JSON Schema and MUST NOT be permitted.  Regular expressions can often also be crafted to be extremely expensive to compute (with so-called "catastrophic backtracking"), resulting in a denial-of-service attack.  </p>
+<p id="rfc.section.10.p.3">Implementations that support validating or otherwise evaluating instance string data based on "contentEncoding" and/or "contentMediaType" are at risk of evaluating data in an unsafe way based on misleading information.  Applications can mitigate this risk by only performing such processing when a relationship between the schema and instance is established (e.g., they share the same authority).  </p>
+<p id="rfc.section.10.p.4">Processing a media type or encoding is subject to the security considerations of that media type or encoding.  For example, the security considerations of <a href="#RFC4329" class="xref">RFC 4329 Scripting Media Types</a> apply when processing JavaScript or ECMAScript encoded within a JSON string.  </p>
+<h1 id="rfc.references">
+<a href="#rfc.references">11.</a> References</h1>
+<h1 id="rfc.references.1">
+<a href="#rfc.references.1">11.1.</a> Normative References</h1>
+<table><tbody>
+<tr>
+<td class="reference"><b id="ecma262">[ecma262]</b></td>
+<td class="top">"<a href="http://www.ecma-international.org/publications/files/ECMA-ST/Ecma-262.pdf">ECMA 262 specification</a>"</td>
+</tr>
+<tr>
+<td class="reference"><b id="json-schema">[json-schema]</b></td>
+<td class="top">
+<a>Wright, A.</a> and <a>H. Andrews</a>, "<a href="https://tools.ietf.org/html/draft-handrews-json-schema-02">JSON Schema: A Media Type for Describing JSON Documents</a>", Internet-Draft draft-handrews-json-schema-02, November 2017.</td>
+</tr>
+<tr>
+<td class="reference"><b id="relative-json-pointer">[relative-json-pointer]</b></td>
+<td class="top">
+<a>Luff, G.</a> and <a title="Cloudflare, Inc.">H. Andrews</a>, "<a href="https://tools.ietf.org/html/draft-handrews-relative-json-pointer-01">Relative JSON Pointers</a>", Internet-Draft draft-handrews-relative-json-pointer-01, November 2017.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC1123">[RFC1123]</b></td>
+<td class="top">
+<a>Braden, R.</a>, "<a href="https://tools.ietf.org/html/rfc1123">Requirements for Internet Hosts - Application and Support</a>", STD 3, RFC 1123, DOI 10.17487/RFC1123, October 1989.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC2045">[RFC2045]</b></td>
+<td class="top">
+<a>Freed, N.</a> and <a>N. Borenstein</a>, "<a href="https://tools.ietf.org/html/rfc2045">Multipurpose Internet Mail Extensions (MIME) Part One: Format of Internet Message Bodies</a>", RFC 2045, DOI 10.17487/RFC2045, November 1996.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC2046">[RFC2046]</b></td>
+<td class="top">
+<a>Freed, N.</a> and <a>N. Borenstein</a>, "<a href="https://tools.ietf.org/html/rfc2046">Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types</a>", RFC 2046, DOI 10.17487/RFC2046, November 1996.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC2119">[RFC2119]</b></td>
+<td class="top">
+<a>Bradner, S.</a>, "<a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>", BCP 14, RFC 2119, DOI 10.17487/RFC2119, March 1997.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC2673">[RFC2673]</b></td>
+<td class="top">
+<a>Crawford, M.</a>, "<a href="https://tools.ietf.org/html/rfc2673">Binary Labels in the Domain Name System</a>", RFC 2673, DOI 10.17487/RFC2673, August 1999.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC3339">[RFC3339]</b></td>
+<td class="top">
+<a>Klyne, G.</a> and <a>C. Newman</a>, "<a href="https://tools.ietf.org/html/rfc3339">Date and Time on the Internet: Timestamps</a>", RFC 3339, DOI 10.17487/RFC3339, July 2002.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC3986">[RFC3986]</b></td>
+<td class="top">
+<a>Berners-Lee, T.</a>, <a>Fielding, R.</a> and <a>L. Masinter</a>, "<a href="https://tools.ietf.org/html/rfc3986">Uniform Resource Identifier (URI): Generic Syntax</a>", STD 66, RFC 3986, DOI 10.17487/RFC3986, January 2005.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC3987">[RFC3987]</b></td>
+<td class="top">
+<a>Duerst, M.</a> and <a>M. Suignard</a>, "<a href="https://tools.ietf.org/html/rfc3987">Internationalized Resource Identifiers (IRIs)</a>", RFC 3987, DOI 10.17487/RFC3987, January 2005.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC4122">[RFC4122]</b></td>
+<td class="top">
+<a>Leach, P.</a>, <a>Mealling, M.</a> and <a>R. Salz</a>, "<a href="https://tools.ietf.org/html/rfc4122">A Universally Unique IDentifier (UUID) URN Namespace</a>", RFC 4122, DOI 10.17487/RFC4122, July 2005.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC4291">[RFC4291]</b></td>
+<td class="top">
+<a>Hinden, R.</a> and <a>S. Deering</a>, "<a href="https://tools.ietf.org/html/rfc4291">IP Version 6 Addressing Architecture</a>", RFC 4291, DOI 10.17487/RFC4291, February 2006.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC4648">[RFC4648]</b></td>
+<td class="top">
+<a>Josefsson, S.</a>, "<a href="https://tools.ietf.org/html/rfc4648">The Base16, Base32, and Base64 Data Encodings</a>", RFC 4648, DOI 10.17487/RFC4648, October 2006.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC5322">[RFC5322]</b></td>
+<td class="top">
+<a>Resnick, P.</a>, "<a href="https://tools.ietf.org/html/rfc5322">Internet Message Format</a>", RFC 5322, DOI 10.17487/RFC5322, October 2008.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC5890">[RFC5890]</b></td>
+<td class="top">
+<a>Klensin, J.</a>, "<a href="https://tools.ietf.org/html/rfc5890">Internationalized Domain Names for Applications (IDNA): Definitions and Document Framework</a>", RFC 5890, DOI 10.17487/RFC5890, August 2010.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC5891">[RFC5891]</b></td>
+<td class="top">
+<a>Klensin, J.</a>, "<a href="https://tools.ietf.org/html/rfc5891">Internationalized Domain Names in Applications (IDNA): Protocol</a>", RFC 5891, DOI 10.17487/RFC5891, August 2010.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC6531">[RFC6531]</b></td>
+<td class="top">
+<a>Yao, J.</a> and <a>W. Mao</a>, "<a href="https://tools.ietf.org/html/rfc6531">SMTP Extension for Internationalized Email</a>", RFC 6531, DOI 10.17487/RFC6531, February 2012.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC6570">[RFC6570]</b></td>
+<td class="top">
+<a>Gregorio, J.</a>, <a>Fielding, R.</a>, <a>Hadley, M.</a>, <a>Nottingham, M.</a> and <a>D. Orchard</a>, "<a href="https://tools.ietf.org/html/rfc6570">URI Template</a>", RFC 6570, DOI 10.17487/RFC6570, March 2012.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC6901">[RFC6901]</b></td>
+<td class="top">
+<a>Bryan, P.</a>, <a>Zyp, K.</a> and <a>M. Nottingham</a>, "<a href="https://tools.ietf.org/html/rfc6901">JavaScript Object Notation (JSON) Pointer</a>", RFC 6901, DOI 10.17487/RFC6901, April 2013.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC8259">[RFC8259]</b></td>
+<td class="top">
+<a>Bray, T.</a>, "<a href="https://tools.ietf.org/html/rfc8259">The JavaScript Object Notation (JSON) Data Interchange Format</a>", STD 90, RFC 8259, DOI 10.17487/RFC8259, December 2017.</td>
+</tr>
+</tbody></table>
+<h1 id="rfc.references.2">
+<a href="#rfc.references.2">11.2.</a> Informative References</h1>
+<table><tbody><tr>
+<td class="reference"><b id="RFC4329">[RFC4329]</b></td>
+<td class="top">
+<a>Hoehrmann, B.</a>, "<a href="https://tools.ietf.org/html/rfc4329">Scripting Media Types</a>", RFC 4329, DOI 10.17487/RFC4329, April 2006.</td>
+</tr></tbody></table>
+<h1 id="rfc.appendix.A">
+<a href="#rfc.appendix.A">Appendix A.</a> Keywords Moved from Validation to Core</h1>
+<p id="rfc.section.A.p.1">Several keywords have been moved from this document into the <a href="#json-schema" class="xref">Core Specification</a> as of this draft, in some cases with re-naming or other changes.  This affects the following former validation keywords: </p>
+
+<dl>
+<dt>"definitions"</dt>
+<dd style="margin-left: 8">Renamed to "$defs" to match "$ref" and be shorter to type.  Schema vocabulary authors SHOULD NOT define a "definitions" keyword with different behavior in order to avoid invalidating schemas that still use the older name.  </dd>
+<dt>"allOf", "anyOf", "oneOf", "not", "if", "then", "else",                                  "items", "additionalItems", "contains", "propertyNames",                                  "properties", "patternProperties", "additionalProperties"</dt>
+<dd style="margin-left: 8">All of these keywords apply subschemas to the instance and combine their results, without asserting any conditions of their own.  Without assertion keywords, these applicators can only cause assertion failures by using the false boolean schema, or by inverting the result of the true boolean schema.  For this reason, they are better defined as a generic mechanism on which validation, hyper-schema, and extension vocabularies can all be based </dd>
+<dt>"dependencies"</dt>
+<dd style="margin-left: 8">This keyword had two different modes of behavior, which made it relatively challenging to implement and reason about.  The schema form has been moved to Core and renamed to "dependentSchemas", as part of the applicator vocabulary.  It is analogous to "properties", except that instead of applying its subschema to the property value, it applies it to the object containing the property.  The property name array form is retained here and renamed to "dependentRequired", as it is an assertion which is a shortcut for the conditional use of the "required" assertion keyword.  </dd>
+</dl>
+
+<p> </p>
+<h1 id="rfc.appendix.B">
+<a href="#rfc.appendix.B">Appendix B.</a> Acknowledgments</h1>
+<p id="rfc.section.B.p.1">Thanks to Gary Court, Francis Galiegue, Kris Zyp, and Geraint Luff for their work on the initial drafts of JSON Schema.  </p>
+<p id="rfc.section.B.p.2">Thanks to Jason Desrosiers, Daniel Perrett, Erik Wilde, Ben Hutton, Evgeny Poberezkin, Brad Bowman, Gowry Sankar, Donald Pipowitch, Dave Finlay, and Denis Laxalde for their submissions and patches to the document.  </p>
+<h1 id="rfc.appendix.C">
+<a href="#rfc.appendix.C">Appendix C.</a> ChangeLog</h1>
+<p><a id="CREF2" class="info">[CREF2]<span class="info">This section to be removed before leaving Internet-Draft status.</span></a> </p>
+<p></p>
+
+<dl>
+<dt>draft-handrews-json-schema-validation-02</dt>
+<dd style="margin-left: 8">
+<ul>
+<li>Moved "definitions" to the core spec as "$defs"</li>
+<li>Moved applicator keywords to the core spec</li>
+<li>Renamed the array form of "dependencies" to "dependentRequired", moved the schema form to the core spec</li>
+<li>Added "contentSchema" to allow applying a schema to a string-encoded document</li>
+<li>Also allow RFC 4648 encodings in "contentEncoding"</li>
+<li>Added "minContains" and "maxContains"</li>
+<li>Update RFC reference for "hostname" and "idn-hostname"</li>
+<li>Add "uuid" and "duration" formats</li>
+</ul>
+<p> </p>
+</dd>
+<dt>draft-handrews-json-schema-validation-01</dt>
+<dd style="margin-left: 8">
+<ul>
+<li>This draft is purely a clarification with no functional changes</li>
+<li>Provided the general principle behind ignoring annotations under "not" and similar cases</li>
+<li>Clarified "if"/"then"/"else" validation interactions</li>
+<li>Clarified "if"/"then"/"else" behavior for annotation</li>
+<li>Minor formatting and cross-referencing improvements</li>
+</ul>
+<p> </p>
+</dd>
+<dt>draft-handrews-json-schema-validation-00</dt>
+<dd style="margin-left: 8">
+<ul>
+<li>Added "if"/"then"/"else"</li>
+<li>Classify keywords as assertions or annotations per the core spec</li>
+<li>Warn of possibly removing "dependencies" in the future</li>
+<li>Grouped validation keywords into sub-sections for readability</li>
+<li>Moved "readOnly" from hyper-schema to validation meta-data</li>
+<li>Added "writeOnly"</li>
+<li>Added string-encoded media section, with former hyper-schema "media" keywords</li>
+<li>Restored "regex" format (removal was unintentional)</li>
+<li>Added "date" and "time" formats, and reserved additional RFC 3339 format names</li>
+<li>I18N formats: "iri", "iri-reference", "idn-hostname", "idn-email"</li>
+<li>Clarify that "json-pointer" format means string encoding, not URI fragment</li>
+<li>Fixed typo that inverted the meaning of "minimum" and "exclusiveMinimum"</li>
+<li>Move format syntax references into Normative References</li>
+<li>JSON is a normative requirement</li>
+</ul>
+<p> </p>
+</dd>
+<dt>draft-wright-json-schema-validation-01</dt>
+<dd style="margin-left: 8">
+<ul>
+<li>Standardized on hyphenated format names with full words ("uriref" becomes "uri-reference")</li>
+<li>Add the formats "uri-template" and "json-pointer"</li>
+<li>Changed "exclusiveMaximum"/"exclusiveMinimum" from boolean modifiers of "maximum"/"minimum" to independent numeric fields.</li>
+<li>Split the additionalItems/items into two sections</li>
+<li>Reworked properties/patternProperties/additionalProperties definition</li>
+<li>Added "examples" keyword</li>
+<li>Added "contains" keyword</li>
+<li>Allow empty "required" and "dependencies" arrays</li>
+<li>Fixed "type" reference to primitive types</li>
+<li>Added "const" keyword</li>
+<li>Added "propertyNames" keyword</li>
+</ul>
+<p> </p>
+</dd>
+<dt>draft-wright-json-schema-validation-00</dt>
+<dd style="margin-left: 8">
+<ul>
+<li>Added additional security considerations</li>
+<li>Removed reference to "latest version" meta-schema, use numbered version instead</li>
+<li>Rephrased many keyword definitions for brevity</li>
+<li>Added "uriref" format that also allows relative URI references</li>
+</ul>
+<p> </p>
+</dd>
+<dt>draft-fge-json-schema-validation-00</dt>
+<dd style="margin-left: 8">
+<ul>
+<li>Initial draft.</li>
+<li>Salvaged from draft v3.</li>
+<li>Redefine the "required" keyword.</li>
+<li>Remove "extends", "disallow"</li>
+<li>Add "anyOf", "allOf", "oneOf", "not", "definitions", "minProperties", "maxProperties".</li>
+<li>"dependencies" member values can no longer be single strings; at least one element is required in a property dependency array.</li>
+<li>Rename "divisibleBy" to "multipleOf".</li>
+<li>"type" arrays can no longer have schemas; remove "any" as a possible value.</li>
+<li>Rework the "format" section; make support optional.</li>
+<li>"format": remove attributes "phone", "style", "color"; rename "ip-address" to "ipv4"; add references for all attributes.</li>
+<li>Provide algorithms to calculate schema(s) for array/object instances.</li>
+<li>Add interoperability considerations.</li>
+</ul>
+<p> </p>
+</dd>
+</dl>
+
+<p> </p>
+<h1 id="rfc.authors"><a href="#rfc.authors">Authors' Addresses</a></h1>
+<div class="avoidbreak">
+  <address class="vcard">
+	<span class="vcardline">
+	  <span class="fn">Austin Wright</span> (editor)
+	  <span class="n hidden">
+		<span class="family-name">Wright</span>
+	  </span>
+	</span>
+	<span class="org vcardline"></span>
+	<span class="adr">
+	  
+	  <span class="vcardline">
+		<span class="locality"></span> 
+		<span class="region"></span>
+		<span class="code"></span>
+	  </span>
+	  <span class="country-name vcardline"></span>
+	</span>
+	<span class="vcardline">EMail: <a href="mailto:aaa@bzfx.net">aaa@bzfx.net</a></span>
+
+  </address>
+</div><div class="avoidbreak">
+  <address class="vcard">
+	<span class="vcardline">
+	  <span class="fn">Henry Andrews</span> (editor)
+	  <span class="n hidden">
+		<span class="family-name">Andrews</span>
+	  </span>
+	</span>
+	<span class="org vcardline">Riverbed Technology</span>
+	<span class="adr">
+	  <span class="vcardline">680 Folsom St.</span>
+
+	  <span class="vcardline">
+		<span class="locality">San Francisco</span>,  
+		<span class="region">CA</span> 
+		<span class="code"></span>
+	  </span>
+	  <span class="country-name vcardline">USA</span>
+	</span>
+	<span class="vcardline">EMail: <a href="mailto:handrews@riverbed.com">handrews@riverbed.com</a></span>
+
+  </address>
+</div><div class="avoidbreak">
+  <address class="vcard">
+	<span class="vcardline">
+	  <span class="fn">Ben Hutton</span> (editor)
+	  <span class="n hidden">
+		<span class="family-name">Hutton</span>
+	  </span>
+	</span>
+	<span class="org vcardline">Wellcome Sanger Institute</span>
+	<span class="adr">
+	  
+	  <span class="vcardline">
+		<span class="locality"></span> 
+		<span class="region"></span>
+		<span class="code"></span>
+	  </span>
+	  <span class="country-name vcardline"></span>
+	</span>
+	<span class="vcardline">EMail: <a href="mailto:bh7@sanger.ac.uk">bh7@sanger.ac.uk</a></span>
+
+  </address>
+</div><div class="avoidbreak">
+  <address class="vcard">
+	<span class="vcardline">
+	  <span class="fn">Geraint Luff</span> 
+	  <span class="n hidden">
+		<span class="family-name">Luff</span>
+	  </span>
+	</span>
+	<span class="org vcardline"></span>
+	<span class="adr">
+	  
+	  <span class="vcardline">
+		<span class="locality">Cambridge</span>,  
+		<span class="region"></span>
+		<span class="code"></span>
+	  </span>
+	  <span class="country-name vcardline">UK</span>
+	</span>
+	<span class="vcardline">EMail: <a href="mailto:luffgd@gmail.com">luffgd@gmail.com</a></span>
+
+  </address>
+</div>
+
+</body>
+</html>

--- a/work-in-progress/WIP-jsonschema-validation.html
+++ b/work-in-progress/WIP-jsonschema-validation.html
@@ -447,7 +447,7 @@
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Wright, A., Ed., Andrews, H., Ed., Hutton, B., Ed., and G. Luff" />
-  <meta name="dct.identifier" content="urn:ietf:id:draft-handrews-json-schema-validation-02" />
+  <meta name="dct.identifier" content="urn:ietf:id:draft-handrews-json-schema-validation-WIP" />
   <meta name="dct.issued" scheme="ISO8601" content="2019-25" />
   <meta name="dct.abstract" content="JSON Schema (application/schema+json) has several purposes, one of which is JSON instance validation.  This document specifies a vocabulary for JSON Schema to describe the meaning of JSON documents, provide hints for user interfaces working with JSON data, and to make assertions about what a valid document must look like.  " />
   <meta name="description" content="JSON Schema (application/schema+json) has several purposes, one of which is JSON instance validation.  This document specifies a vocabulary for JSON Schema to describe the meaning of JSON documents, provide hints for user interfaces working with JSON data, and to make assertions about what a valid document must look like.  " />
@@ -497,7 +497,7 @@
   </table>
 
   <p class="title">JSON Schema Validation: A Vocabulary for Structural Validation of JSON <br />
-  <span class="filename">draft-handrews-json-schema-validation-02</span></p>
+  <span class="filename">draft-handrews-json-schema-validation-WIP</span></p>
   
   <h1 id="rfc.abstract"><a href="#rfc.abstract">Abstract</a></h1>
 <p>JSON Schema (application/schema+json) has several purposes, one of which is JSON instance validation.  This document specifies a vocabulary for JSON Schema to describe the meaning of JSON documents, provide hints for user interfaces working with JSON data, and to make assertions about what a valid document must look like.  </p>
@@ -1066,7 +1066,7 @@
 <tr>
 <td class="reference"><b id="json-schema">[json-schema]</b></td>
 <td class="top">
-<a>Wright, A.</a> and <a>H. Andrews</a>, "<a href="https://tools.ietf.org/html/draft-handrews-json-schema-02">JSON Schema: A Media Type for Describing JSON Documents</a>", Internet-Draft draft-handrews-json-schema-02, November 2017.</td>
+<a>Wright, A.</a> and <a>H. Andrews</a>, "<a href="https://tools.ietf.org/html/draft-handrews-json-schema-02">JSON Schema: A Media Type for Describing JSON Documents</a>", Internet-Draft draft-handrews-json-schema-WIP, November 2017.</td>
 </tr>
 <tr>
 <td class="reference"><b id="relative-json-pointer">[relative-json-pointer]</b></td>
@@ -1195,7 +1195,7 @@
 <p></p>
 
 <dl>
-<dt>draft-handrews-json-schema-validation-02</dt>
+<dt>draft-handrews-json-schema-validation-WIP</dt>
 <dd style="margin-left: 8">
 <ul>
 <li>Moved "definitions" to the core spec as "$defs"</li>

--- a/work-in-progress/WIP-jsonschema-validation.txt
+++ b/work-in-progress/WIP-jsonschema-validation.txt
@@ -1,0 +1,1512 @@
+
+
+
+
+Internet Engineering Task Force                           A. Wright, Ed.
+Internet-Draft
+Intended status: Informational                           H. Andrews, Ed.
+Expires: November 26, 2019                           Riverbed Technology
+                                                          B. Hutton, Ed.
+                                               Wellcome Sanger Institute
+                                                                 G. Luff
+                                                            May 25, 2019
+
+
+ JSON Schema Validation: A Vocabulary for Structural Validation of JSON
+                draft-handrews-json-schema-validation-02
+
+Abstract
+
+   JSON Schema (application/schema+json) has several purposes, one of
+   which is JSON instance validation.  This document specifies a
+   vocabulary for JSON Schema to describe the meaning of JSON documents,
+   provide hints for user interfaces working with JSON data, and to make
+   assertions about what a valid document must look like.
+
+Note to Readers
+
+   The issues list for this draft can be found at <https://github.com/
+   json-schema-org/json-schema-spec/issues>.
+
+   For additional information, see <http://json-schema.org/>.
+
+   To provide feedback, use this issue tracker, the communication
+   methods listed on the homepage, or email the document editors.
+
+Status of This Memo
+
+   This Internet-Draft is submitted in full conformance with the
+   provisions of BCP 78 and BCP 79.
+
+   Internet-Drafts are working documents of the Internet Engineering
+   Task Force (IETF).  Note that other groups may also distribute
+   working documents as Internet-Drafts.  The list of current Internet-
+   Drafts is at https://datatracker.ietf.org/drafts/current/.
+
+   Internet-Drafts are draft documents valid for a maximum of six months
+   and may be updated, replaced, or obsoleted by other documents at any
+   time.  It is inappropriate to use Internet-Drafts as reference
+   material or to cite them other than as "work in progress."
+
+   This Internet-Draft will expire on November 26, 2019.
+
+
+
+
+Wright, et al.          Expires November 26, 2019               [Page 1]
+
+Internet-Draft           JSON Schema Validation                 May 2019
+
+
+Copyright Notice
+
+   Copyright (c) 2019 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (https://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+Table of Contents
+
+   1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   3
+   2.  Conventions and Terminology . . . . . . . . . . . . . . . . .   4
+   3.  Overview  . . . . . . . . . . . . . . . . . . . . . . . . . .   4
+   4.  Interoperability Considerations . . . . . . . . . . . . . . .   4
+     4.1.  Validation of String Instances  . . . . . . . . . . . . .   4
+     4.2.  Validation of Numeric Instances . . . . . . . . . . . . .   5
+     4.3.  Regular Expressions . . . . . . . . . . . . . . . . . . .   5
+   5.  Meta-Schema . . . . . . . . . . . . . . . . . . . . . . . . .   5
+   6.  A Vocabulary for Structural Validation  . . . . . . . . . . .   5
+     6.1.  Validation Keywords for Any Instance Type . . . . . . . .   6
+       6.1.1.  type  . . . . . . . . . . . . . . . . . . . . . . . .   6
+       6.1.2.  enum  . . . . . . . . . . . . . . . . . . . . . . . .   6
+       6.1.3.  const . . . . . . . . . . . . . . . . . . . . . . . .   6
+     6.2.  Validation Keywords for Numeric Instances (number and
+           integer)  . . . . . . . . . . . . . . . . . . . . . . . .   6
+       6.2.1.  multipleOf  . . . . . . . . . . . . . . . . . . . . .   6
+       6.2.2.  maximum . . . . . . . . . . . . . . . . . . . . . . .   7
+       6.2.3.  exclusiveMaximum  . . . . . . . . . . . . . . . . . .   7
+       6.2.4.  minimum . . . . . . . . . . . . . . . . . . . . . . .   7
+       6.2.5.  exclusiveMinimum  . . . . . . . . . . . . . . . . . .   7
+     6.3.  Validation Keywords for Strings . . . . . . . . . . . . .   7
+       6.3.1.  maxLength . . . . . . . . . . . . . . . . . . . . . .   7
+       6.3.2.  minLength . . . . . . . . . . . . . . . . . . . . . .   8
+       6.3.3.  pattern . . . . . . . . . . . . . . . . . . . . . . .   8
+     6.4.  Validation Keywords for Arrays  . . . . . . . . . . . . .   8
+       6.4.1.  maxItems  . . . . . . . . . . . . . . . . . . . . . .   8
+       6.4.2.  minItems  . . . . . . . . . . . . . . . . . . . . . .   8
+       6.4.3.  uniqueItems . . . . . . . . . . . . . . . . . . . . .   8
+       6.4.4.  maxContains . . . . . . . . . . . . . . . . . . . . .   9
+       6.4.5.  minContains . . . . . . . . . . . . . . . . . . . . .   9
+     6.5.  Validation Keywords for Objects . . . . . . . . . . . . .   9
+
+
+
+Wright, et al.          Expires November 26, 2019               [Page 2]
+
+Internet-Draft           JSON Schema Validation                 May 2019
+
+
+       6.5.1.  maxProperties . . . . . . . . . . . . . . . . . . . .   9
+       6.5.2.  minProperties . . . . . . . . . . . . . . . . . . . .   9
+       6.5.3.  required  . . . . . . . . . . . . . . . . . . . . . .  10
+       6.5.4.  dependentRequired . . . . . . . . . . . . . . . . . .  10
+   7.  A Vocabulary for Semantic Validation With "format"  . . . . .  10
+     7.1.  Foreword  . . . . . . . . . . . . . . . . . . . . . . . .  10
+     7.2.  Implementation Requirements . . . . . . . . . . . . . . .  11
+     7.3.  Defined Formats . . . . . . . . . . . . . . . . . . . . .  11
+       7.3.1.  Dates, Times, and Duration  . . . . . . . . . . . . .  11
+       7.3.2.  Email Addresses . . . . . . . . . . . . . . . . . . .  12
+       7.3.3.  Hostnames . . . . . . . . . . . . . . . . . . . . . .  12
+       7.3.4.  IP Addresses  . . . . . . . . . . . . . . . . . . . .  13
+       7.3.5.  Resource Identifiers  . . . . . . . . . . . . . . . .  13
+       7.3.6.  uri-template  . . . . . . . . . . . . . . . . . . . .  13
+       7.3.7.  JSON Pointers . . . . . . . . . . . . . . . . . . . .  14
+       7.3.8.  regex . . . . . . . . . . . . . . . . . . . . . . . .  14
+   8.  A Vocabulary for the Contents of String-Encoded Data  . . . .  14
+     8.1.  Foreword  . . . . . . . . . . . . . . . . . . . . . . . .  14
+     8.2.  Implementation Requirements . . . . . . . . . . . . . . .  15
+     8.3.  contentEncoding . . . . . . . . . . . . . . . . . . . . .  15
+     8.4.  contentMediaType  . . . . . . . . . . . . . . . . . . . .  15
+     8.5.  contentSchema . . . . . . . . . . . . . . . . . . . . . .  16
+     8.6.  Example . . . . . . . . . . . . . . . . . . . . . . . . .  16
+   9.  A Vocabulary for Basic Meta-Data Annotations  . . . . . . . .  17
+     9.1.  "title" and "description" . . . . . . . . . . . . . . . .  18
+     9.2.  "default" . . . . . . . . . . . . . . . . . . . . . . . .  18
+     9.3.  "deprecated"  . . . . . . . . . . . . . . . . . . . . . .  18
+     9.4.  "readOnly" and "writeOnly"  . . . . . . . . . . . . . . .  18
+     9.5.  "examples"  . . . . . . . . . . . . . . . . . . . . . . .  19
+   10. Security Considerations . . . . . . . . . . . . . . . . . . .  20
+   11. References  . . . . . . . . . . . . . . . . . . . . . . . . .  20
+     11.1.  Normative References . . . . . . . . . . . . . . . . . .  20
+     11.2.  Informative References . . . . . . . . . . . . . . . . .  22
+   Appendix A.  Keywords Moved from Validation to Core . . . . . . .  23
+   Appendix B.  Acknowledgments  . . . . . . . . . . . . . . . . . .  23
+   Appendix C.  ChangeLog  . . . . . . . . . . . . . . . . . . . . .  24
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  27
+
+1.  Introduction
+
+   JSON Schema can be used to require that a given JSON document (an
+   instance) satisfies a certain number of criteria.  These criteria are
+   asserted by using keywords described in this specification.  In
+   addition, a set of keywords is also defined to assist in interactive
+   user interface instance generation.
+
+   This specification will use the concepts, syntax, and terminology
+   defined by the JSON Schema core [json-schema] specification.
+
+
+
+Wright, et al.          Expires November 26, 2019               [Page 3]
+
+Internet-Draft           JSON Schema Validation                 May 2019
+
+
+2.  Conventions and Terminology
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in RFC 2119 [RFC2119].
+
+   This specification uses the term "container instance" to refer to
+   both array and object instances.  It uses the term "children
+   instances" to refer to array elements or object member values.
+
+   Elements in an array value are said to be unique if no two elements
+   of this array are equal [json-schema].
+
+3.  Overview
+
+   JSON Schema validation asserts constraints on the structure of
+   instance data.  An instance location that satisfies all asserted
+   constraints is then annotated with any keywords that contain non-
+   assertion information, such as descriptive metadata and usage hints.
+   If all locations within the instance satisfy all asserted
+   constraints, then the instance is said to be valid against the
+   schema.
+
+   Each schema object is independently evaluated against each instance
+   location to which it applies.  This greatly simplifies the
+   implementation requirements for validators by ensuring that they do
+   not need to maintain state across the document-wide validation
+   process.
+
+   This specification defines a set of assertion keywords, as well as a
+   small vocabulary of metadata keywords that can be used to annotate
+   the JSON instance with useful information.  The Section 7 and
+   Section 8 keywords are also useful as annotations as well as being
+   optional assertions, as they convey additional usage guidance for the
+   instance data.
+
+4.  Interoperability Considerations
+
+4.1.  Validation of String Instances
+
+   It should be noted that the nul character (\u0000) is valid in a JSON
+   string.  An instance to validate may contain a string value with this
+   character, regardless of the ability of the underlying programming
+   language to deal with such data.
+
+
+
+
+
+
+
+Wright, et al.          Expires November 26, 2019               [Page 4]
+
+Internet-Draft           JSON Schema Validation                 May 2019
+
+
+4.2.  Validation of Numeric Instances
+
+   The JSON specification allows numbers with arbitrary precision, and
+   JSON Schema does not add any such bounds.  This means that numeric
+   instances processed by JSON Schema can be arbitrarily large and/or
+   have an arbitrarily long decimal part, regardless of the ability of
+   the underlying programming language to deal with such data.
+
+4.3.  Regular Expressions
+
+   Keywords that use regular expressions, or constrain the instance
+   value to be a regular expression, are subject to the interoperability
+   considerations for regular expressions in the JSON Schema Core
+   [json-schema] specification.
+
+5.  Meta-Schema
+
+   The current URI for the JSON Schema Validation meta-schema is
+   <http://json-schema.org/draft/2019-04/schenma#>.  For schema author
+   convenience, this meta-schema describes all vocabularies defined in
+   this specification and the JSON Schema Core specification.
+   Individual vocabulary and vocabulary meta-schema URIs are given for
+   each section below.
+
+   Updated vocabulary and meta-schema URIs MAY be published between
+   specification drafts in order to correct errors.  Implementations
+   SHOULD consider URIs dated after this specification draft and before
+   the next to indicate the same syntax and semantics as those listed
+   here.
+
+6.  A Vocabulary for Structural Validation
+
+   Validation keywords in a schema impose requirements for successful
+   validation of an instance.  These keywords are all assertions without
+   any annotation behavior.
+
+   Meta-schemas that do not use "$vocabulary" SHOULD be considered to
+   require this vocabulary as if its URI were present with a value of
+   true.
+
+   The current URI for this vocabulary, known as the Validation
+   vocabulary, is: <https://json-schema.org/draft/2019-04/vocab/
+   validation>.
+
+   The current URI for the corresponding meta-schema is: <https://json-
+   schema.org/draft/2019-04/meta/validation>.
+
+
+
+
+
+Wright, et al.          Expires November 26, 2019               [Page 5]
+
+Internet-Draft           JSON Schema Validation                 May 2019
+
+
+6.1.  Validation Keywords for Any Instance Type
+
+6.1.1.  type
+
+   The value of this keyword MUST be either a string or an array.  If it
+   is an array, elements of the array MUST be strings and MUST be
+   unique.
+
+   String values MUST be one of the six primitive types ("null",
+   "boolean", "object", "array", "number", or "string"), or "integer"
+   which matches any number with a zero fractional part.
+
+   An instance validates if and only if the instance is in any of the
+   sets listed for this keyword.
+
+6.1.2.  enum
+
+   The value of this keyword MUST be an array.  This array SHOULD have
+   at least one element.  Elements in the array SHOULD be unique.
+
+   An instance validates successfully against this keyword if its value
+   is equal to one of the elements in this keyword's array value.
+
+   Elements in the array might be of any type, including null.
+
+6.1.3.  const
+
+   The value of this keyword MAY be of any type, including null.
+
+   Use of this keyword is functionally equivalent to an "enum"
+   (Section 6.1.2) with a single value.
+
+   An instance validates successfully against this keyword if its value
+   is equal to the value of the keyword.
+
+6.2.  Validation Keywords for Numeric Instances (number and integer)
+
+6.2.1.  multipleOf
+
+   The value of "multipleOf" MUST be a number, strictly greater than 0.
+
+   A numeric instance is valid only if division by this keyword's value
+   results in an integer.
+
+
+
+
+
+
+
+
+Wright, et al.          Expires November 26, 2019               [Page 6]
+
+Internet-Draft           JSON Schema Validation                 May 2019
+
+
+6.2.2.  maximum
+
+   The value of "maximum" MUST be a number, representing an inclusive
+   upper limit for a numeric instance.
+
+   If the instance is a number, then this keyword validates only if the
+   instance is less than or exactly equal to "maximum".
+
+6.2.3.  exclusiveMaximum
+
+   The value of "exclusiveMaximum" MUST be number, representing an
+   exclusive upper limit for a numeric instance.
+
+   If the instance is a number, then the instance is valid only if it
+   has a value strictly less than (not equal to) "exclusiveMaximum".
+
+6.2.4.  minimum
+
+   The value of "minimum" MUST be a number, representing an inclusive
+   lower limit for a numeric instance.
+
+   If the instance is a number, then this keyword validates only if the
+   instance is greater than or exactly equal to "minimum".
+
+6.2.5.  exclusiveMinimum
+
+   The value of "exclusiveMinimum" MUST be number, representing an
+   exclusive lower limit for a numeric instance.
+
+   If the instance is a number, then the instance is valid only if it
+   has a value strictly greater than (not equal to) "exclusiveMinimum".
+
+6.3.  Validation Keywords for Strings
+
+6.3.1.  maxLength
+
+   The value of this keyword MUST be a non-negative integer.
+
+   A string instance is valid against this keyword if its length is less
+   than, or equal to, the value of this keyword.
+
+   The length of a string instance is defined as the number of its
+   characters as defined by RFC 8259 [RFC8259].
+
+
+
+
+
+
+
+
+Wright, et al.          Expires November 26, 2019               [Page 7]
+
+Internet-Draft           JSON Schema Validation                 May 2019
+
+
+6.3.2.  minLength
+
+   The value of this keyword MUST be a non-negative integer.
+
+   A string instance is valid against this keyword if its length is
+   greater than, or equal to, the value of this keyword.
+
+   The length of a string instance is defined as the number of its
+   characters as defined by RFC 8259 [RFC8259].
+
+   Omitting this keyword has the same behavior as a value of 0.
+
+6.3.3.  pattern
+
+   The value of this keyword MUST be a string.  This string SHOULD be a
+   valid regular expression, according to the ECMA 262 regular
+   expression dialect.
+
+   A string instance is considered valid if the regular expression
+   matches the instance successfully.  Recall: regular expressions are
+   not implicitly anchored.
+
+6.4.  Validation Keywords for Arrays
+
+6.4.1.  maxItems
+
+   The value of this keyword MUST be a non-negative integer.
+
+   An array instance is valid against "maxItems" if its size is less
+   than, or equal to, the value of this keyword.
+
+6.4.2.  minItems
+
+   The value of this keyword MUST be a non-negative integer.
+
+   An array instance is valid against "minItems" if its size is greater
+   than, or equal to, the value of this keyword.
+
+   Omitting this keyword has the same behavior as a value of 0.
+
+6.4.3.  uniqueItems
+
+   The value of this keyword MUST be a boolean.
+
+   If this keyword has boolean value false, the instance validates
+   successfully.  If it has boolean value true, the instance validates
+   successfully if all of its elements are unique.
+
+
+
+
+Wright, et al.          Expires November 26, 2019               [Page 8]
+
+Internet-Draft           JSON Schema Validation                 May 2019
+
+
+   Omitting this keyword has the same behavior as a value of false.
+
+6.4.4.  maxContains
+
+   The value of this keyword MUST be a non-negative integer.
+
+   An array instance is valid against "maxContains" if the number of
+   elements that are valid against the schema for "contains"
+   [json-schema] is less than, or equal to, the value of this keyword.
+
+   If "contains" is not present within the same schema object, then this
+   keyword has no effect.
+
+6.4.5.  minContains
+
+   The value of this keyword MUST be a non-negative integer.
+
+   An array instance is valid against "minContains" if the number of
+   elements that are valid against the schema for "contains"
+   [json-schema] is greater than, or equal to, the value of this
+   keyword.
+
+   A value of 0 is allowed, but is only useful for setting a range of
+   occurrences from 0 to the value of "maxContains".  A value of 0 with
+   no "maxContains" causes "contains" to always pass validation.
+
+   If "contains" is not present within the same schema object, then this
+   keyword has no effect.
+
+   Omitting this keyword has the same behavior as a value of 1.
+
+6.5.  Validation Keywords for Objects
+
+6.5.1.  maxProperties
+
+   The value of this keyword MUST be a non-negative integer.
+
+   An object instance is valid against "maxProperties" if its number of
+   properties is less than, or equal to, the value of this keyword.
+
+6.5.2.  minProperties
+
+   The value of this keyword MUST be a non-negative integer.
+
+   An object instance is valid against "minProperties" if its number of
+   properties is greater than, or equal to, the value of this keyword.
+
+   Omitting this keyword has the same behavior as a value of 0.
+
+
+
+Wright, et al.          Expires November 26, 2019               [Page 9]
+
+Internet-Draft           JSON Schema Validation                 May 2019
+
+
+6.5.3.  required
+
+   The value of this keyword MUST be an array.  Elements of this array,
+   if any, MUST be strings, and MUST be unique.
+
+   An object instance is valid against this keyword if every item in the
+   array is the name of a property in the instance.
+
+   Omitting this keyword has the same behavior as an empty array.
+
+6.5.4.  dependentRequired
+
+   The value of this keyword MUST be an object.  Properties in this
+   object, if any, MUST be arrays.  Elements in each array, if any, MUST
+   be strings, and MUST be unique.
+
+   This keyword specifies properties that are required if a specific
+   other property is present.  Their requirement is dependent on the
+   presence of the other property.
+
+   Validation succeeds if, for each name that appears in both the
+   instance and as a name within this keyword's value, every item in the
+   corresponding array is also the name of a property in the instance.
+
+   Omitting this keyword has the same behavior as an empty object.
+
+7.  A Vocabulary for Semantic Validation With "format"
+
+7.1.  Foreword
+
+   Structural validation alone may be insufficient to validate that an
+   instance meets all the requirements of an application.  The "format"
+   keyword is defined to allow interoperable semantic validation for a
+   fixed subset of values which are accurately described by
+   authoritative resources, be they RFCs or other external
+   specifications.
+
+   The value of this keyword is called a format attribute.  It MUST be a
+   string.  A format attribute can generally only validate a given set
+   of instance types.  If the type of the instance to validate is not in
+   this set, validation for this format attribute and instance SHOULD
+   succeed.
+
+   Meta-schemas that do not use "$vocabulary" SHOULD be considered to
+   require this vocabulary as if its URI were present with a value of
+   true, although see the Implementation Requirements below for details.
+
+
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 10]
+
+Internet-Draft           JSON Schema Validation                 May 2019
+
+
+   The current URI for this vocabulary, known as the Format vocabulary,
+   is: <https://json-schema.org/draft/2019-04/vocab/format>.
+
+   The current URI for the corresponding meta-schema is: <https://json-
+   schema.org/draft/2019-04/meta/format>.
+
+7.2.  Implementation Requirements
+
+   The "format" keyword functions as both an annotation and as an
+   assertion.  While no special effort is required to implement it as an
+   annotation conveying semantic meaning, implementing validation is
+   non-trivial.
+
+   Implementations MAY support the "format" keyword as a validation
+   assertion.  Should they choose to do so:
+
+      they SHOULD implement validation for attributes defined below;
+
+      they SHOULD offer an option to disable validation for this
+      keyword.
+
+   Implementations MAY add custom format attributes.  Save for agreement
+   between parties, schema authors SHALL NOT expect a peer
+   implementation to support this keyword and/or custom format
+   attributes.
+
+7.3.  Defined Formats
+
+7.3.1.  Dates, Times, and Duration
+
+   These attributes apply to string instances.
+
+   Date and time format names are derived from RFC 3339, section 5.6
+   [RFC3339].  The duration format is from the ISO 8601 ABNF as given in
+   Appendix A of RFC 3339.
+
+   Implementations supporting formats SHOULD implement support for the
+   following attributes:
+
+   date-time:  A string instance is valid against this attribute if it
+      is a valid representation according to the "date-time" production.
+
+   date:  A string instance is valid against this attribute if it is a
+      valid representation according to the "full-date" production.
+
+   time:  A string instance is valid against this attribute if it is a
+      valid representation according to the "full-time" production.
+
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 11]
+
+Internet-Draft           JSON Schema Validation                 May 2019
+
+
+   duration:  A string instance is valid against this attribute if it is
+      a valid representation according to the "duration" production.
+
+   Implementations MAY support additional attributes using the other
+   production names defined in that section.  If "full-date" or "full-
+   time" are implemented, the corresponding short form ("date" or "time"
+   respectively) MUST be implemented, and MUST behave identically.
+   Implementations SHOULD NOT define extension attributes with any name
+   matching an RFC 3339 production unless it validates according to the
+   rules of that production.  [[CREF1: There is not currently consensus
+   on the need for supporting all RFC 3339 formats, so this approach of
+   reserving the namespace will encourage experimentation without
+   committing to the entire set.  Either the format implementation
+   requirements will become more flexible in general, or these will
+   likely either be promoted to fully specified attributes or dropped.
+   ]]
+
+7.3.2.  Email Addresses
+
+   These attributes apply to string instances.
+
+   A string instance is valid against these attributes if it is a valid
+   Internet email address as follows:
+
+   email:  As defined by RFC 5322, section 3.4.1 [RFC5322].
+
+   idn-email:  As defined by RFC 6531 [RFC6531]
+
+   Note that all strings valid against the "email" attribute are also
+   valid against the "idn-email" attribute.
+
+7.3.3.  Hostnames
+
+   These attributes apply to string instances.
+
+   A string instance is valid against these attributes if it is a valid
+   representation for an Internet hostname as follows:
+
+   hostname:  As defined by RFC 1123, section 2.1 [RFC1123], including
+      host names produced using the Punycode algorithm specified in RFC
+      5891, section 4.4 [RFC5891].
+
+   idn-hostname:  As defined by either RFC 1123 as for hostname, or an
+      internationalized hostname as defined by RFC 5890, section 2.3.2.3
+      [RFC5890].
+
+   Note that all strings valid against the "hostname" attribute are also
+   valid against the "idn-hostname" attribute.
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 12]
+
+Internet-Draft           JSON Schema Validation                 May 2019
+
+
+7.3.4.  IP Addresses
+
+   These attributes apply to string instances.
+
+   A string instance is valid against these attributes if it is a valid
+   representation of an IP address as follows:
+
+   ipv4:  An IPv4 address according to the "dotted-quad" ABNF syntax as
+      defined in RFC 2673, section 3.2 [RFC2673].
+
+   ipv6:  An IPv6 address as defined in RFC 4291, section 2.2 [RFC4291].
+
+7.3.5.  Resource Identifiers
+
+   These attributes apply to string instances.
+
+   uri:  A string instance is valid against this attribute if it is a
+      valid URI, according to [RFC3986].
+
+   uri-reference:  A string instance is valid against this attribute if
+      it is a valid URI Reference (either a URI or a relative-
+      reference), according to [RFC3986].
+
+   iri:  A string instance is valid against this attribute if it is a
+      valid IRI, according to [RFC3987].
+
+   iri-reference:  A string instance is valid against this attribute if
+      it is a valid IRI Reference (either an IRI or a relative-
+      reference), according to [RFC3987].
+
+   uuid:  A string instance is valid against this attribute if it is a
+      valid string representation of a UUID, according to [RFC4122].
+
+   Note that all valid URIs are valid IRIs, and all valid URI References
+   are also valid IRI References.
+
+   Note also that the "uuid" format is for plain UUIDs, not UUIDs in
+   URNs.  An example is "f81d4fae-7dec-11d0-a765-00a0c91e6bf6".  For
+   UUIDs as URNs, use the "uri" format, with a "pattern" regular
+   expression of "^urn:uuid:" to indicate the URI scheme and URN
+   namespace.
+
+7.3.6.  uri-template
+
+   This attribute applies to string instances.
+
+   A string instance is valid against this attribute if it is a valid
+   URI Template (of any level), according to [RFC6570].
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 13]
+
+Internet-Draft           JSON Schema Validation                 May 2019
+
+
+   Note that URI Templates may be used for IRIs; there is no separate
+   IRI Template specification.
+
+7.3.7.  JSON Pointers
+
+   These attributes apply to string instances.
+
+   json-pointer:  A string instance is valid against this attribute if
+      it is a valid JSON string representation of a JSON Pointer,
+      according to RFC 6901, section 5 [RFC6901].
+
+   relative-json-pointer:  A string instance is valid against this
+      attribute if it is a valid Relative JSON Pointer
+      [relative-json-pointer].
+
+   To allow for both absolute and relative JSON Pointers, use "anyOf" or
+   "oneOf" to indicate support for either format.
+
+7.3.8.  regex
+
+   This attribute applies to string instances.
+
+   A regular expression, which SHOULD be valid according to the ECMA 262
+   [ecma262] regular expression dialect.
+
+   Implementations that validate formats MUST accept at least the subset
+   of ECMA 262 defined in the Regular Expressions (Section 4.3) section
+   of this specification, and SHOULD accept all valid ECMA 262
+   expressions.
+
+8.  A Vocabulary for the Contents of String-Encoded Data
+
+8.1.  Foreword
+
+   Properties defined in this section indicate that an instance contains
+   non-JSON data encoded in a JSON string.  They describe the type of
+   content and how it is encoded.
+
+   These properties provide additional information required to interpret
+   JSON data as rich multimedia documents.
+
+   Meta-schemas that do not use "$vocabulary" SHOULD be considered to
+   require this vocabulary as if its URI were present with a value of
+   true, although see the Implementation Requirements below for details.
+
+   The current URI for this vocabulary, known as the Content vocabulary,
+   is: <https://json-schema.org/draft/2019-04/vocab/content>.
+
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 14]
+
+Internet-Draft           JSON Schema Validation                 May 2019
+
+
+   The current URI for the corresponding meta-schema is: <https://json-
+   schema.org/draft/2019-04/meta/content>.
+
+8.2.  Implementation Requirements
+
+   The content keywords function as both annotations and as assertions.
+   While no special effort is required to implement them as annotations
+   conveying how applications can interpret the data in the string,
+   implementing validation of conformance to the media type and encoding
+   is non-trivial.
+
+   Implementations MAY support the "contentMediaType" and
+   "contentEncoding" keywords as validation assertions.  Should they
+   choose to do so, they SHOULD offer an option to disable validation
+   for these keywords.
+
+8.3.  contentEncoding
+
+   If the instance value is a string, this property defines that the
+   string SHOULD be interpreted as binary data and decoded using the
+   encoding named by this property.
+
+   Possible values for this property are listed in RFC 2045, Sec 6.1
+   [RFC2045] and RFC 4648 [RFC4648].  For "base64", which is defined in
+   both RFCs, the definition in RFC 4648, which removes line length
+   limitations, SHOULD be used, as various other specifications have
+   mandated different lengths.  Note that line lengths within a string
+   can be constrained using the "pattern" (Section 6.3.3) keyword.
+
+   If this keyword is absent, but "contentMediaType" is present, this
+   indicates that the media type could be encoded into UTF-8 like any
+   other JSON string value, and does not require additional decoding.
+
+   The value of this property MUST be a string.
+
+   The value of this property SHOULD be ignored if the instance
+   described is not a string.
+
+8.4.  contentMediaType
+
+   If the instance is a string, this property defines the media type of
+   the contents of the string.  If "contentEncoding" is present, this
+   property describes the decoded string.
+
+   The value of this property MUST be a string, which MUST be a media
+   type, as defined by RFC 2046 [RFC2046].
+
+
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 15]
+
+Internet-Draft           JSON Schema Validation                 May 2019
+
+
+   The value of this property SHOULD be ignored if the instance
+   described is not a string.
+
+8.5.  contentSchema
+
+   If the instance is a string, and if "contentMediaType" is present,
+   this property contains a schema which describes the structure of the
+   string.
+
+   This keyword MAY be used with any media type that can be mapped into
+   JSON Schema's data model.
+
+   The value of this property SHOULD be ignored if the instance
+   described is not a string, or if "contentMediaType" is not present.
+
+8.6.  Example
+
+   Here is an example schema, illustrating the use of "contentEncoding"
+   and "contentMediaType":
+
+
+   {
+       "type": "string",
+       "contentEncoding": "base64",
+       "contentMediaType": "image/png"
+   }
+
+
+   Instances described by this schema should be strings, and their
+   values should be interpretable as base64-encoded PNG images.
+
+   Another example:
+
+
+   {
+       "type": "string",
+       "contentMediaType": "text/html"
+   }
+
+
+   Instances described by this schema should be strings containing HTML,
+   using whatever character set the JSON string was decoded into.  Per
+   section 8.1 of RFC 8259 [RFC8259], outside of an entirely closed
+   system, this MUST be UTF-8.
+
+
+
+
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 16]
+
+Internet-Draft           JSON Schema Validation                 May 2019
+
+
+   This example describes a JWT that is MACed using the HMAC SHA-256
+   algorithm, and requires the "iss" and "exp" fields in its claim set.
+
+
+   {
+       "type": "string",
+       "contentMediaType": "application/jwt",
+       "contentSchema": {
+           "type": "array",
+           "minItems": 2,
+           "items": [
+               {
+                   "const": {
+                       "typ": "JWT",
+                       "alg": "HS256"
+                   }
+               },
+               {
+                   "type": "object",
+                   "required": ["iss", "exp"],
+                   "properties": {
+                       "iss": {"type": "string"},
+                       "exp": {"type": "integer"}
+                   }
+               }
+           ]
+       }
+   }
+
+   Note that "contentEncoding" does not appear.  While the "application/
+   jwt" media type makes use of base64url encoding, that is defined by
+   the media type, which determines how the JWT string is decoded into a
+   list of two JSON data structures: first the header, and then the
+   payload.  Since the JWT media type ensures that the JWT can be
+   represented in a JSON string, there is no need for further encoding
+   or decoding.
+
+9.  A Vocabulary for Basic Meta-Data Annotations
+
+   These general-purpose annotation keywords provide commonly used
+   information for documentation and user interface display purposes.
+   They are not intended to form a comprehensive set of features.
+   Rather, additional vocabularies can be defined for more complex
+   annotation-based applications.
+
+   Meta-schemas that do not use "$vocabulary" SHOULD be considered to
+   require this vocabulary as if its URI were present with a value of
+   true.
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 17]
+
+Internet-Draft           JSON Schema Validation                 May 2019
+
+
+   The current URI for this vocabulary, known as the Meta-Data
+   vocabulary, is: <https://json-schema.org/draft/2019-04/vocab/meta-
+   data>.
+
+   The current URI for the corresponding meta-schema is: <https://json-
+   schema.org/draft/2019-04/meta/meta-data>.
+
+9.1.  "title" and "description"
+
+   The value of both of these keywords MUST be a string.
+
+   Both of these keywords can be used to decorate a user interface with
+   information about the data produced by this user interface.  A title
+   will preferably be short, whereas a description will provide
+   explanation about the purpose of the instance described by this
+   schema.
+
+9.2.  "default"
+
+   There are no restrictions placed on the value of this keyword.  When
+   multiple occurrences of this keyword are applicable to a single sub-
+   instance, implementations SHOULD remove duplicates.
+
+   This keyword can be used to supply a default JSON value associated
+   with a particular schema.  It is RECOMMENDED that a default value be
+   valid against the associated schema.
+
+9.3.  "deprecated"
+
+   The value of this keyword MUST be a boolean.  When multiple
+   occurrences of this keyword are applicable to a single sub-instance,
+   the resulting value MUST be true if any occurrence specifies a true
+   value, and MUST be false otherwise.
+
+   If "deprecated" has a value of boolean true, it indicates that
+   applications SHOULD refrain from usage of the declared property.  It
+   MAY mean the property is going to be removed in the future.
+
+   A root schema containing "deprecated" with a value of true indicates
+   the entire root schema MAY be removed in the future.
+
+   Omitting this keyword has the same behavior as a value of false.
+
+9.4.  "readOnly" and "writeOnly"
+
+   The value of these keywords MUST be a boolean.  When multiple
+   occurrences of these keywords are applicable to a single sub-
+
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 18]
+
+Internet-Draft           JSON Schema Validation                 May 2019
+
+
+   instance, the resulting value MUST be true if any occurrence
+   specifies a true value, and MUST be false otherwise.
+
+   If "readOnly" has a value of boolean true, it indicates that the
+   value of the instance is managed exclusively by the owning authority,
+   and attempts by an application to modify the value of this property
+   are expected to be ignored or rejected by that owning authority.
+
+   An instance document that is marked as "readOnly for the entire
+   document MAY be ignored if sent to the owning authority, or MAY
+   result in an error, at the authority's discretion.
+
+   If "writeOnly" has a value of boolean true, it indicates that the
+   value is never present when the instance is retrieved from the owning
+   authority.  It can be present when sent to the owning authority to
+   update or create the document (or the resource it represents), but it
+   will not be included in any updated or newly created version of the
+   instance.
+
+   An instance document that is marked as "writeOnly" for the entire
+   document MAY be returned as a blank document of some sort, or MAY
+   produce an error upon retrieval, or have the retrieval request
+   ignored, at the authority's discretion.
+
+   For example, "readOnly" would be used to mark a database-generated
+   serial number as read-only, while "writeOnly" would be used to mark a
+   password input field.
+
+   These keywords can be used to assist in user interface instance
+   generation.  In particular, an application MAY choose to use a widget
+   that hides input values as they are typed for write-only fields.
+
+   Omitting these keywords has the same behavior as values of false.
+
+9.5.  "examples"
+
+   The value of this keyword MUST be an array.  There are no
+   restrictions placed on the values within the array.  When multiple
+   occurrences of this keyword are applicable to a single sub-instance,
+   implementations MUST provide a flat array of all values rather than
+   an array of arrays.
+
+   This keyword can be used to provide sample JSON values associated
+   with a particular schema, for the purpose of illustrating usage.  It
+   is RECOMMENDED that these values be valid against the associated
+   schema.
+
+
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 19]
+
+Internet-Draft           JSON Schema Validation                 May 2019
+
+
+   Implementations MAY use the value(s) of "default", if present, as an
+   additional example.  If "examples" is absent, "default" MAY still be
+   used in this manner.
+
+10.  Security Considerations
+
+   JSON Schema validation defines a vocabulary for JSON Schema core and
+   concerns all the security considerations listed there.
+
+   JSON Schema validation allows the use of Regular Expressions, which
+   have numerous different (often incompatible) implementations.  Some
+   implementations allow the embedding of arbitrary code, which is
+   outside the scope of JSON Schema and MUST NOT be permitted.  Regular
+   expressions can often also be crafted to be extremely expensive to
+   compute (with so-called "catastrophic backtracking"), resulting in a
+   denial-of-service attack.
+
+   Implementations that support validating or otherwise evaluating
+   instance string data based on "contentEncoding" and/or
+   "contentMediaType" are at risk of evaluating data in an unsafe way
+   based on misleading information.  Applications can mitigate this risk
+   by only performing such processing when a relationship between the
+   schema and instance is established (e.g., they share the same
+   authority).
+
+   Processing a media type or encoding is subject to the security
+   considerations of that media type or encoding.  For example, the
+   security considerations of RFC 4329 Scripting Media Types [RFC4329]
+   apply when processing JavaScript or ECMAScript encoded within a JSON
+   string.
+
+11.  References
+
+11.1.  Normative References
+
+   [ecma262]  "ECMA 262 specification", <http://www.ecma-
+              international.org/publications/files/ECMA-ST/
+              Ecma-262.pdf>.
+
+   [json-schema]
+              Wright, A. and H. Andrews, "JSON Schema: A Media Type for
+              Describing JSON Documents", draft-handrews-json-schema-02
+              (work in progress), November 2017.
+
+   [relative-json-pointer]
+              Luff, G. and H. Andrews, "Relative JSON Pointers", draft-
+              handrews-relative-json-pointer-01 (work in progress),
+              November 2017.
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 20]
+
+Internet-Draft           JSON Schema Validation                 May 2019
+
+
+   [RFC1123]  Braden, R., Ed., "Requirements for Internet Hosts -
+              Application and Support", STD 3, RFC 1123,
+              DOI 10.17487/RFC1123, October 1989,
+              <https://www.rfc-editor.org/info/rfc1123>.
+
+   [RFC2045]  Freed, N. and N. Borenstein, "Multipurpose Internet Mail
+              Extensions (MIME) Part One: Format of Internet Message
+              Bodies", RFC 2045, DOI 10.17487/RFC2045, November 1996,
+              <https://www.rfc-editor.org/info/rfc2045>.
+
+   [RFC2046]  Freed, N. and N. Borenstein, "Multipurpose Internet Mail
+              Extensions (MIME) Part Two: Media Types", RFC 2046,
+              DOI 10.17487/RFC2046, November 1996,
+              <https://www.rfc-editor.org/info/rfc2046>.
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119,
+              DOI 10.17487/RFC2119, March 1997,
+              <https://www.rfc-editor.org/info/rfc2119>.
+
+   [RFC2673]  Crawford, M., "Binary Labels in the Domain Name System",
+              RFC 2673, DOI 10.17487/RFC2673, August 1999,
+              <https://www.rfc-editor.org/info/rfc2673>.
+
+   [RFC3339]  Klyne, G. and C. Newman, "Date and Time on the Internet:
+              Timestamps", RFC 3339, DOI 10.17487/RFC3339, July 2002,
+              <https://www.rfc-editor.org/info/rfc3339>.
+
+   [RFC3986]  Berners-Lee, T., Fielding, R., and L. Masinter, "Uniform
+              Resource Identifier (URI): Generic Syntax", STD 66,
+              RFC 3986, DOI 10.17487/RFC3986, January 2005,
+              <https://www.rfc-editor.org/info/rfc3986>.
+
+   [RFC3987]  Duerst, M. and M. Suignard, "Internationalized Resource
+              Identifiers (IRIs)", RFC 3987, DOI 10.17487/RFC3987,
+              January 2005, <https://www.rfc-editor.org/info/rfc3987>.
+
+   [RFC4122]  Leach, P., Mealling, M., and R. Salz, "A Universally
+              Unique IDentifier (UUID) URN Namespace", RFC 4122,
+              DOI 10.17487/RFC4122, July 2005,
+              <https://www.rfc-editor.org/info/rfc4122>.
+
+   [RFC4291]  Hinden, R. and S. Deering, "IP Version 6 Addressing
+              Architecture", RFC 4291, DOI 10.17487/RFC4291, February
+              2006, <https://www.rfc-editor.org/info/rfc4291>.
+
+
+
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 21]
+
+Internet-Draft           JSON Schema Validation                 May 2019
+
+
+   [RFC4648]  Josefsson, S., "The Base16, Base32, and Base64 Data
+              Encodings", RFC 4648, DOI 10.17487/RFC4648, October 2006,
+              <https://www.rfc-editor.org/info/rfc4648>.
+
+   [RFC5322]  Resnick, P., Ed., "Internet Message Format", RFC 5322,
+              DOI 10.17487/RFC5322, October 2008,
+              <https://www.rfc-editor.org/info/rfc5322>.
+
+   [RFC5890]  Klensin, J., "Internationalized Domain Names for
+              Applications (IDNA): Definitions and Document Framework",
+              RFC 5890, DOI 10.17487/RFC5890, August 2010,
+              <https://www.rfc-editor.org/info/rfc5890>.
+
+   [RFC5891]  Klensin, J., "Internationalized Domain Names in
+              Applications (IDNA): Protocol", RFC 5891,
+              DOI 10.17487/RFC5891, August 2010,
+              <https://www.rfc-editor.org/info/rfc5891>.
+
+   [RFC6531]  Yao, J. and W. Mao, "SMTP Extension for Internationalized
+              Email", RFC 6531, DOI 10.17487/RFC6531, February 2012,
+              <https://www.rfc-editor.org/info/rfc6531>.
+
+   [RFC6570]  Gregorio, J., Fielding, R., Hadley, M., Nottingham, M.,
+              and D. Orchard, "URI Template", RFC 6570,
+              DOI 10.17487/RFC6570, March 2012,
+              <https://www.rfc-editor.org/info/rfc6570>.
+
+   [RFC6901]  Bryan, P., Ed., Zyp, K., and M. Nottingham, Ed.,
+              "JavaScript Object Notation (JSON) Pointer", RFC 6901,
+              DOI 10.17487/RFC6901, April 2013,
+              <https://www.rfc-editor.org/info/rfc6901>.
+
+   [RFC8259]  Bray, T., Ed., "The JavaScript Object Notation (JSON) Data
+              Interchange Format", STD 90, RFC 8259,
+              DOI 10.17487/RFC8259, December 2017,
+              <https://www.rfc-editor.org/info/rfc8259>.
+
+11.2.  Informative References
+
+   [RFC4329]  Hoehrmann, B., "Scripting Media Types", RFC 4329,
+              DOI 10.17487/RFC4329, April 2006,
+              <https://www.rfc-editor.org/info/rfc4329>.
+
+
+
+
+
+
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 22]
+
+Internet-Draft           JSON Schema Validation                 May 2019
+
+
+Appendix A.  Keywords Moved from Validation to Core
+
+   Several keywords have been moved from this document into the Core
+   Specification [json-schema] as of this draft, in some cases with re-
+   naming or other changes.  This affects the following former
+   validation keywords:
+
+   "definitions"  Renamed to "$defs" to match "$ref" and be shorter to
+      type.  Schema vocabulary authors SHOULD NOT define a "definitions"
+      keyword with different behavior in order to avoid invalidating
+      schemas that still use the older name.
+
+   "allOf", "anyOf", "oneOf", "not", "if", "then", "else",
+                                     "items", "additionalItems",
+   "contains", "propertyNames",
+   "properties", "patternProperties", "additionalProperties"
+      All of these keywords apply subschemas to the instance and combine
+      their results, without asserting any conditions of their own.
+      Without assertion keywords, these applicators can only cause
+      assertion failures by using the false boolean schema, or by
+      inverting the result of the true boolean schema.  For this reason,
+      they are better defined as a generic mechanism on which
+      validation, hyper-schema, and extension vocabularies can all be
+      based
+
+   "dependencies"  This keyword had two different modes of behavior,
+      which made it relatively challenging to implement and reason
+      about.  The schema form has been moved to Core and renamed to
+      "dependentSchemas", as part of the applicator vocabulary.  It is
+      analogous to "properties", except that instead of applying its
+      subschema to the property value, it applies it to the object
+      containing the property.  The property name array form is retained
+      here and renamed to "dependentRequired", as it is an assertion
+      which is a shortcut for the conditional use of the "required"
+      assertion keyword.
+
+Appendix B.  Acknowledgments
+
+   Thanks to Gary Court, Francis Galiegue, Kris Zyp, and Geraint Luff
+   for their work on the initial drafts of JSON Schema.
+
+   Thanks to Jason Desrosiers, Daniel Perrett, Erik Wilde, Ben Hutton,
+   Evgeny Poberezkin, Brad Bowman, Gowry Sankar, Donald Pipowitch, Dave
+   Finlay, and Denis Laxalde for their submissions and patches to the
+   document.
+
+
+
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 23]
+
+Internet-Draft           JSON Schema Validation                 May 2019
+
+
+Appendix C.  ChangeLog
+
+   [[CREF2: This section to be removed before leaving Internet-Draft
+   status.]]
+
+   draft-handrews-json-schema-validation-02
+
+      *  Moved "definitions" to the core spec as "$defs"
+
+      *  Moved applicator keywords to the core spec
+
+      *  Renamed the array form of "dependencies" to
+         "dependentRequired", moved the schema form to the core spec
+
+      *  Added "contentSchema" to allow applying a schema to a string-
+         encoded document
+
+      *  Also allow RFC 4648 encodings in "contentEncoding"
+
+      *  Added "minContains" and "maxContains"
+
+      *  Update RFC reference for "hostname" and "idn-hostname"
+
+      *  Add "uuid" and "duration" formats
+
+   draft-handrews-json-schema-validation-01
+
+      *  This draft is purely a clarification with no functional changes
+
+      *  Provided the general principle behind ignoring annotations
+         under "not" and similar cases
+
+      *  Clarified "if"/"then"/"else" validation interactions
+
+      *  Clarified "if"/"then"/"else" behavior for annotation
+
+      *  Minor formatting and cross-referencing improvements
+
+   draft-handrews-json-schema-validation-00
+
+      *  Added "if"/"then"/"else"
+
+      *  Classify keywords as assertions or annotations per the core
+         spec
+
+      *  Warn of possibly removing "dependencies" in the future
+
+      *  Grouped validation keywords into sub-sections for readability
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 24]
+
+Internet-Draft           JSON Schema Validation                 May 2019
+
+
+      *  Moved "readOnly" from hyper-schema to validation meta-data
+
+      *  Added "writeOnly"
+
+      *  Added string-encoded media section, with former hyper-schema
+         "media" keywords
+
+      *  Restored "regex" format (removal was unintentional)
+
+      *  Added "date" and "time" formats, and reserved additional RFC
+         3339 format names
+
+      *  I18N formats: "iri", "iri-reference", "idn-hostname", "idn-
+         email"
+
+      *  Clarify that "json-pointer" format means string encoding, not
+         URI fragment
+
+      *  Fixed typo that inverted the meaning of "minimum" and
+         "exclusiveMinimum"
+
+      *  Move format syntax references into Normative References
+
+      *  JSON is a normative requirement
+
+   draft-wright-json-schema-validation-01
+
+      *  Standardized on hyphenated format names with full words
+         ("uriref" becomes "uri-reference")
+
+      *  Add the formats "uri-template" and "json-pointer"
+
+      *  Changed "exclusiveMaximum"/"exclusiveMinimum" from boolean
+         modifiers of "maximum"/"minimum" to independent numeric fields.
+
+      *  Split the additionalItems/items into two sections
+
+      *  Reworked properties/patternProperties/additionalProperties
+         definition
+
+      *  Added "examples" keyword
+
+      *  Added "contains" keyword
+
+      *  Allow empty "required" and "dependencies" arrays
+
+      *  Fixed "type" reference to primitive types
+
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 25]
+
+Internet-Draft           JSON Schema Validation                 May 2019
+
+
+      *  Added "const" keyword
+
+      *  Added "propertyNames" keyword
+
+   draft-wright-json-schema-validation-00
+
+      *  Added additional security considerations
+
+      *  Removed reference to "latest version" meta-schema, use numbered
+         version instead
+
+      *  Rephrased many keyword definitions for brevity
+
+      *  Added "uriref" format that also allows relative URI references
+
+   draft-fge-json-schema-validation-00
+
+      *  Initial draft.
+
+      *  Salvaged from draft v3.
+
+      *  Redefine the "required" keyword.
+
+      *  Remove "extends", "disallow"
+
+      *  Add "anyOf", "allOf", "oneOf", "not", "definitions",
+         "minProperties", "maxProperties".
+
+      *  "dependencies" member values can no longer be single strings;
+         at least one element is required in a property dependency
+         array.
+
+      *  Rename "divisibleBy" to "multipleOf".
+
+      *  "type" arrays can no longer have schemas; remove "any" as a
+         possible value.
+
+      *  Rework the "format" section; make support optional.
+
+      *  "format": remove attributes "phone", "style", "color"; rename
+         "ip-address" to "ipv4"; add references for all attributes.
+
+      *  Provide algorithms to calculate schema(s) for array/object
+         instances.
+
+      *  Add interoperability considerations.
+
+
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 26]
+
+Internet-Draft           JSON Schema Validation                 May 2019
+
+
+Authors' Addresses
+
+   Austin Wright (editor)
+
+   EMail: aaa@bzfx.net
+
+
+   Henry Andrews (editor)
+   Riverbed Technology
+   680 Folsom St.
+   San Francisco, CA
+   USA
+
+   EMail: handrews@riverbed.com
+
+
+   Ben Hutton (editor)
+   Wellcome Sanger Institute
+
+   EMail: bh7@sanger.ac.uk
+
+
+   Geraint Luff
+   Cambridge
+   UK
+
+   EMail: luffgd@gmail.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Wright, et al.          Expires November 26, 2019              [Page 27]

--- a/work-in-progress/WIP-jsonschema-validation.txt
+++ b/work-in-progress/WIP-jsonschema-validation.txt
@@ -13,7 +13,7 @@ Expires: November 26, 2019                           Riverbed Technology
 
 
  JSON Schema Validation: A Vocabulary for Structural Validation of JSON
-                draft-handrews-json-schema-validation-02
+                draft-handrews-json-schema-validation-WIP
 
 Abstract
 
@@ -1107,7 +1107,7 @@ Internet-Draft           JSON Schema Validation                 May 2019
 
    [json-schema]
               Wright, A. and H. Andrews, "JSON Schema: A Media Type for
-              Describing JSON Documents", draft-handrews-json-schema-02
+              Describing JSON Documents", draft-handrews-json-schema-WIP
               (work in progress), November 2017.
 
    [relative-json-pointer]
@@ -1295,7 +1295,7 @@ Appendix C.  ChangeLog
    [[CREF2: This section to be removed before leaving Internet-Draft
    status.]]
 
-   draft-handrews-json-schema-validation-02
+   draft-handrews-json-schema-validation-WIP
 
       *  Moved "definitions" to the core spec as "$defs"
 

--- a/work-in-progress/WIP-links.json
+++ b/work-in-progress/WIP-links.json
@@ -1,0 +1,91 @@
+{
+    "$schema": "http://json-schema.org/draft/2019-04/hyper-schema#",
+    "$id": "http://json-schema.org/draft/2019-04/links",
+    "title": "Link Description Object",
+    "allOf": [
+        { "required": [ "rel", "href" ] },
+        { "$ref": "#/$defs/noRequiredFields" }
+    ],
+    "$defs": {
+        "noRequiredFields": {
+            "type": "object",
+            "properties": {
+                "anchor": {
+                    "type": "string",
+                    "format": "uri-template"
+                },
+                "anchorPointer": {
+                    "type": "string",
+                    "anyOf": [
+                        { "format": "json-pointer" },
+                        { "format": "relative-json-pointer" }
+                    ]
+                },
+                "rel": {
+                    "anyOf": [
+                        { "type": "string" },
+                        {
+                            "type": "array",
+                            "items": { "type": "string" },
+                            "minItems": 1
+                        }
+                    ]
+                },
+                "href": {
+                    "type": "string",
+                    "format": "uri-template"
+                },
+                "hrefSchema": {
+                    "$recursiveRef": "http://json-schema.org/draft/2019-04/hyper-schema",
+                    "default": false
+                },
+                "templatePointers": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string",
+                        "anyOf": [
+                            { "format": "json-pointer" },
+                            { "format": "relative-json-pointer" }
+                        ]
+                    }
+                },
+                "templateRequired": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "uniqueItems": true
+                },
+                "title": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "targetSchema": {
+                    "$recursiveRef": "http://json-schema.org/draft/2019-04/hyper-schema",
+                    "default": true
+                },
+                "targetMediaType": {
+                    "type": "string"
+                },
+                "targetHints": { },
+                "headerSchema": {
+                    "$recursiveRef": "http://json-schema.org/draft/2019-04/hyper-schema",
+                    "default": true
+                },
+                "submissionMediaType": {
+                    "type": "string",
+                    "default": "application/json"
+                },
+                "submissionSchema": {
+                    "$recursiveRef": "http://json-schema.org/draft/2019-04/hyper-schema",
+                    "default": true
+                },
+                "$comment": {
+                    "type": "string"
+                }
+            }
+        }
+    }
+}

--- a/work-in-progress/WIP-links.json
+++ b/work-in-progress/WIP-links.json
@@ -1,6 +1,6 @@
 {
-    "$schema": "http://json-schema.org/draft/2019-04/hyper-schema#",
-    "$id": "http://json-schema.org/draft/2019-04/links",
+    "$schema": "http://json-schema.org/draft/2019-WIP/hyper-schema#",
+    "$id": "http://json-schema.org/draft/2019-WIP/links",
     "title": "Link Description Object",
     "allOf": [
         { "required": [ "rel", "href" ] },
@@ -36,7 +36,7 @@
                     "format": "uri-template"
                 },
                 "hrefSchema": {
-                    "$recursiveRef": "http://json-schema.org/draft/2019-04/hyper-schema",
+                    "$recursiveRef": "http://json-schema.org/draft/2019-WIP/hyper-schema",
                     "default": false
                 },
                 "templatePointers": {
@@ -63,7 +63,7 @@
                     "type": "string"
                 },
                 "targetSchema": {
-                    "$recursiveRef": "http://json-schema.org/draft/2019-04/hyper-schema",
+                    "$recursiveRef": "http://json-schema.org/draft/2019-WIP/hyper-schema",
                     "default": true
                 },
                 "targetMediaType": {
@@ -71,7 +71,7 @@
                 },
                 "targetHints": { },
                 "headerSchema": {
-                    "$recursiveRef": "http://json-schema.org/draft/2019-04/hyper-schema",
+                    "$recursiveRef": "http://json-schema.org/draft/2019-WIP/hyper-schema",
                     "default": true
                 },
                 "submissionMediaType": {
@@ -79,7 +79,7 @@
                     "default": "application/json"
                 },
                 "submissionSchema": {
-                    "$recursiveRef": "http://json-schema.org/draft/2019-04/hyper-schema",
+                    "$recursiveRef": "http://json-schema.org/draft/2019-WIP/hyper-schema",
                     "default": true
                 },
                 "$comment": {

--- a/work-in-progress/WIP-relative-json-pointer.html
+++ b/work-in-progress/WIP-relative-json-pointer.html
@@ -1,0 +1,692 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" 
+  "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+<head profile="http://www.w3.org/2006/03/hcard http://dublincore.org/documents/2008/08/04/dc-html/">
+  <meta http-equiv="Content-Type" content="text/html; charset=us-ascii" />
+
+  <title>Relative JSON Pointers</title>
+
+  <style type="text/css" title="Xml2Rfc (sans serif)">
+  /*<![CDATA[*/
+	  a {
+	  text-decoration: none;
+	  }
+      /* info code from SantaKlauss at http://www.madaboutstyle.com/tooltip2.html */
+      a.info {
+          /* This is the key. */
+          position: relative;
+          z-index: 24;
+          text-decoration: none;
+      }
+      a.info:hover {
+          z-index: 25;
+          color: #FFF; background-color: #900;
+      }
+      a.info span { display: none; }
+      a.info:hover span.info {
+          /* The span will display just on :hover state. */
+          display: block;
+          position: absolute;
+          font-size: smaller;
+          top: 2em; left: -5em; width: 15em;
+          padding: 2px; border: 1px solid #333;
+          color: #900; background-color: #EEE;
+          text-align: left;
+      }
+	  a.smpl {
+	  color: black;
+	  }
+	  a:hover {
+	  text-decoration: underline;
+	  }
+	  a:active {
+	  text-decoration: underline;
+	  }
+	  address {
+	  margin-top: 1em;
+	  margin-left: 2em;
+	  font-style: normal;
+	  }
+	  body {
+	  color: black;
+	  font-family: verdana, helvetica, arial, sans-serif;
+	  font-size: 10pt;
+	  max-width: 55em;
+	  
+	  }
+	  cite {
+	  font-style: normal;
+	  }
+	  dd {
+	  margin-right: 2em;
+	  }
+	  dl {
+	  margin-left: 2em;
+	  }
+	
+	  ul.empty {
+	  list-style-type: none;
+	  }
+	  ul.empty li {
+	  margin-top: .5em;
+	  }
+	  dl p {
+	  margin-left: 0em;
+	  }
+	  dt {
+	  margin-top: .5em;
+	  }
+	  h1 {
+	  font-size: 14pt;
+	  line-height: 21pt;
+	  page-break-after: avoid;
+	  }
+	  h1.np {
+	  page-break-before: always;
+	  }
+	  h1 a {
+	  color: #333333;
+	  }
+	  h2 {
+	  font-size: 12pt;
+	  line-height: 15pt;
+	  page-break-after: avoid;
+	  }
+	  h3, h4, h5, h6 {
+	  font-size: 10pt;
+	  page-break-after: avoid;
+	  }
+	  h2 a, h3 a, h4 a, h5 a, h6 a {
+	  color: black;
+	  }
+	  img {
+	  margin-left: 3em;
+	  }
+	  li {
+	  margin-left: 2em;
+	  margin-right: 2em;
+	  }
+	  ol {
+	  margin-left: 2em;
+	  margin-right: 2em;
+	  }
+	  ol p {
+	  margin-left: 0em;
+	  }
+	  p {
+	  margin-left: 2em;
+	  margin-right: 2em;
+	  }
+	  pre {
+	  margin-left: 3em;
+	  background-color: lightyellow;
+	  padding: .25em;
+	  }
+	  pre.text2 {
+	  border-style: dotted;
+	  border-width: 1px;
+	  background-color: #f0f0f0;
+	  width: 69em;
+	  }
+	  pre.inline {
+	  background-color: white;
+	  padding: 0em;
+	  }
+	  pre.text {
+	  border-style: dotted;
+	  border-width: 1px;
+	  background-color: #f8f8f8;
+	  width: 69em;
+	  }
+	  pre.drawing {
+	  border-style: solid;
+	  border-width: 1px;
+	  background-color: #f8f8f8;
+	  padding: 2em;
+	  }
+	  table {
+	  margin-left: 2em;
+	  }
+	  table.tt {
+	  vertical-align: top;
+	  }
+	  table.full {
+	  border-style: outset;
+	  border-width: 1px;
+	  }
+	  table.headers {
+	  border-style: outset;
+	  border-width: 1px;
+	  }
+	  table.tt td {
+	  vertical-align: top;
+	  }
+	  table.full td {
+	  border-style: inset;
+	  border-width: 1px;
+	  }
+	  table.tt th {
+	  vertical-align: top;
+	  }
+	  table.full th {
+	  border-style: inset;
+	  border-width: 1px;
+	  }
+	  table.headers th {
+	  border-style: none none inset none;
+	  border-width: 1px;
+	  }
+	  table.left {
+	  margin-right: auto;
+	  }
+	  table.right {
+	  margin-left: auto;
+	  }
+	  table.center {
+	  margin-left: auto;
+	  margin-right: auto;
+	  }
+	  caption {
+	  caption-side: bottom;
+	  font-weight: bold;
+	  font-size: 9pt;
+	  margin-top: .5em;
+	  }
+	
+	  table.header {
+	  border-spacing: 1px;
+	  width: 95%;
+	  font-size: 10pt;
+	  color: white;
+	  }
+	  td.top {
+	  vertical-align: top;
+	  }
+	  td.topnowrap {
+	  vertical-align: top;
+	  white-space: nowrap; 
+	  }
+	  table.header td {
+	  background-color: gray;
+	  width: 50%;
+	  }
+	  table.header a {
+	  color: white;
+	  }
+	  td.reference {
+	  vertical-align: top;
+	  white-space: nowrap;
+	  padding-right: 1em;
+	  }
+	  thead {
+	  display:table-header-group;
+	  }
+	  ul.toc, ul.toc ul {
+	  list-style: none;
+	  margin-left: 1.5em;
+	  margin-right: 0em;
+	  padding-left: 0em;
+	  }
+	  ul.toc li {
+	  line-height: 150%;
+	  font-weight: bold;
+	  font-size: 10pt;
+	  margin-left: 0em;
+	  margin-right: 0em;
+	  }
+	  ul.toc li li {
+	  line-height: normal;
+	  font-weight: normal;
+	  font-size: 9pt;
+	  margin-left: 0em;
+	  margin-right: 0em;
+	  }
+	  li.excluded {
+	  font-size: 0pt;
+	  }
+	  ul p {
+	  margin-left: 0em;
+	  }
+	
+	  .comment {
+	  background-color: yellow;
+	  }
+	  .center {
+	  text-align: center;
+	  }
+	  .error {
+	  color: red;
+	  font-style: italic;
+	  font-weight: bold;
+	  }
+	  .figure {
+	  font-weight: bold;
+	  text-align: center;
+	  font-size: 9pt;
+	  }
+	  .filename {
+	  color: #333333;
+	  font-weight: bold;
+	  font-size: 12pt;
+	  line-height: 21pt;
+	  text-align: center;
+	  }
+	  .fn {
+	  font-weight: bold;
+	  }
+	  .hidden {
+	  display: none;
+	  }
+	  .left {
+	  text-align: left;
+	  }
+	  .right {
+	  text-align: right;
+	  }
+	  .title {
+	  color: #990000;
+	  font-size: 18pt;
+	  line-height: 18pt;
+	  font-weight: bold;
+	  text-align: center;
+	  margin-top: 36pt;
+	  }
+	  .vcardline {
+	  display: block;
+	  }
+	  .warning {
+	  font-size: 14pt;
+	  background-color: yellow;
+	  }
+	
+	
+	  @media print {
+	  .noprint {
+		display: none;
+	  }
+	
+	  a {
+		color: black;
+		text-decoration: none;
+	  }
+	
+	  table.header {
+		width: 90%;
+	  }
+	
+	  td.header {
+		width: 50%;
+		color: black;
+		background-color: white;
+		vertical-align: top;
+		font-size: 12pt;
+	  }
+	
+	  ul.toc a::after {
+		content: leader('.') target-counter(attr(href), page);
+	  }
+	
+	  ul.ind li li a {
+		content: target-counter(attr(href), page);
+	  }
+	
+	  .print2col {
+		column-count: 2;
+		-moz-column-count: 2;
+		column-fill: auto;
+	  }
+	  }
+	
+	  @page {
+	  @top-left {
+		   content: "Internet-Draft"; 
+	  } 
+	  @top-right {
+		   content: "December 2010"; 
+	  } 
+	  @top-center {
+		   content: "Abbreviated Title";
+	  } 
+	  @bottom-left {
+		   content: "Doe"; 
+	  } 
+	  @bottom-center {
+		   content: "Expires June 2011"; 
+	  } 
+	  @bottom-right {
+		   content: "[Page " counter(page) "]"; 
+	  } 
+	  }
+	
+	  @page:first { 
+		@top-left {
+		  content: normal;
+		}
+		@top-right {
+		  content: normal;
+		}
+		@top-center {
+		  content: normal;
+		}
+	  }
+  /*]]>*/
+  </style>
+
+  <link href="#rfc.toc" rel="Contents">
+<link href="#rfc.section.1" rel="Chapter" title="1 Introduction">
+<link href="#rfc.section.2" rel="Chapter" title="2 Conventions and Terminology">
+<link href="#rfc.section.3" rel="Chapter" title="3 Syntax">
+<link href="#rfc.section.4" rel="Chapter" title="4 Evaluation">
+<link href="#rfc.section.5" rel="Chapter" title="5 JSON String Representation">
+<link href="#rfc.section.5.1" rel="Chapter" title="5.1 Examples">
+<link href="#rfc.section.6" rel="Chapter" title="6 Non-use in URI Fragment Identifiers">
+<link href="#rfc.section.7" rel="Chapter" title="7 Error Handling">
+<link href="#rfc.section.8" rel="Chapter" title="8 Relationship to JSON Pointer">
+<link href="#rfc.section.9" rel="Chapter" title="9 Acknowledgements">
+<link href="#rfc.section.10" rel="Chapter" title="10 Security Considerations">
+<link href="#rfc.references" rel="Chapter" title="11 References">
+<link href="#rfc.references.1" rel="Chapter" title="11.1 Normative References">
+<link href="#rfc.references.2" rel="Chapter" title="11.2 Informative References">
+<link href="#rfc.appendix.A" rel="Chapter" title="A ChangeLog">
+<link href="#rfc.authors" rel="Chapter">
+
+
+  <meta name="generator" content="xml2rfc version 2.20.1 - https://tools.ietf.org/tools/xml2rfc" />
+  <link rel="schema.dct" href="http://purl.org/dc/terms/" />
+
+  <meta name="dct.creator" content="Luff, G. and H. Andrews, Ed." />
+  <meta name="dct.identifier" content="urn:ietf:id:draft-handrews-relative-json-pointer-02" />
+  <meta name="dct.issued" scheme="ISO8601" content="2019-25" />
+  <meta name="dct.abstract" content="JSON Pointer is a syntax for specifying locations in a JSON document, starting from the document root.  This document defines an extension to the JSON Pointer syntax, allowing relative locations from within the document.  " />
+  <meta name="description" content="JSON Pointer is a syntax for specifying locations in a JSON document, starting from the document root.  This document defines an extension to the JSON Pointer syntax, allowing relative locations from within the document.  " />
+
+</head>
+
+<body>
+
+  <table class="header">
+    <tbody>
+    
+    	<tr>
+<td class="left">Internet Engineering Task Force</td>
+<td class="right">G. Luff</td>
+</tr>
+<tr>
+<td class="left">Internet-Draft</td>
+<td class="right"></td>
+</tr>
+<tr>
+<td class="left">Intended status: Informational</td>
+<td class="right">H. Andrews, Ed.</td>
+</tr>
+<tr>
+<td class="left">Expires: November 26, 2019</td>
+<td class="right">Riverbed Technology</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="right">May 25, 2019</td>
+</tr>
+
+    	
+    </tbody>
+  </table>
+
+  <p class="title">Relative JSON Pointers<br />
+  <span class="filename">draft-handrews-relative-json-pointer-02</span></p>
+  
+  <h1 id="rfc.abstract"><a href="#rfc.abstract">Abstract</a></h1>
+<p>JSON Pointer is a syntax for specifying locations in a JSON document, starting from the document root.  This document defines an extension to the JSON Pointer syntax, allowing relative locations from within the document.  </p>
+<h1 id="rfc.status"><a href="#rfc.status">Status of This Memo</a></h1>
+<p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.</p>
+<p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at https://datatracker.ietf.org/drafts/current/.</p>
+<p>Internet-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use Internet-Drafts as reference material or to cite them other than as "work in progress."</p>
+<p>This Internet-Draft will expire on November 26, 2019.</p>
+<h1 id="rfc.copyrightnotice"><a href="#rfc.copyrightnotice">Copyright Notice</a></h1>
+<p>Copyright (c) 2019 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
+<p>This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating to IETF Documents (https://trustee.ietf.org/license-info) in effect on the date of publication of this document.  Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.</p>
+
+  
+  <hr class="noprint" />
+  <h1 class="np" id="rfc.toc"><a href="#rfc.toc">Table of Contents</a></h1>
+  <ul class="toc">
+
+  	<li>1.   <a href="#rfc.section.1">Introduction</a>
+</li>
+<li>2.   <a href="#rfc.section.2">Conventions and Terminology</a>
+</li>
+<li>3.   <a href="#rfc.section.3">Syntax</a>
+</li>
+<li>4.   <a href="#rfc.section.4">Evaluation</a>
+</li>
+<li>5.   <a href="#rfc.section.5">JSON String Representation</a>
+</li>
+<ul><li>5.1.   <a href="#rfc.section.5.1">Examples</a>
+</li>
+</ul><li>6.   <a href="#rfc.section.6">Non-use in URI Fragment Identifiers</a>
+</li>
+<li>7.   <a href="#rfc.section.7">Error Handling</a>
+</li>
+<li>8.   <a href="#rfc.section.8">Relationship to JSON Pointer</a>
+</li>
+<li>9.   <a href="#rfc.section.9">Acknowledgements</a>
+</li>
+<li>10.   <a href="#rfc.section.10">Security Considerations</a>
+</li>
+<li>11.   <a href="#rfc.references">References</a>
+</li>
+<ul><li>11.1.   <a href="#rfc.references.1">Normative References</a>
+</li>
+<li>11.2.   <a href="#rfc.references.2">Informative References</a>
+</li>
+</ul><li>Appendix A.   <a href="#rfc.appendix.A">ChangeLog</a>
+</li>
+<li><a href="#rfc.authors">Authors' Addresses</a>
+</li>
+
+
+  </ul>
+
+  <h1 id="rfc.section.1">
+<a href="#rfc.section.1">1.</a> Introduction</h1>
+<p id="rfc.section.1.p.1">JSON Pointer (<a href="#RFC6901" class="xref">RFC 6901</a>) is a syntax for specifying locations in a JSON document, starting from the document root.  This document defines a related syntax allowing identification of relative locations from within the document.  </p>
+<h1 id="rfc.section.2">
+<a href="#rfc.section.2">2.</a> Conventions and Terminology</h1>
+<p id="rfc.section.2.p.1">The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in <a href="#RFC2119" class="xref">RFC 2119</a>.  </p>
+<h1 id="rfc.section.3">
+<a href="#rfc.section.3">3.</a> Syntax</h1>
+<p id="rfc.section.3.p.1">A Relative JSON Pointer is a Unicode string in UTF-8 encoding (see RFC 8259, <a href="#RFC8259" class="xref">Section 8</a>), comprising a non-negative integer, followed by either a '#' (%x23) character or a JSON Pointer (<a href="#RFC6901" class="xref">RFC 6901</a>).  </p>
+<p id="rfc.section.3.p.2">The separation between the integer prefix and the JSON Pointer will always be unambiguous, because a JSON Pointer must be either zero- length or start with a '/' (%x2F).  Similarly, a JSON Pointer will never be ambiguous with the '#'.  </p>
+<p>The ABNF syntax of a Relative JSON Pointer is: </p>
+<pre>
+
+   relative-json-pointer =  non-negative-integer &amp;lt;json-pointer&amp;gt;
+   relative-json-pointer =/ non-negative-integer "#"
+   non-negative-integer      =  %x30 / %x31-39 *( %x30-39 )
+           ; "0", or digits without a leading "0"
+
+                </pre>
+<p>where &lt;json-pointer&gt; follows the production defined in <a href="#RFC6901" class="xref">RFC 6901, Section&#160;3</a> ("Syntax").  </p>
+<p></p>
+<h1 id="rfc.section.4">
+<a href="#rfc.section.4">4.</a> Evaluation</h1>
+<p id="rfc.section.4.p.1">Evaluation of a Relative JSON Pointer begins with a reference to a value within a JSON document, and completes with either a value within that document, a string corresponding to an object member, or integer value representing an array index.  </p>
+<p id="rfc.section.4.p.2">Evaluation begins by processing the non-negative-integer prefix.  This can be found by taking the longest continuous sequence of decimal digits available, starting from the beginning of the string, taking the decimal numerical value.  If this value is more than zero, then the following steps are repeated that number of times: <a href="#RFC6901" class="xref">RFC 6901, Section 4</a> ("Evaluation"), with the modification that the initial reference being used is the reference currently being held (which may not be root of the document).  </p>
+
+<ul class="empty">
+<li>If the current referenced value is the root of the document, then evaluation fails (see below).  </li>
+<li>If the referenced value is an item within an array, then the new referenced value is that array.  </li>
+<li>If the referenced value is an object member within an object, then the new referenced value is that object.  </li>
+</ul>
+
+<p> If the remainder of the Relative JSON Pointer is a JSON Pointer, then evaluation proceeds as per </p>
+<p id="rfc.section.4.p.3">Otherwise (when the remainder of the Relative JSON Pointer is the character '#'), the final result is determined as follows: </p>
+
+<ul class="empty">
+<li>If the current referenced value is the root of the document, then evaluation fails (see below).  </li>
+<li>If the referenced value is an item within an array, then the final evaluation result is the value's index position within the array.  </li>
+<li>If the referenced value is an object member within an object, then the new referenced value is the corresponding member name.  </li>
+</ul>
+
+<p> </p>
+<h1 id="rfc.section.5">
+<a href="#rfc.section.5">5.</a> JSON String Representation</h1>
+<p id="rfc.section.5.p.1">The concerns surrounding JSON String representation of a Relative JSON Pointer are identical to those laid out in <a href="#RFC6901" class="xref">RFC 6901, Section 5</a>.  </p>
+<h1 id="rfc.section.5.1">
+<a href="#rfc.section.5.1">5.1.</a> Examples</h1>
+<p>For example, given the JSON document: </p>
+<pre>
+
+                      {
+                         "foo": ["bar", "baz"],
+                         "highly": {
+                            "nested": {
+                               "objects": true
+                            }
+                         }
+                      }
+
+                    </pre>
+<p>Starting from the value "baz" (inside "foo"), the following JSON strings evaluate to the accompanying values: </p>
+<pre>
+
+                  "0"                         "baz"
+                  "1/0"                       "bar"
+                  "2/highly/nested/objects"   true
+                  "0#"                        1
+                  "1#"                        "foo"
+
+                    </pre>
+<p>Starting from the value {"objects":true} (corresponding to the member key "nested"), the following JSON strings evaluate to the accompanying values: </p>
+<pre>
+
+                "0/objects"                 true
+                "1/nested/objects"          true
+                "2/foo/0"                   "bar"
+                "0#"                        "nested"
+                "1#"                        "highly"
+
+                    </pre>
+<h1 id="rfc.section.6">
+<a href="#rfc.section.6">6.</a> Non-use in URI Fragment Identifiers</h1>
+<p id="rfc.section.6.p.1">Unlike a JSON Pointer, a Relative JSON Pointer can not be used in a URI fragment identifier.  Such fragments specify exact positions within a document, and therefore Relative JSON Pointers are not suitable.  </p>
+<h1 id="rfc.section.7">
+<a href="#rfc.section.7">7.</a> Error Handling</h1>
+<p id="rfc.section.7.p.1">In the event of an error condition, evaluation of the JSON Pointer fails to complete.  </p>
+<p id="rfc.section.7.p.2">Evaluation may fail due to invalid syntax, or referencing a non- existent value.  This specification does not define how errors are handled.  An application of JSON Relative Pointer SHOULD specify the impact and handling of each type of error.  </p>
+<h1 id="rfc.section.8">
+<a href="#rfc.section.8">8.</a> Relationship to JSON Pointer</h1>
+<p id="rfc.section.8.p.1">Relative JSON Pointers are intended as a companion to JSON Pointers.  Applications MUST specify the use of each syntax separately.  Defining either JSON Pointer or Relative JSON Pointer as an acceptable syntax does not imply that the other syntax is also acceptable.  </p>
+<h1 id="rfc.section.9">
+<a href="#rfc.section.9">9.</a> Acknowledgements</h1>
+<p id="rfc.section.9.p.1">The language and structure of this specification are based heavily on <a href="#RFC6901" class="xref">[RFC6901]</a>, sometimes quoting it outright.  </p>
+<p id="rfc.section.9.p.2">This draft remains primarily as written and published by Geraint Luff, with only minor subsequent alterations under new editorship.  </p>
+<h1 id="rfc.section.10">
+<a href="#rfc.section.10">10.</a> Security Considerations</h1>
+<p id="rfc.section.10.p.1">Evaluation of a given Relative JSON Pointer is not guaranteed to reference an actual JSON value.  Applications using Relative JSON Pointer should anticipate this situation by defining how a pointer that does not resolve ought to be handled.  </p>
+<p id="rfc.section.10.p.2">As part of processing, a composite data structure may be assembled from multiple JSON documents (in part or in full).  In such cases, applications SHOULD ensure that a Relative JSON Pointer does not evaluate to a value outside the document for which is was written.  </p>
+<p id="rfc.section.10.p.3">Note that JSON pointers can contain the NUL (Unicode U+0000) character.  Care is needed not to misinterpret this character in programming languages that use NUL to mark the end of a string.  </p>
+<h1 id="rfc.references">
+<a href="#rfc.references">11.</a> References</h1>
+<h1 id="rfc.references.1">
+<a href="#rfc.references.1">11.1.</a> Normative References</h1>
+<table><tbody>
+<tr>
+<td class="reference"><b id="RFC2119">[RFC2119]</b></td>
+<td class="top">
+<a>Bradner, S.</a>, "<a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>", BCP 14, RFC 2119, DOI 10.17487/RFC2119, March 1997.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC6901">[RFC6901]</b></td>
+<td class="top">
+<a>Bryan, P.</a>, <a>Zyp, K.</a> and <a>M. Nottingham</a>, "<a href="https://tools.ietf.org/html/rfc6901">JavaScript Object Notation (JSON) Pointer</a>", RFC 6901, DOI 10.17487/RFC6901, April 2013.</td>
+</tr>
+</tbody></table>
+<h1 id="rfc.references.2">
+<a href="#rfc.references.2">11.2.</a> Informative References</h1>
+<table><tbody><tr>
+<td class="reference"><b id="RFC8259">[RFC8259]</b></td>
+<td class="top">
+<a>Bray, T.</a>, "<a href="https://tools.ietf.org/html/rfc8259">The JavaScript Object Notation (JSON) Data Interchange Format</a>", STD 90, RFC 8259, DOI 10.17487/RFC8259, December 2017.</td>
+</tr></tbody></table>
+<h1 id="rfc.appendix.A">
+<a href="#rfc.appendix.A">Appendix A.</a> ChangeLog</h1>
+<p><a id="CREF1" class="info">[CREF1]<span class="info">This section to be removed before leaving Internet-Draft status.</span></a> </p>
+<p></p>
+
+<dl>
+<dt>draft-handrews-relative-json-pointer-02</dt>
+<dd style="margin-left: 8">
+<ul><li>Update to the latest JSON RFC</li></ul>
+<p> </p>
+</dd>
+<dt>draft-handrews-relative-json-pointer-01</dt>
+<dd style="margin-left: 8">
+<ul><li>The initial number is "non-negative", not "positive"</li></ul>
+<p> </p>
+</dd>
+<dt>draft-handrews-relative-json-pointer-00</dt>
+<dd style="margin-left: 8">
+<ul>
+<li>Revived draft with identical wording and structure.</li>
+<li>Clarified how to use alongside JSON Pointer.</li>
+</ul>
+<p> </p>
+</dd>
+<dt>draft-luff-relative-json-pointer-00</dt>
+<dd style="margin-left: 8">
+<ul><li>Initial draft.</li></ul>
+<p> </p>
+</dd>
+</dl>
+
+<p> </p>
+<h1 id="rfc.authors"><a href="#rfc.authors">Authors' Addresses</a></h1>
+<div class="avoidbreak">
+  <address class="vcard">
+	<span class="vcardline">
+	  <span class="fn">Geraint Luff</span> 
+	  <span class="n hidden">
+		<span class="family-name">Luff</span>
+	  </span>
+	</span>
+	<span class="org vcardline"></span>
+	<span class="adr">
+	  
+	  <span class="vcardline">
+		<span class="locality">Cambridge</span>,  
+		<span class="region"></span>
+		<span class="code"></span>
+	  </span>
+	  <span class="country-name vcardline">UK</span>
+	</span>
+	<span class="vcardline">EMail: <a href="mailto:luffgd@gmail.com">luffgd@gmail.com</a></span>
+
+  </address>
+</div><div class="avoidbreak">
+  <address class="vcard">
+	<span class="vcardline">
+	  <span class="fn">Henry Andrews</span> (editor)
+	  <span class="n hidden">
+		<span class="family-name">Andrews</span>
+	  </span>
+	</span>
+	<span class="org vcardline">Riverbed Technology</span>
+	<span class="adr">
+	  <span class="vcardline">680 Folsom St.</span>
+
+	  <span class="vcardline">
+		<span class="locality">San Francisco</span>,  
+		<span class="region">CA</span> 
+		<span class="code"></span>
+	  </span>
+	  <span class="country-name vcardline">USA</span>
+	</span>
+	<span class="vcardline">EMail: <a href="mailto:handrews@riverbed.com">handrews@riverbed.com</a></span>
+
+  </address>
+</div>
+
+</body>
+</html>

--- a/work-in-progress/WIP-relative-json-pointer.html
+++ b/work-in-progress/WIP-relative-json-pointer.html
@@ -396,7 +396,7 @@
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Luff, G. and H. Andrews, Ed." />
-  <meta name="dct.identifier" content="urn:ietf:id:draft-handrews-relative-json-pointer-02" />
+  <meta name="dct.identifier" content="urn:ietf:id:draft-handrews-relative-json-pointer-WIP" />
   <meta name="dct.issued" scheme="ISO8601" content="2019-25" />
   <meta name="dct.abstract" content="JSON Pointer is a syntax for specifying locations in a JSON document, starting from the document root.  This document defines an extension to the JSON Pointer syntax, allowing relative locations from within the document.  " />
   <meta name="description" content="JSON Pointer is a syntax for specifying locations in a JSON document, starting from the document root.  This document defines an extension to the JSON Pointer syntax, allowing relative locations from within the document.  " />
@@ -434,7 +434,7 @@
   </table>
 
   <p class="title">Relative JSON Pointers<br />
-  <span class="filename">draft-handrews-relative-json-pointer-02</span></p>
+  <span class="filename">draft-handrews-relative-json-pointer-WIP</span></p>
   
   <h1 id="rfc.abstract"><a href="#rfc.abstract">Abstract</a></h1>
 <p>JSON Pointer is a syntax for specifying locations in a JSON document, starting from the document root.  This document defines an extension to the JSON Pointer syntax, allowing relative locations from within the document.  </p>
@@ -616,7 +616,7 @@
 <p></p>
 
 <dl>
-<dt>draft-handrews-relative-json-pointer-02</dt>
+<dt>draft-handrews-relative-json-pointer-WIP</dt>
 <dd style="margin-left: 8">
 <ul><li>Update to the latest JSON RFC</li></ul>
 <p> </p>

--- a/work-in-progress/WIP-relative-json-pointer.txt
+++ b/work-in-progress/WIP-relative-json-pointer.txt
@@ -1,0 +1,392 @@
+
+
+
+
+Internet Engineering Task Force                                  G. Luff
+Internet-Draft
+Intended status: Informational                           H. Andrews, Ed.
+Expires: November 26, 2019                           Riverbed Technology
+                                                            May 25, 2019
+
+
+                         Relative JSON Pointers
+                draft-handrews-relative-json-pointer-02
+
+Abstract
+
+   JSON Pointer is a syntax for specifying locations in a JSON document,
+   starting from the document root.  This document defines an extension
+   to the JSON Pointer syntax, allowing relative locations from within
+   the document.
+
+Status of This Memo
+
+   This Internet-Draft is submitted in full conformance with the
+   provisions of BCP 78 and BCP 79.
+
+   Internet-Drafts are working documents of the Internet Engineering
+   Task Force (IETF).  Note that other groups may also distribute
+   working documents as Internet-Drafts.  The list of current Internet-
+   Drafts is at https://datatracker.ietf.org/drafts/current/.
+
+   Internet-Drafts are draft documents valid for a maximum of six months
+   and may be updated, replaced, or obsoleted by other documents at any
+   time.  It is inappropriate to use Internet-Drafts as reference
+   material or to cite them other than as "work in progress."
+
+   This Internet-Draft will expire on November 26, 2019.
+
+Copyright Notice
+
+   Copyright (c) 2019 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (https://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+
+
+Luff & Andrews          Expires November 26, 2019               [Page 1]
+
+Internet-Draft           Relative JSON Pointers                 May 2019
+
+
+Table of Contents
+
+   1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   2
+   2.  Conventions and Terminology . . . . . . . . . . . . . . . . .   2
+   3.  Syntax  . . . . . . . . . . . . . . . . . . . . . . . . . . .   2
+   4.  Evaluation  . . . . . . . . . . . . . . . . . . . . . . . . .   3
+   5.  JSON String Representation  . . . . . . . . . . . . . . . . .   4
+     5.1.  Examples  . . . . . . . . . . . . . . . . . . . . . . . .   4
+   6.  Non-use in URI Fragment Identifiers . . . . . . . . . . . . .   5
+   7.  Error Handling  . . . . . . . . . . . . . . . . . . . . . . .   5
+   8.  Relationship to JSON Pointer  . . . . . . . . . . . . . . . .   5
+   9.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .   5
+   10. Security Considerations . . . . . . . . . . . . . . . . . . .   5
+   11. References  . . . . . . . . . . . . . . . . . . . . . . . . .   6
+     11.1.  Normative References . . . . . . . . . . . . . . . . . .   6
+     11.2.  Informative References . . . . . . . . . . . . . . . . .   6
+   Appendix A.  ChangeLog  . . . . . . . . . . . . . . . . . . . . .   7
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .   7
+
+1.  Introduction
+
+   JSON Pointer (RFC 6901 [RFC6901]) is a syntax for specifying
+   locations in a JSON document, starting from the document root.  This
+   document defines a related syntax allowing identification of relative
+   locations from within the document.
+
+2.  Conventions and Terminology
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in RFC 2119 [RFC2119].
+
+3.  Syntax
+
+   A Relative JSON Pointer is a Unicode string in UTF-8 encoding (see
+   RFC 8259, Section 8 [RFC8259]), comprising a non-negative integer,
+   followed by either a '#' (%x23) character or a JSON Pointer (RFC 6901
+   [RFC6901]).
+
+   The separation between the integer prefix and the JSON Pointer will
+   always be unambiguous, because a JSON Pointer must be either zero-
+   length or start with a '/' (%x2F).  Similarly, a JSON Pointer will
+   never be ambiguous with the '#'.
+
+
+
+
+
+
+
+
+Luff & Andrews          Expires November 26, 2019               [Page 2]
+
+Internet-Draft           Relative JSON Pointers                 May 2019
+
+
+              The ABNF syntax of a Relative JSON Pointer is:
+
+
+      relative-json-pointer =  non-negative-integer &lt;json-pointer&gt;
+      relative-json-pointer =/ non-negative-integer "#"
+      non-negative-integer      =  %x30 / %x31-39 *( %x30-39 )
+              ; "0", or digits without a leading "0"
+
+
+     where <json-pointer> follows the production defined in RFC 6901,
+                      Section 3 [RFC6901] ("Syntax").
+
+4.  Evaluation
+
+   Evaluation of a Relative JSON Pointer begins with a reference to a
+   value within a JSON document, and completes with either a value
+   within that document, a string corresponding to an object member, or
+   integer value representing an array index.
+
+   Evaluation begins by processing the non-negative-integer prefix.
+   This can be found by taking the longest continuous sequence of
+   decimal digits available, starting from the beginning of the string,
+   taking the decimal numerical value.  If this value is more than zero,
+   then the following steps are repeated that number of times:
+
+      If the current referenced value is the root of the document, then
+      evaluation fails (see below).
+
+      If the referenced value is an item within an array, then the new
+      referenced value is that array.
+
+      If the referenced value is an object member within an object, then
+      the new referenced value is that object.
+
+   If the remainder of the Relative JSON Pointer is a JSON Pointer, then
+   evaluation proceeds as per RFC 6901, Section 4 [RFC6901]
+   ("Evaluation"), with the modification that the initial reference
+   being used is the reference currently being held (which may not be
+   root of the document).
+
+   Otherwise (when the remainder of the Relative JSON Pointer is the
+   character '#'), the final result is determined as follows:
+
+      If the current referenced value is the root of the document, then
+      evaluation fails (see below).
+
+      If the referenced value is an item within an array, then the final
+      evaluation result is the value's index position within the array.
+
+
+
+Luff & Andrews          Expires November 26, 2019               [Page 3]
+
+Internet-Draft           Relative JSON Pointers                 May 2019
+
+
+      If the referenced value is an object member within an object, then
+      the new referenced value is the corresponding member name.
+
+5.  JSON String Representation
+
+   The concerns surrounding JSON String representation of a Relative
+   JSON Pointer are identical to those laid out in RFC 6901, Section 5
+   [RFC6901].
+
+5.1.  Examples
+
+                   For example, given the JSON document:
+
+
+                         {
+                            "foo": ["bar", "baz"],
+                            "highly": {
+                               "nested": {
+                                  "objects": true
+                               }
+                            }
+                         }
+
+
+     Starting from the value "baz" (inside "foo"), the following JSON
+               strings evaluate to the accompanying values:
+
+
+                     "0"                         "baz"
+                     "1/0"                       "bar"
+                     "2/highly/nested/objects"   true
+                     "0#"                        1
+                     "1#"                        "foo"
+
+
+   Starting from the value {"objects":true} (corresponding to the member
+         key "nested"), the following JSON strings evaluate to the
+                           accompanying values:
+
+
+                   "0/objects"                 true
+                   "1/nested/objects"          true
+                   "2/foo/0"                   "bar"
+                   "0#"                        "nested"
+                   "1#"                        "highly"
+
+
+
+
+
+
+Luff & Andrews          Expires November 26, 2019               [Page 4]
+
+Internet-Draft           Relative JSON Pointers                 May 2019
+
+
+6.  Non-use in URI Fragment Identifiers
+
+   Unlike a JSON Pointer, a Relative JSON Pointer can not be used in a
+   URI fragment identifier.  Such fragments specify exact positions
+   within a document, and therefore Relative JSON Pointers are not
+   suitable.
+
+7.  Error Handling
+
+   In the event of an error condition, evaluation of the JSON Pointer
+   fails to complete.
+
+   Evaluation may fail due to invalid syntax, or referencing a non-
+   existent value.  This specification does not define how errors are
+   handled.  An application of JSON Relative Pointer SHOULD specify the
+   impact and handling of each type of error.
+
+8.  Relationship to JSON Pointer
+
+   Relative JSON Pointers are intended as a companion to JSON Pointers.
+   Applications MUST specify the use of each syntax separately.
+   Defining either JSON Pointer or Relative JSON Pointer as an
+   acceptable syntax does not imply that the other syntax is also
+   acceptable.
+
+9.  Acknowledgements
+
+   The language and structure of this specification are based heavily on
+   [RFC6901], sometimes quoting it outright.
+
+   This draft remains primarily as written and published by Geraint
+   Luff, with only minor subsequent alterations under new editorship.
+
+10.  Security Considerations
+
+   Evaluation of a given Relative JSON Pointer is not guaranteed to
+   reference an actual JSON value.  Applications using Relative JSON
+   Pointer should anticipate this situation by defining how a pointer
+   that does not resolve ought to be handled.
+
+   As part of processing, a composite data structure may be assembled
+   from multiple JSON documents (in part or in full).  In such cases,
+   applications SHOULD ensure that a Relative JSON Pointer does not
+   evaluate to a value outside the document for which is was written.
+
+   Note that JSON pointers can contain the NUL (Unicode U+0000)
+   character.  Care is needed not to misinterpret this character in
+   programming languages that use NUL to mark the end of a string.
+
+
+
+Luff & Andrews          Expires November 26, 2019               [Page 5]
+
+Internet-Draft           Relative JSON Pointers                 May 2019
+
+
+11.  References
+
+11.1.  Normative References
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119,
+              DOI 10.17487/RFC2119, March 1997,
+              <https://www.rfc-editor.org/info/rfc2119>.
+
+   [RFC6901]  Bryan, P., Ed., Zyp, K., and M. Nottingham, Ed.,
+              "JavaScript Object Notation (JSON) Pointer", RFC 6901,
+              DOI 10.17487/RFC6901, April 2013,
+              <https://www.rfc-editor.org/info/rfc6901>.
+
+11.2.  Informative References
+
+   [RFC8259]  Bray, T., Ed., "The JavaScript Object Notation (JSON) Data
+              Interchange Format", STD 90, RFC 8259,
+              DOI 10.17487/RFC8259, December 2017,
+              <https://www.rfc-editor.org/info/rfc8259>.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Luff & Andrews          Expires November 26, 2019               [Page 6]
+
+Internet-Draft           Relative JSON Pointers                 May 2019
+
+
+Appendix A.  ChangeLog
+
+   [[CREF1: This section to be removed before leaving Internet-Draft
+   status.]]
+
+   draft-handrews-relative-json-pointer-02
+
+      *  Update to the latest JSON RFC
+
+   draft-handrews-relative-json-pointer-01
+
+      *  The initial number is "non-negative", not "positive"
+
+   draft-handrews-relative-json-pointer-00
+
+      *  Revived draft with identical wording and structure.
+
+      *  Clarified how to use alongside JSON Pointer.
+
+   draft-luff-relative-json-pointer-00
+
+      *  Initial draft.
+
+Authors' Addresses
+
+   Geraint Luff
+   Cambridge
+   UK
+
+   EMail: luffgd@gmail.com
+
+
+   Henry Andrews (editor)
+   Riverbed Technology
+   680 Folsom St.
+   San Francisco, CA
+   USA
+
+   EMail: handrews@riverbed.com
+
+
+
+
+
+
+
+
+
+
+
+
+Luff & Andrews          Expires November 26, 2019               [Page 7]

--- a/work-in-progress/WIP-relative-json-pointer.txt
+++ b/work-in-progress/WIP-relative-json-pointer.txt
@@ -10,7 +10,7 @@ Expires: November 26, 2019                           Riverbed Technology
 
 
                          Relative JSON Pointers
-                draft-handrews-relative-json-pointer-02
+                draft-handrews-relative-json-pointer-WIP
 
 Abstract
 
@@ -343,7 +343,7 @@ Appendix A.  ChangeLog
    [[CREF1: This section to be removed before leaving Internet-Draft
    status.]]
 
-   draft-handrews-relative-json-pointer-02
+   draft-handrews-relative-json-pointer-WIP
 
       *  Update to the latest JSON RFC
 

--- a/work-in-progress/WIP-schema.json
+++ b/work-in-progress/WIP-schema.json
@@ -1,0 +1,42 @@
+{
+    "$schema": "http://json-schema.org/draft/2019-04/schema#",
+    "$id": "http://json-schema.org/draft/2019-04/schema#",
+    "$vocabulary": {
+        "https://json-schema.org/draft/2019-04/vocab/core": true,
+        "https://json-schema.org/draft/2019-04/vocab/applicator": true,
+        "https://json-schema.org/draft/2019-04/vocab/validation": true,
+        "https://json-schema.org/draft/2019-04/vocab/meta-data": true,
+        "https://json-schema.org/draft/2019-04/vocab/format": true,
+        "https://json-schema.org/draft/2019-04/vocab/content": true
+    },
+    "$recursiveAnchor": true,
+
+    "title": "Core and Validation specifications meta-schema",
+    "allOf": [
+        {"$ref": "meta/core"},
+        {"$ref": "meta/applicator"},
+        {"$ref": "meta/validation"},
+        {"$ref": "meta/meta-data"},
+        {"$ref": "meta/format"},
+        {"$ref": "meta/content"}
+    ],
+    "type": ["object", "boolean"],
+    "properties": {
+        "definitions": {
+            "$comment": "While no longer an official keyword as it is replaced by $defs, this keyword is retained in the meta-schema to prevent incompatible extensions as it remains in common use.",
+            "type": "object",
+            "additionalProperties": { "$recursiveRef": "#" },
+            "default": {}
+        },
+        "dependencies": {
+            "$comment": "\"dependencies\" is no longer a keyword, but schema authors should avoid redefining it to facilitate a smooth transition to \"dependentSchemas\" and \"dependentRequired\"",
+            "type": "object",
+            "additionalProperties": {
+                "anyOf": [
+                    { "$recursiveRef": "#" },
+                    { "$ref": "meta/validation#/$defs/stringArray" }
+                ]
+            }
+        }
+    }
+}

--- a/work-in-progress/WIP-schema.json
+++ b/work-in-progress/WIP-schema.json
@@ -1,13 +1,13 @@
 {
-    "$schema": "http://json-schema.org/draft/2019-04/schema#",
-    "$id": "http://json-schema.org/draft/2019-04/schema#",
+    "$schema": "http://json-schema.org/draft/2019-WIP/schema#",
+    "$id": "http://json-schema.org/draft/2019-WIP/schema#",
     "$vocabulary": {
-        "https://json-schema.org/draft/2019-04/vocab/core": true,
-        "https://json-schema.org/draft/2019-04/vocab/applicator": true,
-        "https://json-schema.org/draft/2019-04/vocab/validation": true,
-        "https://json-schema.org/draft/2019-04/vocab/meta-data": true,
-        "https://json-schema.org/draft/2019-04/vocab/format": true,
-        "https://json-schema.org/draft/2019-04/vocab/content": true
+        "https://json-schema.org/draft/2019-WIP/vocab/core": true,
+        "https://json-schema.org/draft/2019-WIP/vocab/applicator": true,
+        "https://json-schema.org/draft/2019-WIP/vocab/validation": true,
+        "https://json-schema.org/draft/2019-WIP/vocab/meta-data": true,
+        "https://json-schema.org/draft/2019-WIP/vocab/format": true,
+        "https://json-schema.org/draft/2019-WIP/vocab/content": true
     },
     "$recursiveAnchor": true,
 

--- a/work-in-progress/index.md
+++ b/work-in-progress/index.md
@@ -7,7 +7,116 @@ permalink: /work-in-progress
 * TOC
 {:toc}
 
-**draft-07** (a.k.a. **draft-handrews-\*-00**) has been released!
-Please see the [specification](../documentation.md) page for details.
+## The Next Draft (by whatever name) Is Ready for Final Pre-Publication Review!
 
-This page will remain empty until draft-08 enters the final pre-publication review period.
+The forthcoming draft is now feature-frozen and entering the final four-week feedback
+period before publication.  This final review will last from May 27th to June 24th, 2019.
+
+The timeline may be compressed if, after at least two weeks, there is a clear consensus that
+the drafts are solid and it would be best to publish sooner rather than later.
+
+The following sorts of feedback are particularly desired:
+
+* Clarity, readability, and accessibility to new readers
+* Contradictions, inconsistencies and other bugs
+* Anything so egregious that implementation would be infeasible or impossible
+
+New features or major changes to existing features will be deferred to a future draft,
+and work on the next draft will begin immediately after this one is published.
+
+## What Is This Draft Called, Anyway?
+
+We have typically referred to this as `draft-08`, following our own convention of just
+incrementing the draft number for meta-schemas regardless of the IETF identifier.
+
+However, this is frowned upon by the IETF and has in fact been a source of confusion.
+It worked well up to and including `draft-04`, as even after the split into multiple
+documents, `draft-zyp-json-schema-04` (the core spec) at least ended in `-04`!
+Unfortnately, after that point, the numbers stopped matching in any way.
+
+Assuming this new draft gets published more or less as presented in this WIP,
+and by the end of June, it will be:
+
+* IETF identifiers: `draft-handrews-*-02`
+* Meta-schema identifiers: `draft/2019-06`
+
+Meta-schemas will now be identified with dates, which can be correlated with the publication
+and expiration dates of the IETF documents.  This will make it more clear when a bugfix
+meta-schema is produced, and also make it more obvious that the IETF and meta-schema identifiers
+are not expected to match exactly.
+
+## Pre-Built Review Documents
+
+To encourage as many reviewers as possible, pre-built documents are available.  These may
+slightly lag those in the GitHub repository, although all efforts will be made to keep them
+in sync during the review period.  After the review period, these will be removed.  In particular,
+using "WORK IN PROGRESS" meta-schemas **is not allowed** and **will break** as soon as the files
+are moved to their permanent homes.
+
+### Specifications:
+
+As always, these are the actual normative documents:
+
+_**NOTE:** Links to meta-schemas and among the drafts will not work correctly in these review copies._
+
+* [WIP: JSON Schema (core)](/work-in-progress/WIP-jsonschema-core.html)
+* [WIP: JSON Schema Validation](/work-in-progress/WIP-jsonschema-validation.html)
+* [WIP: JSON Schema Hyper-Schema](/work-in-progress/WIP-jsonschema-hyperschema.html)
+* [WIP: Relative JSON Pointer](/work-in-progress/WIP-relative-json-pointer.html)
+
+### General use meta-schemas:
+
+These are the traditional non-normative meta-schemas, which serve the same purpose as
+in previous drafts, although their internal structure is different.
+
+_**NOTE:** when published, the `.json` will be removed from the final URI_
+
+* [WIP: schema.json](/work-in-progress/WIP-schema.json) (core and validation)
+* [WIP: links.json](/work-in-progress/WIP-links.json) (individual link description object)
+* [WIP: hyper-schema.json](/work-in-progress/WIP-hyper-schema.json) (hyper-schema, references schema and links)
+
+### Single-vocabulary meta-schemas:
+
+The new draft introduces the concept of modular vocabularies.  Most schema authors will not directly
+reference these meta-schemas.  Instead, they are combined in useful ways by the general use meta-schemas.
+However, those wishing to build custom meta-schemas may find it useful to choose different subsets of
+the standard keywords depending on the custom meta-schema's intended purpose.
+
+_**NOTE:** when published, the `.json` will be removed from the final URI_
+
+* [WIP: meta/core.json](/work-in-progress/meta/WIP-core.json) (core keywords, from the core spec)
+* [WIP: meta/applicator.json](/work-in-progress/meta/WIP-applicator.json) (applicator keywords, from the core spec)
+* [WIP: meta/validation.json](/work-in-progress/meta/WIP-validation.json) (validation assertions, from the validation spec)
+* [WIP: meta/meta-data.json](/work-in-progress/meta/WIP-meta-data.json) (meta-data annotations, from the validation spec)
+* [WIP: meta/format.json](/work-in-progress/meta/WIP-format.json) (the format keyword, from the validation spec)
+* [WIP: meta/content.json](/work-in-progress/meta/WIP-content.json) (content keywords, from the validation spec)
+* [WIP: meta/hyper-schema.json](/work-in-progress/meta/WIP-hyper-schema.json) (hyper-schema keywords, from the hyper-shema spec)
+
+### Output schema:
+
+The new draft also introduces recommended output formats for reporting errors and annotations.
+
+_**NOTE:** when published, the `.json` will be removed from the final URI_
+
+* [WIP: schema.json](/work-in-progress/output/WIP-schema.json) (schema for recommended output formats)
+* [WIP: verbose-example.json](/work-in-progress/output/WIP-verbose-example.json) (example of the most verbose output format)
+* [WIP: hyper-schema.json](/work-in-progress/output/WIP-hyper-schema.json) (format used by the proposed hyper-schema test suite, and used in examples in the specification)
+
+## Providing Feedback and Tracking Progress in GitHub
+
+We are **particularly interested** in feedback on whether the wording and concepts is an
+improvement in terms of how easy it is to understand and learn the specifications.
+
+Note that _all drafts have Changelog appendicies_, for a concise list of notable changes.
+
+* The active sources are on the
+["master" branch of json-schema-org/json-schema-spec](https://github.com/json-schema-org/json-schema-spec)
+* The [draft-08 milestone](https://github.com/json-schema-org/json-schema-spec/milestone/6)
+  tracks all issues and PRs for this draft
+  _(yes, it's still called draft-08 here because GitHub doesn't handle milestone renames well)_
+* Check the [open PRs](https://github.com/json-schema-org/json-schema-spec/pulls)
+  to see what is already being changed from other feedback
+* [file an issue](https://github.com/json-schema-org/json-schema-spec/issues/new?milestone=draft-08)
+  or [join us on Slack](https://join.slack.com/t/json-schema/shared_invite/enQtMjk1NDcyNDI2NTAwLTcyYmYwMjdmMmUxNzZjYzIxNGU2YjdkNzdlOGZiNjIwNDI2M2Y3NmRkYjA4YmMwODMwYjgyOTFlNWZjZjAyNjg) to submit feedback
+  _(technically there is also a [mailing list](https://groups.google.com/forum/#!forum/json-schema) but it gets very little traffic and is not closely monitored)_
+

--- a/work-in-progress/meta/WIP-applicator.json
+++ b/work-in-progress/meta/WIP-applicator.json
@@ -1,0 +1,60 @@
+{
+    "$schema": "http://json-schema.org/draft/2019-04/schema#",
+    "$id": "https://json-schema.org/draft/2019-04/meta/applicator",
+    "$vocabulary": {
+        "https://json-schema.org/draft/2019-04/vocab/applicator": true
+    },
+    "$recursiveAnchor": true,
+
+    "title": "Applicator vocabulary meta-schema",
+    "properties": {
+        "additionalItems": { "$recursiveRef": "#" },
+        "unevaluatedItems": { "$recursiveRef": "#" },
+        "items": {
+            "anyOf": [
+                { "$recursiveRef": "#" },
+                { "$ref": "#/$defs/schemaArray" }
+            ]
+        },
+        "contains": { "$recursiveRef": "#" },
+        "additionalProperties": { "$recursiveRef": "#" },
+        "unevaluatedProperties": {
+            "type": "object",
+            "additionalProperties": {
+                "$recursiveRef": "#"
+            }
+        },
+        "properties": {
+            "type": "object",
+            "additionalProperties": { "$recursiveRef": "#" },
+            "default": {}
+        },
+        "patternProperties": {
+            "type": "object",
+            "additionalProperties": { "$recursiveRef": "#" },
+            "propertyNames": { "format": "regex" },
+            "default": {}
+        },
+        "dependentSchemas": {
+            "type": "object",
+            "additionalProperties": {
+                "$recursiveRef": "#"
+            }
+        },
+        "propertyNames": { "$recursiveRef": "#" },
+        "if": { "$recursiveRef": "#" },
+        "then": { "$recursiveRef": "#" },
+        "else": { "$recursiveRef": "#" },
+        "allOf": { "$ref": "#/$defs/schemaArray" },
+        "anyOf": { "$ref": "#/$defs/schemaArray" },
+        "oneOf": { "$ref": "#/$defs/schemaArray" },
+        "not": { "$recursiveRef": "#" }
+    },
+    "$defs": {
+        "schemaArray": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "$recursiveRef": "#" }
+        }
+    }
+}

--- a/work-in-progress/meta/WIP-applicator.json
+++ b/work-in-progress/meta/WIP-applicator.json
@@ -1,8 +1,8 @@
 {
-    "$schema": "http://json-schema.org/draft/2019-04/schema#",
-    "$id": "https://json-schema.org/draft/2019-04/meta/applicator",
+    "$schema": "http://json-schema.org/draft/2019-WIP/schema#",
+    "$id": "https://json-schema.org/draft/2019-WIP/meta/applicator",
     "$vocabulary": {
-        "https://json-schema.org/draft/2019-04/vocab/applicator": true
+        "https://json-schema.org/draft/2019-WIP/vocab/applicator": true
     },
     "$recursiveAnchor": true,
 

--- a/work-in-progress/meta/WIP-content.json
+++ b/work-in-progress/meta/WIP-content.json
@@ -1,0 +1,17 @@
+{
+    "$schema": "http://json-schema.org/draft/2019-04/schema#",
+    "$id": "http://json-schema.org/draft/2019-04/meta/content",
+    "$vocabulary": {
+        "https://json-schema.org/draft/2019-04/vocab/content": true
+    },
+    "$recursiveAnchor": true,
+
+    "title": "Content vocabulary meta-schema",
+
+    "type": ["object", "boolean"],
+    "properties": {
+        "contentMediaType": { "type": "string" },
+        "contentEncoding": { "type": "string" },
+        "contentSchema": { "$recursiveRef": "#" }
+    }
+}

--- a/work-in-progress/meta/WIP-content.json
+++ b/work-in-progress/meta/WIP-content.json
@@ -1,8 +1,8 @@
 {
-    "$schema": "http://json-schema.org/draft/2019-04/schema#",
-    "$id": "http://json-schema.org/draft/2019-04/meta/content",
+    "$schema": "http://json-schema.org/draft/2019-WIP/schema#",
+    "$id": "http://json-schema.org/draft/2019-WIP/meta/content",
     "$vocabulary": {
-        "https://json-schema.org/draft/2019-04/vocab/content": true
+        "https://json-schema.org/draft/2019-WIP/vocab/content": true
     },
     "$recursiveAnchor": true,
 

--- a/work-in-progress/meta/WIP-core.json
+++ b/work-in-progress/meta/WIP-core.json
@@ -1,0 +1,52 @@
+{
+    "$schema": "http://json-schema.org/draft/2019-04/schema#",
+    "$id": "https://json-schema.org/draft/2019-04/meta/core",
+    "$vocabulary": {
+        "https://json-schema.org/draft/2019-04/vocab/core": true
+    },
+    "$recursiveAnchor": true,
+
+    "title": "Core vocabulary meta-schema",
+    "type": ["object", "boolean"],
+    "properties": {
+        "$id": {
+            "type": "string",
+            "format": "uri-reference"
+        },
+        "$schema": {
+            "type": "string",
+            "format": "uri"
+        },
+        "$ref": {
+            "type": "string",
+            "format": "uri-reference"
+        },
+        "$recursiveRef": {
+            "type": "string",
+            "format": "uri-reference"
+        },
+        "$recursiveAnchor": {
+            "type": "boolean",
+            "const": true,
+            "default": false
+        },
+        "$vocabulary": {
+            "type": "object",
+            "propertyNames": {
+                "type": "string",
+                "format": "uri"
+            },
+            "additionalProperties": {
+                "type": "boolean"
+            }
+        },
+        "$comment": {
+            "type": "string"
+        },
+        "$defs": {
+            "type": "object",
+            "additionalProperties": { "$recursiveRef": "#" },
+            "default": {}
+        }
+    }
+}

--- a/work-in-progress/meta/WIP-core.json
+++ b/work-in-progress/meta/WIP-core.json
@@ -1,8 +1,8 @@
 {
-    "$schema": "http://json-schema.org/draft/2019-04/schema#",
-    "$id": "https://json-schema.org/draft/2019-04/meta/core",
+    "$schema": "http://json-schema.org/draft/2019-WIP/schema#",
+    "$id": "https://json-schema.org/draft/2019-WIP/meta/core",
     "$vocabulary": {
-        "https://json-schema.org/draft/2019-04/vocab/core": true
+        "https://json-schema.org/draft/2019-WIP/vocab/core": true
     },
     "$recursiveAnchor": true,
 

--- a/work-in-progress/meta/WIP-format.json
+++ b/work-in-progress/meta/WIP-format.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "http://json-schema.org/draft/2019-04/schema#",
+    "$id": "http://json-schema.org/draft/2019-04/meta/format",
+    "$vocabulary": {
+        "https://json-schema.org/draft/2019-04/vocab/format": true
+    },
+    "$recursiveAnchor": true,
+
+    "title": "Format vocabulary meta-schema",
+    "type": ["object", "boolean"],
+    "properties": {
+        "format": { "type": "string" }
+    }
+}

--- a/work-in-progress/meta/WIP-format.json
+++ b/work-in-progress/meta/WIP-format.json
@@ -1,8 +1,8 @@
 {
-    "$schema": "http://json-schema.org/draft/2019-04/schema#",
-    "$id": "http://json-schema.org/draft/2019-04/meta/format",
+    "$schema": "http://json-schema.org/draft/2019-WIP/schema#",
+    "$id": "http://json-schema.org/draft/2019-WIP/meta/format",
     "$vocabulary": {
-        "https://json-schema.org/draft/2019-04/vocab/format": true
+        "https://json-schema.org/draft/2019-WIP/vocab/format": true
     },
     "$recursiveAnchor": true,
 

--- a/work-in-progress/meta/WIP-hyper-schema.json
+++ b/work-in-progress/meta/WIP-hyper-schema.json
@@ -1,0 +1,29 @@
+{
+    "$schema": "http://json-schema.org/draft/2019-04/hyper-schema#",
+    "$id": "http://json-schema.org/draft/2019-04/meta/hyper-schema",
+    "$vocabulary": {
+        "https://json-schema.org/draft/2019-04/vocab/hyper-schema": true
+    },
+    "$recursiveAnchor": true,
+
+    "title": "JSON Hyper-Schema Vocabulary Schema",
+    "type": ["object", "boolean"],
+    "properties": {
+        "base": {
+            "type": "string",
+            "format": "uri-template"
+        },
+        "links": {
+            "type": "array",
+            "items": {
+                "$ref": "http://json-schema.org/draft/2019-04/links"
+            }
+        }
+    },
+    "links": [
+        {
+            "rel": "self",
+            "href": "{+%24id}"
+        }
+    ]
+}

--- a/work-in-progress/meta/WIP-hyper-schema.json
+++ b/work-in-progress/meta/WIP-hyper-schema.json
@@ -1,8 +1,8 @@
 {
-    "$schema": "http://json-schema.org/draft/2019-04/hyper-schema#",
-    "$id": "http://json-schema.org/draft/2019-04/meta/hyper-schema",
+    "$schema": "http://json-schema.org/draft/2019-WIP/hyper-schema#",
+    "$id": "http://json-schema.org/draft/2019-WIP/meta/hyper-schema",
     "$vocabulary": {
-        "https://json-schema.org/draft/2019-04/vocab/hyper-schema": true
+        "https://json-schema.org/draft/2019-WIP/vocab/hyper-schema": true
     },
     "$recursiveAnchor": true,
 
@@ -16,7 +16,7 @@
         "links": {
             "type": "array",
             "items": {
-                "$ref": "http://json-schema.org/draft/2019-04/links"
+                "$ref": "http://json-schema.org/draft/2019-WIP/links"
             }
         }
     },

--- a/work-in-progress/meta/WIP-meta-data.json
+++ b/work-in-progress/meta/WIP-meta-data.json
@@ -1,0 +1,37 @@
+{
+    "$schema": "http://json-schema.org/draft/2019-04/schema#",
+    "$id": "http://json-schema.org/draft/2019-04/meta/meta-data",
+    "$vocabulary": {
+        "https://json-schema.org/draft/2019-04/vocab/meta-data": true
+    },
+    "$recursiveAnchor": true,
+
+    "title": "Meta-data vocabulary meta-schema",
+
+    "type": ["object", "boolean"],
+    "properties": {
+        "title": {
+            "type": "string"
+        },
+        "description": {
+            "type": "string"
+        },
+        "default": true,
+        "deprecated": {
+            "type": "boolean",
+            "default": false
+        },
+        "readOnly": {
+            "type": "boolean",
+            "default": false
+        },
+        "writeOnly": {
+            "type": "boolean",
+            "default": false
+        },
+        "examples": {
+            "type": "array",
+            "items": true
+        }
+    }
+}

--- a/work-in-progress/meta/WIP-meta-data.json
+++ b/work-in-progress/meta/WIP-meta-data.json
@@ -1,8 +1,8 @@
 {
-    "$schema": "http://json-schema.org/draft/2019-04/schema#",
-    "$id": "http://json-schema.org/draft/2019-04/meta/meta-data",
+    "$schema": "http://json-schema.org/draft/2019-WIP/schema#",
+    "$id": "http://json-schema.org/draft/2019-WIP/meta/meta-data",
     "$vocabulary": {
-        "https://json-schema.org/draft/2019-04/vocab/meta-data": true
+        "https://json-schema.org/draft/2019-WIP/vocab/meta-data": true
     },
     "$recursiveAnchor": true,
 

--- a/work-in-progress/meta/WIP-validation.json
+++ b/work-in-progress/meta/WIP-validation.json
@@ -1,0 +1,98 @@
+{
+    "$schema": "http://json-schema.org/draft/2019-04/schema#",
+    "$id": "http://json-schema.org/draft/2019-04/meta/validation",
+    "$vocabulary": {
+        "https://json-schema.org/draft/2019-04/vocab/validation": true
+    },
+    "$recursiveAnchor": true,
+
+    "title": "Validation vocabulary meta-schema",
+    "type": ["object", "boolean"],
+    "properties": {
+        "multipleOf": {
+            "type": "number",
+            "exclusiveMinimum": 0
+        },
+        "maximum": {
+            "type": "number"
+        },
+        "exclusiveMaximum": {
+            "type": "number"
+        },
+        "minimum": {
+            "type": "number"
+        },
+        "exclusiveMinimum": {
+            "type": "number"
+        },
+        "maxLength": { "$ref": "#/$defs/nonNegativeInteger" },
+        "minLength": { "$ref": "#/$defs/nonNegativeIntegerDefault0" },
+        "pattern": {
+            "type": "string",
+            "format": "regex"
+        },
+        "maxItems": { "$ref": "#/$defs/nonNegativeInteger" },
+        "minItems": { "$ref": "#/$defs/nonNegativeIntegerDefault0" },
+        "uniqueItems": {
+            "type": "boolean",
+            "default": false
+        },
+        "maxContains": { "$ref": "#/$defs/nonNegativeInteger" },
+        "minContains": {
+            "$ref": "#/$defs/nonNegativeInteger",
+            "default": 1
+        },
+        "maxProperties": { "$ref": "#/$defs/nonNegativeInteger" },
+        "minProperties": { "$ref": "#/$defs/nonNegativeIntegerDefault0" },
+        "required": { "$ref": "#/$defs/stringArray" },
+        "dependentRequired": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/$defs/stringArray"
+            }
+        },
+        "const": true,
+        "enum": {
+            "type": "array",
+            "items": true
+        },
+        "type": {
+            "anyOf": [
+                { "$ref": "#/$defs/simpleTypes" },
+                {
+                    "type": "array",
+                    "items": { "$ref": "#/$defs/simpleTypes" },
+                    "minItems": 1,
+                    "uniqueItems": true
+                }
+            ]
+        }
+    },
+    "$defs": {
+        "nonNegativeInteger": {
+            "type": "integer",
+            "minimum": 0
+        },
+        "nonNegativeIntegerDefault0": {
+            "$ref": "#/$defs/nonNegativeInteger",
+            "default": 0
+        },
+        "simpleTypes": {
+            "enum": [
+                "array",
+                "boolean",
+                "integer",
+                "null",
+                "number",
+                "object",
+                "string"
+            ]
+        },
+        "stringArray": {
+            "type": "array",
+            "items": { "type": "string" },
+            "uniqueItems": true,
+            "default": []
+        }
+    }
+}

--- a/work-in-progress/meta/WIP-validation.json
+++ b/work-in-progress/meta/WIP-validation.json
@@ -1,8 +1,8 @@
 {
-    "$schema": "http://json-schema.org/draft/2019-04/schema#",
-    "$id": "http://json-schema.org/draft/2019-04/meta/validation",
+    "$schema": "http://json-schema.org/draft/2019-WIP/schema#",
+    "$id": "http://json-schema.org/draft/2019-WIP/meta/validation",
     "$vocabulary": {
-        "https://json-schema.org/draft/2019-04/vocab/validation": true
+        "https://json-schema.org/draft/2019-WIP/vocab/validation": true
     },
     "$recursiveAnchor": true,
 

--- a/work-in-progress/output/WIP-hyper-schema.json
+++ b/work-in-progress/output/WIP-hyper-schema.json
@@ -1,0 +1,62 @@
+{
+    "$schema": "http://json-schema.org/draft/2019-04/schema#",
+    "$id": "http://json-schema.org/draft/2019-04/output/hyper-schema",
+    "title": "JSON Hyper-Schema Output",
+    "type": "array",
+    "items": {
+        "allOf": [
+            {"$ref": "http://json-schema.org/draft/2019-04/links#/$defs/noRequiredFields" }
+        ],
+        "type": "object",
+        "required": [
+            "contextUri",
+            "contextPointer",
+            "rel",
+            "attachmentPointer"
+        ],
+        "if": { "required": [ "hrefSchema" ] },
+        "then": { "required": [ "hrefInputTemplates", "hrefPrepopulatedInput" ] },
+        "else": { "required": [ "targetUri" ] },
+        "properties": {
+            "contextUri": {
+                "$comment": "The fully resolved URI of the link context, including a fragment if it is possible to construct one for the given media type and instance",
+                "type": "string",
+                "format": "uri"
+            },
+            "contextPointer": {
+                "$comment": "The absolute JSON Pointer to the location in the instance that is the context of the link.  If the context resource supports JSON Pointer fragments, this will the string form of the identical JSON Pointer",
+                "type": "string",
+                "format": "json-pointer"
+            },
+            "rel": {
+                "type": "string"
+            },
+            "targetUri": {
+                "$comment": "The fully resolved target URI",
+                "type": "string",
+                "format": "uri"
+            },
+            "hrefInputTemplates": {
+                "$comment": "The list of partially resolved URI Templates, starting with \"href\", followed by applicable \"base\" values from nearest to furthest.",
+                "type": "array",
+                "items": {
+                    "type": "string",
+                    "format": "uri-template"
+                }
+            },
+            "hrefPrepopulatedInput": {
+                "$comment": "The initial data set to be presented with the input form when URI Tempalte input is accepted.",
+                "type": "object",
+                "propertyNames": {
+                    "$comment": "These are all URI Template variable names, specifically the 'varname' production from RFC 6570, Section 2.3",
+                    "pattern": "^(?:\\w|(?:%[a-f\\d]{2}))+(?:\\.(?:\\w|(?:%[a-f\\d]{2})))*$"
+                }
+            },
+            "attachmentPointer": {
+                "$comment": "The absolute JSON Pointer, in string form, of the position to which this resolved link applies",
+                "type": "string",
+                "format": "json-pointer"
+            }
+        }
+    }
+}

--- a/work-in-progress/output/WIP-hyper-schema.json
+++ b/work-in-progress/output/WIP-hyper-schema.json
@@ -1,11 +1,11 @@
 {
-    "$schema": "http://json-schema.org/draft/2019-04/schema#",
-    "$id": "http://json-schema.org/draft/2019-04/output/hyper-schema",
+    "$schema": "http://json-schema.org/draft/2019-WIP/schema#",
+    "$id": "http://json-schema.org/draft/2019-WIP/output/hyper-schema",
     "title": "JSON Hyper-Schema Output",
     "type": "array",
     "items": {
         "allOf": [
-            {"$ref": "http://json-schema.org/draft/2019-04/links#/$defs/noRequiredFields" }
+            {"$ref": "http://json-schema.org/draft/2019-WIP/links#/$defs/noRequiredFields" }
         ],
         "type": "object",
         "required": [

--- a/work-in-progress/output/WIP-schema.json
+++ b/work-in-progress/output/WIP-schema.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "http://json-schema.org/draft/2019-04/schema#",
+  "$id": "http://json-schema.org/draft/2019-04/output/schema",
+  "description": "A schema that validates the minimum requirements for validation output",
+
+  "oneOf": [
+    { "$ref": "#/$defs/flag" },
+    { "$ref": "#/$defs/basic" },
+    { "$ref": "#/$defs/detailed" },
+    { "$ref": "#/$defs/verbose" }
+  ],
+  "$defs": {
+    "outputUnit":{
+      "properties": {
+        "valid": { "type": "boolean" },
+        "keywordLocation": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "absoluteKeywordLocation": {
+          "type": "string",
+          "format": "uri"
+        },
+        "instanceLocation": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "errors": {
+          "$ref": "#/$defs/outputUnitArray"
+        },
+        "annotations": {
+          "$ref": "#/$defs/outputUnitArray"
+        }
+      },
+      "required": [ "valid", "keywordLocation", "instanceLocation" ],
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "valid": { "const": false }
+            }
+          },
+          "then": {
+            "required": [ "errors" ]
+          }
+        },
+        {
+          "if": {
+            "oneOf": [
+              {
+                "properties": {
+                  "keywordLocation": {
+                    "pattern": ".*/$ref/.*"
+                  }
+                }    
+              },
+              {
+                "properties": {
+                  "keywordLocation": {
+                    "pattern": ".*/$recursiveRef/.*"
+                  }
+                }    
+              }
+            ]
+          },
+          "then": {
+            "required": [ "absoluteKeywordLocation" ]
+          }
+        }
+      ]
+    },
+    "outputUnitArray": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/outputUnit" }
+    },
+    "flag": {
+      "properties": {
+        "valid": { "type": "boolean" }
+      },
+      "required": [ "valid" ]
+    },
+    "basic": { "$ref": "#/outputUnit" },
+    "detailed": { "$ref": "#/outputUnit" },
+    "verbose": { "$ref": "#/outputUnit" }
+  }
+}

--- a/work-in-progress/output/WIP-schema.json
+++ b/work-in-progress/output/WIP-schema.json
@@ -1,6 +1,6 @@
 {
-  "$schema": "http://json-schema.org/draft/2019-04/schema#",
-  "$id": "http://json-schema.org/draft/2019-04/output/schema",
+  "$schema": "http://json-schema.org/draft/2019-WIP/schema#",
+  "$id": "http://json-schema.org/draft/2019-WIP/output/schema",
   "description": "A schema that validates the minimum requirements for validation output",
 
   "oneOf": [

--- a/work-in-progress/output/WIP-verbose-example.json
+++ b/work-in-progress/output/WIP-verbose-example.json
@@ -1,0 +1,130 @@
+{
+  "valid": false,
+  "keywordLocation": "#",
+  "instanceLocation": "#",
+  "errors": [
+    {
+      "valid": true,
+      "keywordLocation": "#/definitions",
+      "instanceLocation": "#"
+    },
+    {
+      "valid": true,
+      "keywordLocation": "#/type",
+      "instanceLocation": "#"
+    },
+    {
+      "valid": false,
+      "keywordLocation": "#/items",
+      "instanceLocation": "#",
+      "errors": [
+        {
+          "valid": true,
+          "keywordLocation": "#/items/$ref",
+          "absoluteKeywordLocation":
+            "http://example.com/polygon#/items/$ref",
+          "instanceLocation": "#/0",
+          "annotations": [
+            {
+              "valid": true,
+              "keywordLocation": "#/items/$ref",
+              "absoluteKeywordLocation":
+                "http://example.com/polygon#/definitions/point",
+              "instanceLocation": "#/0",
+              "annotations": [
+                {
+                  "valid": true,
+                  "keywordLocation": "#/items/$ref/type",
+                  "absoluteKeywordLocation":
+                    "http://example.com/polygon#/definitions/point/type",
+                  "instanceLocation": "#/0"
+                },
+                {
+                  "valid": true,
+                  "keywordLocation": "#/items/$ref/properties",
+                  "absoluteKeywordLocation":
+                    "http://example.com/polygon#/definitions/point/properties",
+                  "instanceLocation": "#/0"
+                },
+                {
+                  "valid": true,
+                  "keywordLocation": "#/items/$ref/required",
+                  "absoluteKeywordLocation":
+                    "http://example.com/polygon#/definitions/point/required",
+                  "instanceLocation": "#/0"
+                },
+                {
+                  "valid": true,
+                  "keywordLocation": "#/items/$ref/additionalProperties",
+                  "absoluteKeywordLocation":
+                    "http://example.com/polygon#/definitions/point/additionalProperties",
+                  "instanceLocation": "#/0"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "valid": false,
+          "keywordLocation": "#/items/$ref",
+          "absoluteKeywordLocation":
+            "http://example.com/polygon#/items/$ref",
+          "instanceLocation": "#/1",
+          "errors": [
+            {
+              "valid": false,
+              "keywordLocation": "#/items/$ref",
+              "absoluteKeywordLocation":
+                "http://example.com/polygon#/definitions/point",
+              "instanceLocation": "#/1",
+              "errors": [
+                {
+                  "valid": true,
+                  "keywordLocation": "#/items/$ref/type",
+                  "absoluteKeywordLocation":
+                    "http://example.com/polygon#/definitions/point/type",
+                  "instanceLocation": "#/1"
+                },
+                {
+                  "valid": true,
+                  "keywordLocation": "#/items/$ref/properties",
+                  "absoluteKeywordLocation":
+                    "http://example.com/polygon#/definitions/point/properties",
+                  "instanceLocation": "#/1"
+                },
+                {
+                  "valid": false,
+                  "keywordLocation": "#/items/$ref/required",
+                  "absoluteKeywordLocation":
+                    "http://example.com/polygon#/definitions/point/required",
+                  "instanceLocation": "#/1"
+                },
+                {
+                  "valid": false,
+                  "keywordLocation": "#/items/$ref/additionalProperties",
+                  "absoluteKeywordLocation":
+                    "http://example.com/polygon#/definitions/point/additionalProperties",
+                  "instanceLocation": "#/1",
+                  "errors": [
+                    {
+                      "valid": false,
+                      "keywordLocation": "#/items/$ref/additionalProperties",
+                      "absoluteKeywordLocation":
+                        "http://example.com/polygon#/definitions/point/additionalProperties",
+                      "instanceLocation": "#/1/z"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "valid": false,
+      "keywordLocation": "#/minItems",
+      "instanceLocation": "#"
+    }
+  ]
+}


### PR DESCRIPTION
This revives the way we did it the last time, with some updates.

It's best to mostly just look at the first commit: https://github.com/json-schema-org/json-schema-org.github.io/pull/272/commits/1224440592cf6041dafd43da5465489ec92f3c42 for the general information.

the second one just copies over the spec files, meta-schemas, etc. unchanged.

The 3rd and 4th commits show the identifier changes from `draft-handrews-*-02` to `draft-handrews-*-WIP` and from `draft/2019-04` (which needs to be changed to `06` or `07` when we publish anyway) to `draft/2019-WIP`

***NOTE:*** This time around, the page _does not_ include a detailed overview of changes.  This is because it will be at least two weeks before I would have time to produce such a thing, if not longer.  Given the way things have been recently, probably longer.  The options are move forward without such an overview, or don't move forward at all.