### PR TITLE
Fixes #185

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ sudo: false
 node_js:
 - node
 before_script:
-- npm install ajv-cli
+- npm install ajv-cli@3.1.0
 - PATH="./node_modules/.bin/:$PATH"
 script:
 - bundle exec jekyll build
-- ajv test -s draft-07/schema -d "learn/examples/*.json" --valid
+- ajv test -s draft-07/schema -d "learn/examples/*.json" --valid --add-used-schema=false


### PR DESCRIPTION
Fixes https://github.com/json-schema-org/json-schema-org.github.io/issues/185

Update ajv-cli which now allows for argument to prevent adding the provided schema to the index.
Previously the provided schema, draft-07 meta-schema, was being added, and ajv checks if the
schema is unique according to it's provided ... of course this caused problems.
Put in ajv-cli RP to allow new argument