### PR TITLE
Release Notes: Unicode not required in RegExp

### DIFF
--- a/draft/2020-12/release-notes.md
+++ b/draft/2020-12/release-notes.md
@@ -288,9 +288,9 @@ considered unevaluated and fails the `unevaluatedItems` keyword like it did in
 previous drafts.
 
 ## Regular Expressions
-Regular expressions are now required to support unicode characters. Previously,
-this was unspecified and implementations may or may not support this unicode in
-regular expressions.
+Regular expressions are now expected (but not strictly required) to support
+unicode characters. Previously, this was unspecified and implementations may or
+may not support this unicode in regular expressions.
 
 ## Media Type Changes
 JSON Schema defines two media types, `application/schema+json` and


### PR DESCRIPTION
While "SHOULD" is not a strict requirement, it does imply that it should be followed unless you have a really good reason not to. I tried to choose words that made it sound more important than just a recommendation while still making in clear that it's not strictly
required. Let me know is this works.