### PR TITLE
Update the site with links for the new 2020-12 patch release.

### DIFF
--- a/index.md
+++ b/index.md
@@ -64,6 +64,10 @@ We monitor the `jsonschema` tag on StackOverflow.
 
 ## Project Status
 
+2021-06-10: A patch release of Draft 2020-12 has been published with no functional changes.
+
+The new IETF document IDs are of the form `draft-bhutton-*-01`.
+
 2021-02-01: Draft 2020-12 has been published!
 
 The IETF document IDs are of the form `draft-bhutton-*-00`.

--- a/specification-links.md
+++ b/specification-links.md
@@ -249,19 +249,33 @@ For links to the somewhat more readably formatted versions on this web site, and
         draft&#8209;bhutton&#8209;relative&#8209;json&#8209;pointer&#8209;00
       </a></small></tt><br>
     </td>
-    <td>
+    <td rowspan="3">
       <tt><small>2020&#8209;12</small></tt>
     </td>
-    <td>
+    <td rowspan="3">
       Draft 2020-12
     </td>
-    <td>
+    <td rowspan="3">
       <small>
+      the&nbsp;<tt><small>draft&#8209;bhutton&#8209;*&#8209;01</small></tt> drafts were
+      bugfixes and/or clarifications without meta&#8209;schema or functional changes
+      <br />
       Milestone:
       <a href="https://github.com/json-schema-org/json-schema-spec/milestone/8">draft-08-patch-1</a>
       <br/>
       Changes and fixes as a result of discussion with the OpenAPI community. (Includes breaking changes.)
       </small>
+    </td>
+  </tr>
+  <tr><!-- This empty row keeps the row colors aligned properlty for the two "draft-2020-12" versions --></tr>
+  <tr>
+    <td>
+      <tt><small><a href="https://tools.ietf.org/html/draft-bhutton-json-schema-01">
+        draft&#8209;bhutton&#8209;json&#8209;schema&#8209;01
+      </a></small></tt><br>
+      <tt><small><a href="https://tools.ietf.org/html/draft-bhutton-json-schema-validation-01">
+        draft&#8209;bhutton&#8209;json&#8209;schema&#8209;validation&#8209;01
+      </a></small></tt><br>
     </td>
   </tr>
   <tr>
@@ -288,8 +302,8 @@ For links to the somewhat more readably formatted versions on this web site, and
 ### 2020-12
 
 - Specifications
-    - Core: [draft-bhutton-json-schema-00](https://tools.ietf.org/html/draft-bhutton-json-schema-00) ([changes](https://tools.ietf.org/html/draft-bhutton-json-schema-00#appendix-G))
-    - Validation: [draft-bhutton-json-schema-validation-00](https://tools.ietf.org/html/draft-bhutton-json-schema-validation-00) ([changes](https://tools.ietf.org/html/draft-bhutton-json-schema-validation-00#appendix-C))
+    - Core: [draft-bhutton-json-schema-01](https://tools.ietf.org/html/draft-bhutton-json-schema-01) ([changes](https://tools.ietf.org/html/draft-bhutton-json-schema-01#appendix-G))
+    - Validation: [draft-bhutton-json-schema-validation-01](https://tools.ietf.org/html/draft-bhutton-json-schema-validation-01) ([changes](https://tools.ietf.org/html/draft-bhutton-json-schema-validation-01#appendix-C))
     - Relative JSON Pointer: [draft-bhutton-relative-json-pointer-00](https://tools.ietf.org/html/draft-bhutton-relative-json-pointer-00) ([changes](https://tools.ietf.org/html/draft-bhutton-relative-json-pointer-00#appendix-A))
 - General use meta-schemas
     - [JSON Schema meta-schema](draft/2020-12/schema)

--- a/specification.md
+++ b/specification.md
@@ -23,8 +23,8 @@ Validation in any significant way.
 | [Relative JSON Pointers](draft/2020-12/relative-json-pointer.html)  | extends the JSON Pointer syntax for relative pointers |
 
 They are also available on the IETF main site:
-* [draft-bhutton-json-schema-00 (core)](https://tools.ietf.org/html/draft-bhutton-json-schema-00)
-* [draft-bhutton-json-schema-validation-00](https://tools.ietf.org/html/draft-bhutton-json-schema-validation-00)
+* [draft-bhutton-json-schema-01 (core)](https://tools.ietf.org/html/draft-bhutton-json-schema-01)
+* [draft-bhutton-json-schema-validation-01](https://tools.ietf.org/html/draft-bhutton-json-schema-validation-01)
 * [draft-bhutton-relative-json-pointer-00](https://tools.ietf.org/html/draft-bhutton-relative-json-pointer-00)
 
 Meta-schemas


### PR DESCRIPTION
The links on the site are outdated for the patch release.

Hopefully I've done this remotely right (and that I didn't miss a branch where this was already in-progress).

I don't 100% understand yet whether I was supposed to update the `git` submodules in `_includes`, but I assume one of you will tell me :)

Perhaps we should consider putting together release checklists for a new release (patch or otherwise)? Then we can include bumping this as part of them -- doing this seems slightly more painful than it could be, but again maybe I'm missing something, or we could probably automate some of this a bit if it's important.