### PR TITLE
Add/implementation json schema library

### DIFF
--- a/_data/validator-libraries-modern.yml
+++ b/_data/validator-libraries-modern.yml
@@ -177,6 +177,12 @@
       date-draft: [2019-09, 2020-12]
       draft: [7, 6, 4]
       license: MIT
+    - name: JSON Schema Library
+      url: https://github.com/sagold/json-schema-library
+      notes: "Built for Node.js and browsers. Customizable json-validator and json-schema utilities for traversal, data generation and validation"
+      date-draft:
+      draft: [7, 6, 4]
+      license: MIT
     - name: vue-vuelidate-jsonschema
       url: https://github.com/mokkabonna/vue-vuelidate-jsonschema
       date-draft:

--- a/implementations.md
+++ b/implementations.md
@@ -216,6 +216,7 @@ the utility, and decided on a case-by-case basis.
 
 -   JavaScript
     -   [json-schema-ref-parser](https://github.com/BigstickCarpet/json-schema-ref-parser) (MIT) Tools for dereferencing non-cyclic schemas, bundling referenced schemas into a single file, and other `$ref` processing.
+    -   [json-schema-library](https://github.com/sagold/json-schema-library) (MIT) - Exposes tools to work with json-schema, including: data creation from json-schema, `$ref` processing, walk through schemas, etc.
     -   [@cloudflare/json-schema-walker](https://github.com/cloudflare/json-schema-tools/tree/master/workspaces/json-schema-walker) ([JSON Schema Tools](https://github.com/cloudflare/json-schema-tools)), _draft-07, -06, -04, and Cloudflare's Doca extensions_ Walks schemas and runs pre- and post-walk callbacks.  Can modify schemas in place. (BSD-3-Clause)
     -   [@hyperjump/json-schema-core](https://github.com/jdesrosiers/json-schema-core)
         (MIT) Tools for working with schemas that handle identifiers and


### PR DESCRIPTION
Dear all,

with this pr, [json-schema-library](https://github.com/sagold/json-schema-library) is added to the list of javascript validator and utility implementations. It does support draft 4 to 7 and is part of the json-schema-benchmark. Unfortunately, the benchmark has not been updated since 17 months so I ran and uploaded an update here: https://github.com/sagold/json-schema-benchmark.

Happy to have this library in your list. Thank you very much for your work on json-schema.

Cheers,
Sascha