### PR TITLE
Update implementations.md

### DIFF
--- a/implementations.md
+++ b/implementations.md
@@ -150,8 +150,6 @@ For example, the only incompatibilities between draft-04 and draft-06 involve `e
 -   .NET
     -   [Json.NET](https://www.newtonsoft.com/jsonschema) (AGPL-3.0) - generates schemas from .NET types
     -   [NJsonSchema](https://github.com/RSuter/NJsonSchema/) - (Ms-PL) - generates schemas from .NET types, see issue [574](https://github.com/RSuter/NJsonSchema/issues/574) for draft-06+ support progress
--   Golang
-    -   [alecthomas/jsonschema](https://github.com/alecthomas/jsonschema)(MIT) - generates JSON Schemas from Go types through reflection
 -   PHP
     -   [Liform](https://github.com/Limenius/liform) (MIT) - generates schemas from Symfony forms
 -   TypeScript

--- a/implementations.md
+++ b/implementations.md
@@ -151,7 +151,7 @@ For example, the only incompatibilities between draft-04 and draft-06 involve `e
     -   [Json.NET](https://www.newtonsoft.com/jsonschema) (AGPL-3.0) - generates schemas from .NET types
     -   [NJsonSchema](https://github.com/RSuter/NJsonSchema/) - (Ms-PL) - generates schemas from .NET types, see issue [574](https://github.com/RSuter/NJsonSchema/issues/574) for draft-06+ support progress
 -   Golang
-    -  [qri-io/jsonschema](https://github.com/qri-io/jsonschema)(MIT) - idiomatic go implementation with custom validator support, coding to and from json, rich error returns *supports Draft 7*
+    -   [alecthomas/jsonschema](https://github.com/alecthomas/jsonschema)(MIT) - generates JSON Schemas from Go types through reflection
 -   PHP
     -   [Liform](https://github.com/Limenius/liform) (MIT) - generates schemas from Symfony forms
 -   TypeScript


### PR DESCRIPTION
It appeared that qri-io/jsonschema doesn't do code to schema generation (qri-io/jsonschema#32). Replaced it with the one https://github.com/alecthomas/jsonschema in the list of Golang code to schema generation implementations