### PR TITLE
Add React JSON Schema Form Material UI to Implementations/Web UI generation (UI-Schema & XHR-Schema) 

### DIFF
--- a/implementations.md
+++ b/implementations.md
@@ -224,6 +224,7 @@ Various levels of support for UI generation primarily from the validation vocabu
     -   [JSONForms (jsonforms.io)](https://jsonforms.io/) (EclipseSource) (MIT)
     -   [Liform-react](https://github.com/Limenius/liform-react) (MIT)
     -   [React JSON Schema Form (mozilla)](https://github.com/mozilla-services/react-jsonschema-form) (Apache 2)
+    -   [React JSON Schema Form Material UI](https://github.com/vip-git/react-jsonschema-form-material-ui) (MIT)
     -   [React Schema Form (networknt)](https://github.com/networknt/react-schema-form) (MIT)
     -   [uniforms (Vazco)](https://github.com/vazco/uniforms) (MIT)
 


### PR DESCRIPTION
Hi,

I have recently released JSON Schema for react and material UI which Supports drafts 4, 7, and 2019-09.

It introduces 2 new concepts 
- `ui:interceptors` and `uiData` within UISchema to have separation of concern from `formData` and ui only data.
-  `xhrSchema` to get data over network before building your UI which gets validated by JSONSchema and submitting already formatted data.

https://react-jsonschema-form-material-ui.github56.now.sh

Thanks,
V