### PR TITLE
Fix propertyNames example in draft-06 release notes

### DIFF
--- a/draft-06/json-schema-release-notes.md
+++ b/draft-06/json-schema-release-notes.md
@@ -70,19 +70,19 @@ The difficulty is that if you attempt to do this:
 {
     "type": "object",
     "allOf": [
-        {"$ref": "#/definitions/foo"},
-        {"$ref": "#/definitions/bar"}
+        { "$ref": "#/definitions/foo" },
+        { "$ref": "#/definitions/bar" }
     ],
     "definitions": {
         "foo": {
             "properties": {
-                "foo": {"type": "string"}
+                "foo": { "type": "string" }
             },
             "additionalProperties": false
         },
         "bar": {
             "properties": {
-                "bar": {"type": "number"}
+                "bar": { "type": "number" }
             },
             "additionalProperties": false
         }
@@ -100,30 +100,28 @@ A workaround is available with the new `"propertyNames"` keyword:
 {
     "type": "object",
     "allOf": [
-        {"$ref": "#/definitions/foo"},
-        {"$ref": "#/definitions/bar"}
+        { "$ref": "#/definitions/foo" },
+        { "$ref": "#/definitions/bar" }
     ],
-    "anyOf": [
-        {"$ref": "#/definitions/fooNames"},
-        {"$ref": "#/definitions/barNames"}
-    ],
+    "propertyNames": {
+        "anyOf": [
+            { "$ref": "#/definitions/fooNames" },
+            { "$ref": "#/definitions/barNames" }
+        ]
+    },
     "definitions": {
         "foo": {
             "properties": {
-                "foo": {"type": "string"}
+                "foo": { "type": "string" }
             }
         },
-        "fooNames": {
-            "propertyNames": {"enum": ["foo"]}
-        },
+        "fooNames": { "enum": ["foo"] },
         "bar": {
             "properties": {
-                "bar": {"type": "number"}
+                "bar": { "type": "number" }
             }
         },
-        "barNames": {
-            "propertyNames": {"enum": ["bar"]}
-        }
+        "barNames": { "enum": ["bar"] }
     }
 }
 ```


### PR DESCRIPTION
The example for `propertyNames` in the release notes for draft-06 is wrong. It's come up a few times recently.

https://github.com/json-schema-org/JSON-Schema-Test-Suite/issues/255