### PR TITLE
Include from-code schema generator example for Java

### DIFF
--- a/implementations.md
+++ b/implementations.md
@@ -150,7 +150,7 @@ For example, the only incompatibilities between draft-04 and draft-06 involve `e
 -   Python
     -   [Pydantic](https://pydantic-docs.helpmanual.io/) (MIT) - generates schemas from Python models based on Python 3.6+ type hints.
 -   Java
-    -   [jsonschema-generator](https://github.com/victools/jsonschema-generator) (Apache 2.0) - generates schemas from Java types
+    -   [jsonschema-generator](https://github.com/victools/jsonschema-generator) (Apache 2.0) - generates schemas from Java types *supports Draft 7*
 
 #### From data
 

--- a/implementations.md
+++ b/implementations.md
@@ -149,6 +149,8 @@ For example, the only incompatibilities between draft-04 and draft-06 involve `e
     -   [typescript-json-schema](https://github.com/YousefED/typescript-json-schema)
 -   Python
     -   [Pydantic](https://pydantic-docs.helpmanual.io/) (MIT) - generates schemas from Python models based on Python 3.6+ type hints.
+-   Java
+    -   [jsonschema-generator](https://github.com/victools/jsonschema-generator) (Apache 2.0) - generates schemas from Java types
 
 #### From data
 


### PR DESCRIPTION
Hi there,

I have created a JSON Schema Generator library for Java based on the current draft version (7).
Since there is no such example listed on the website, I'd propose to include my library there.

Cheers,
Carsten