### PR TITLE
website: Fix jsonschema-rs Python bindings URL in validator list

### DIFF
--- a/_data/validator-libraries-modern.yml
+++ b/_data/validator-libraries-modern.yml
@@ -202,7 +202,7 @@
       draft: [7, 6, 4]
       license: BSD-3-Clause
     - name: jsonschema-rs
-      url: https://github.com/Stranger6667/jsonschema-rs/python
+      url: https://github.com/Stranger6667/jsonschema-rs/tree/master/bindings/python
       notes: Python bindings to Rust's jsonschema crate
       date-draft:
       draft: [7, 6, 4]


### PR DESCRIPTION
Super minor, but just noticed that the URL pointing to `jsonschema-rs`'s Python bindings was broken – this PR fixes the URL! ✨ 