### PR TITLE
moved networknt validator to modern

### DIFF
--- a/_data/validator-libraries-modern.yml
+++ b/_data/validator-libraries-modern.yml
@@ -92,7 +92,7 @@
     - name: json-schema-validator
       url: https://github.com/networknt/json-schema-validator
       notes:
-      draft: [4]
+      draft: [7, 6, 4]
       license: Apache License 2.0
 - name: Kotlin
   implementations:

--- a/_data/validator-libraries-modern.yml
+++ b/_data/validator-libraries-modern.yml
@@ -89,6 +89,11 @@
       date-draft:
       draft: [7, 6, 4]
       license: Apache License 2.0
+    - name: json-schema-validator
+      url: https://github.com/networknt/json-schema-validator
+      notes:
+      draft: [4]
+      license: Apache License 2.0
 - name: Kotlin
   implementations:
     - name: Medeia-validator

--- a/_data/validator-libraries-obsolete.yml
+++ b/_data/validator-libraries-obsolete.yml
@@ -73,11 +73,6 @@
       url: https://github.com/java-json-tools/json-schema-validator
       draft: [4]
       license: LGPLv3
-    - name: json-schema-validator
-      url: https://github.com/networknt/json-schema-validator
-      notes:
-      draft: [4]
-      license: Apache License 2.0
 - name: JavaScript
   implementations:
     - name: jsonschema


### PR DESCRIPTION
[This project](https://github.com/networknt/json-schema-validator) now supports draft-06 and draft-07 and therefore should be moved from obsolete to modern.