### PR TITLE
Add common lisp json-schema to implementations list

### DIFF
--- a/_data/validator-libraries-modern.yml
+++ b/_data/validator-libraries-modern.yml
@@ -53,8 +53,8 @@
   implementations:
     - name: json-schema
       url: https://github.com/fisxoj/json-schema
-      date-draft:
-      draft: [4, 6, 7, 2019-09]
+      date-draft: [2019-09]
+      draft: [4, 6, 7]
       license: LGPL
 - name: Elixir
   implementations:

--- a/_data/validator-libraries-modern.yml
+++ b/_data/validator-libraries-modern.yml
@@ -49,6 +49,13 @@
       date-draft:
       draft: [7]
       license: Apache License, Version 2.0
+- name: Common Lisp
+  implementations:
+    - name: json-schema
+      url: https://github.com/fisxoj/json-schema
+      date-draft:
+      draft: [4, 6, 7, 2019-09]
+      license: LGPL
 - name: Elixir
   implementations:
     - name: Elixir JSON Schema validator


### PR DESCRIPTION
Hello!

I was pointed here by @karenetheridge  from the json-schema-test-suite repo.  I'd like to add my implementation to the list.

Thanks.