### PR TITLE
Move JeSSE from obsolete to modern libraries on implementations page

### DIFF
--- a/_data/validator-libraries-modern.yml
+++ b/_data/validator-libraries-modern.yml
@@ -82,6 +82,12 @@
       date-draft:
       draft: [7, 6, 4]
       license: MIT
+- name: Erlang
+  implementations:
+    - name: JeSSE
+      url: https://github.com/for-GET/jesse
+      draft: [6, 4, 3]
+      license: "Apache 2.0"
 - name: Go
   implementations:
     - name: gojsonschema

--- a/_data/validator-libraries-obsolete.yml
+++ b/_data/validator-libraries-obsolete.yml
@@ -53,12 +53,6 @@
       notes:
       draft: [4]
       license: BSL-1.0
-- name: Erlang
-  implementations:
-    - name: JeSSE
-      url: https://github.com/for-GET/jesse
-      draft: [4, 3]
-      license: "Apache 2.0"
 - name: Go
   implementations:
     - name: validate-json


### PR DESCRIPTION
[JeSSE's `README.md`](https://github.com/for-GET/jesse/blame/26cf7ea166f7bc720be90abd3530962935801b0c/README.md#L10) indicates that they've supported Draft 06 as of January 2022.