### PR TITLE
add understanding link to learn page

### DIFF
--- a/learn/index.md
+++ b/learn/index.md
@@ -11,3 +11,4 @@ title: Learn
   * [calendar.schema.json](./examples/calendar.schema.json)
   * [card.schema.json](./examples/card.schema.json)
   * [geographical-location.schema.json](./examples/geographical-location.schema.json)
+* [Understanding JSON Schema](/understanding-json-schema/)


### PR DESCRIPTION
I'm constantly clicking on `Learn` in the navigation - especially when not on my computer, searching there for the detailed how-to's, but then googling for "json-schema object" to get the link to it.