### PR TITLE
Add statham to implementations/codegen/python

### DIFF
--- a/implementations.md
+++ b/implementations.md
@@ -201,7 +201,8 @@ are the only keywords that changed.
 -   PHP
     -  [php-code-builder](https://github.com/swaggest/php-code-builder)(MIT) - generates PHP mapping structures defined by JSON schema using [swaggest/json-schema](https://github.com/swaggest/php-json-schema) *supports Draft 7*
 -   Python
-    - [yacg](https://github.com/OkieOth/yacg) (MIT) - parse JSON Schema and OpenApi files to build a meta model from them. This meta model can be used in Mako templates to generate source code, other schemas or plantUml.   
+    - [yacg](https://github.com/OkieOth/yacg) (MIT) - parse JSON Schema and OpenApi files to build a meta model from them. This meta model can be used in Mako templates to generate source code, other schemas or plantUml.
+    - [statham](https://github.com/jacksmith15/statham-schema) (MIT) - generate type-annotated models from JSON Schema documents.
 -   Rust
     - [schemafy](https://github.com/Marwes/schemafy/) - generates Rust types and serialization code from a JSON schema. *supports Draft 4*
 


### PR DESCRIPTION
Add [statham](https://github.com/jacksmith15/statham-schema) to `implementations.md` under _Code generation - Python_.

Supports Draft 06 with a few exceptions, documented [here](https://statham-schema.readthedocs.io/en/latest/compatibility.html).