### PR TITLE
Redirect the standard vocabulary URIs

### DIFF
--- a/draft/2019-09/vocab/applicator.md
+++ b/draft/2019-09/vocab/applicator.md
@@ -1,0 +1,4 @@
+---
+redirect_to: /draft/2019-09/json-schema-core.html#rfc.section.9
+title: A Vocabulary for Applying Subschemas
+---

--- a/draft/2019-09/vocab/content.md
+++ b/draft/2019-09/vocab/content.md
@@ -1,0 +1,4 @@
+---
+redirect_to: /draft/2019-09/json-schema-validation.html#rfc.section.8
+title: A Vocabulary for the Contents of String-Encoded Data
+---

--- a/draft/2019-09/vocab/core.md
+++ b/draft/2019-09/vocab/core.md
@@ -1,0 +1,4 @@
+---
+redirect_to: /draft/2019-09/json-schema-core.html#rfc.section.8
+title: The JSON Schema Core Vocabulary
+---

--- a/draft/2019-09/vocab/format.md
+++ b/draft/2019-09/vocab/format.md
@@ -1,0 +1,4 @@
+---
+redirect_to: /draft/2019-09/json-schema-validation.html#rfc.section.7
+title: A Vocabulary for Semantic Content with "format"
+---

--- a/draft/2019-09/vocab/hyper-schema.md
+++ b/draft/2019-09/vocab/hyper-schema.md
@@ -1,0 +1,4 @@
+---
+redirect_to: /draft/2019-09/json-schema-hypermedia.html
+title: "JSON Hyper-Schema: A Vocabulary for Hypermedia Annotation of JSON"
+---

--- a/draft/2019-09/vocab/meta-data.md
+++ b/draft/2019-09/vocab/meta-data.md
@@ -1,0 +1,4 @@
+---
+redirect_to: /draft/2019-09/json-schema-validation.html#rfc.section.9
+title: A Vocabulary for Basic Meta-Data Annotations
+---

--- a/draft/2019-09/vocab/validation.md
+++ b/draft/2019-09/vocab/validation.md
@@ -1,0 +1,4 @@
+---
+redirect_to: /draft/2019-09/json-schema-validation.html#rfc.section.6
+title: A Vocabulary for Structural Validation
+---


### PR DESCRIPTION
We've already had one person confused that these URIs 404, even
though the spec says to expect that.  Let's generate HTML stubs
to redirect to the appropriate spec section for each vocabulary
(or the whole spec for Hyper-Schema).

No media type restrictions are given at this time for vocabulary
documents, so having HTML here is fine.  Jekyll (at least the
local version, production sometimes differs) will do the redirect
on URIs without the .html suffix, which is what we need.  It will
also do it with .html, but I think that's fine.