### PR TITLE
@cfworker/json-schema

### DIFF
--- a/_data/validator-libraries-modern.yml
+++ b/_data/validator-libraries-modern.yml
@@ -128,7 +128,7 @@
       date-draft:
       draft: [6]
       license: MIT
-    - name: '@cfworker/json-schema'
+    - name: "@cfworker/json-schema"
       url: https://github.com/cfworker/cfworker/blob/master/packages/json-schema/README.md
       notes: "Built for Cloudflare workers, browsers, and Node.js"
       date-draft: [2019-09]

--- a/_data/validator-libraries-modern.yml
+++ b/_data/validator-libraries-modern.yml
@@ -128,6 +128,12 @@
       date-draft:
       draft: [6]
       license: MIT
+    - name: @cfworker/json-schema
+      url: https://github.com/cfworker/cfworker/blob/master/packages/json-schema/README.md
+      notes: "Built for Cloudflare workers, browsers, and Node.js"
+      date-draft: [2019-09]
+      draft: [7, 6, 4]
+      license: MIT
 - name: Perl
   implementations:
     - name: JSON::Validator

--- a/_data/validator-libraries-modern.yml
+++ b/_data/validator-libraries-modern.yml
@@ -128,7 +128,7 @@
       date-draft:
       draft: [6]
       license: MIT
-    - name: @cfworker/json-schema
+    - name: '@cfworker/json-schema'
       url: https://github.com/cfworker/cfworker/blob/master/packages/json-schema/README.md
       notes: "Built for Cloudflare workers, browsers, and Node.js"
       date-draft: [2019-09]


### PR DESCRIPTION
A JSON schema validator that will run on Cloudflare workers. Supports drafts 4, 7, and 2019-09.

Cloudflare workers do not have APIs required by Ajv schema compilation (eval or new Function(code)). Validators that don't use code generation are not up to date with the current spec so I built yet another validator...

@cfworker/json-schema is currently the fastest among validators which do not use code generation (eval/new function):
https://github.com/ebdrup/json-schema-benchmark#performance
Pretty comparable to jsck and z-schema which do use code generation.