### PR TITLE
Add `jsonschema-rs` to Rust implementations

### DIFF
--- a/_data/validator-libraries-modern.yml
+++ b/_data/validator-libraries-modern.yml
@@ -166,6 +166,14 @@
       date-draft:
       draft: [7, 6, 4]
       license: MIT
+- name: Rust
+  implementations:
+    - name: jsonschema-rs
+      url: https://github.com/Stranger6667/jsonschema-rs
+      notes: Fast due to compiling schema into a validation tree
+      date-draft:
+      draft: [7, 6]
+      license: MIT
 - name: Objective-C
   implementations:
     - name: DSJSONSchemaValidation


### PR DESCRIPTION
Hi! There is a new implementation of JSON Schema validation in Rust. Drafts 6,7 are supported, Draft 4 is in progress