### PR TITLE
Add links to GitHub Discussions

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -13,6 +13,7 @@
           </li>
           {% endif %}
           <li>Discussion: <a href="/slack">Slack</a> | <a href="https://groups.google.com/forum/#!forum/json-schema">Google Groups</a></li>
+          <li><a href="https://github.com/json-schema-org/community/discussions">GitHub Discussions</a></li>
           <li>Site edits: <a href="https://github.com/json-schema-org/json-schema-org.github.io">GitHub repo for site</a></li>
         </ul>
       </div>

--- a/index.md
+++ b/index.md
@@ -110,6 +110,7 @@ We encourage updating to the latest specification where possible, which is 2020-
 Questions? Feeling helpful? Get involved on:
 
 * [GitHub](http://github.com/json-schema-org/json-schema-spec)
+* [GitHub Discussions](https://github.com/json-schema-org/community/discussions)
 * [Google Groups](https://groups.google.com/forum/#!forum/json-schema)
 * [Slack](/slack)
 * [Open Collective](https://opencollective.com/json-schema)


### PR DESCRIPTION
Currently there is no mention of GitHub Discussions, adding it so people know it exists.