### PR TITLE
Changed "discussion" to "join our slack"

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -25,9 +25,7 @@
             <a class="page-link" href="{{ my_page.url | relative_url }}">{{ my_page.title | escape }}</a>
             {%- endif -%}
           {% endfor -%}
-          <a class="page-link" href="https://join.slack.com/t/json-schema/shared_invite/enQtNjc5NTk0MzkzODg5LTVlZGIxNmVhMGY2MWFlYTdiNDQ5NWFiZGUwOThhNmYxZDE0YzA5YjRiOTA5MGY4ZTZlZGZhZDFmYTY4NWM2N2Y">
-            Discussion
-          </a>
+          <a class="page-link" href="https://join.slack.com/t/json-schema/shared_invite/enQtNjc5NTk0MzkzODg5LTVlZGIxNmVhMGY2MWFlYTdiNDQ5NWFiZGUwOThhNmYxZDE0YzA5YjRiOTA5MGY4ZTZlZGZhZDFmYTY4NWM2N2Y">Join our Slack</a>
         </div>
       </nav>
     {%- endif -%}


### PR DESCRIPTION
It isn't obvious what the discussion link in the header is.
Let's fix that.