### PR TITLE
update support info for JSON::Schema::Modern, JSON::Schema::Tiny

### DIFF
--- a/_data/validator-libraries-modern.yml
+++ b/_data/validator-libraries-modern.yml
@@ -183,15 +183,15 @@
       license: MIT
 - name: Perl
   implementations:
-    - name: JSON::Schema::Draft201909
-      url: https://github.com/karenetheridge/JSON-Schema-Draft201909
+    - name: JSON::Schema::Modern
+      url: https://github.com/karenetheridge/JSON-Schema-Modern
       notes:
-      date-draft: [2019-09]
+      date-draft: [7, 2019-09, 2020-12]
       license: "GNU General Public License, Version 1 + The Artistic License 1.0"
     - name: JSON::Schema::Tiny
       url: https://github.com/karenetheridge/JSON-Schema-Tiny
       notes:
-      date-draft: [2019-09]
+      date-draft: [7, 2019-09, 2020-12]
       license: "GNU General Public License, Version 1 + The Artistic License 1.0"
     - name: JSON::Validator
       url: https://github.com/mojolicious/json-validator


### PR DESCRIPTION
JSON::Schema::Draft201909 has been renamed and now also supports drafts 7 and 2020-12
JSON::Schema::Tiny now also supports 7, 2019-09, 2020-12