### PR TITLE
Add Open Collective link

### DIFF
--- a/index.md
+++ b/index.md
@@ -93,3 +93,4 @@ Questions? Feeling helpful? Get involved on:
 * [GitHub](http://github.com/json-schema-org/json-schema-spec)
 * [Google Groups](https://groups.google.com/forum/#!forum/json-schema)
 * [Slack](https://join.slack.com/t/json-schema/shared_invite/enQtNjc5NTk0MzkzODg5LTVlZGIxNmVhMGY2MWFlYTdiNDQ5NWFiZGUwOThhNmYxZDE0YzA5YjRiOTA5MGY4ZTZlZGZhZDFmYTY4NWM2N2Y)
+* [Open Collective](https://opencollective.com/json-schema)


### PR DESCRIPTION
Earlier tonight, we were looking to support JSON Schema. To my surprise, it doesn't list the OC link ;)