### PR TITLE
Redirect unversioned meta-schemas

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ before_script:
 - PATH="./node_modules/.bin/:$PATH"
 script:
 - bundle exec jekyll build
-- ajv test -s schema -d "learn/examples/*.json" --valid
+- ajv test -s draft-07/schema -d "learn/examples/*.json" --valid

--- a/_layouts/redirect.html
+++ b/_layouts/redirect.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <meta charset="utf-8">
+  <title>Redirecting&hellip;</title>
+  <link rel="canonical" href="{{ page.redirect.to }}">
+  <meta http-equiv="refresh" content="0; url={{ page.redirect.to }}">
+  <meta name="robots" content="noindex">
+  <h1>Redirecting&hellip;</h1>
+  <p>
+    Several redirections on json-schema.org are special cases:
+  </p>
+  <ul>
+    <li>The unversioned meta-schema URIs should no longer be used.</li>
+    <li>The vocabularies are represented by their specification text.</li>
+    <li>The "latest" specification URIs are for convenice of browser
+        bookmarking only.</li>
+  </ul>
+  <a href="{{ page.redirect.to }}">Click here if you are not redirected.</a>
+  <script>location="{{ page.redirect.to }}"</script>
+</html>

--- a/hyper-schema
+++ b/hyper-schema
@@ -1,1 +1,0 @@
-draft-07/hyper-schema

--- a/hyper-schema.md
+++ b/hyper-schema.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /draft/2019-09/hyper-schema
+---

--- a/links
+++ b/links
@@ -1,1 +1,0 @@
-draft-07/links

--- a/links.md
+++ b/links.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /draft/2019-09/links
+---

--- a/schema
+++ b/schema
@@ -1,1 +1,0 @@
-draft-07/schema

--- a/schema.md
+++ b/schema.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /draft/2019-09/schema
+---


### PR DESCRIPTION
This replaces these with HTML stubs that will use a meta refresh
tag and canonical link to perform a redirect.

If there's code out there assuming that these exist and are JSON,
then that code will be confused by receiving HTML.  Although we do
say that you can't assume these things are actually hosted.
Not sure this is what anyone had in mind, though.

Also explain the redirects some in the template, because
some of it is weird, and when redirecting for the JSON
files, getting HTML is surprising.

Also, as an example of this problem, the tests of the examples
against the meta-schema were failing because they were using
the unversioned meta-schema, which of course no longer makes
sense as neither the examples nor the validator have been updated.