### PR TITLE
Fix using `type` rather than `$ref` in 2020-12 release notes

### DIFF
--- a/draft/2020-12/release-notes.md
+++ b/draft/2020-12/release-notes.md
@@ -350,8 +350,8 @@ external references that we want to bundle.
   "properties": {
     "address": { "type": "string" },
     "city": { "type": "string" },
-    "postalCode": { "type": "/schema/common#/$defs/usaPostalCode" },
-    "state": { "type": "/$defs/states" }
+    "postalCode": { "$ref": "/schema/common#/$defs/usaPostalCode" },
+    "state": { "$ref": "/$defs/states" }
   },
 
   "$defs": {
@@ -407,8 +407,8 @@ embedded schemas using `$defs`. Here's what the bundled schema would look like.
       "properties": {
         "address": { "type": "string" },
         "city": { "type": "string" },
-        "postalCode": { "type": "/schema/common#/$defs/usaPostalCode" },
-        "state": { "type": "#/$defs/states" }
+        "postalCode": { "$ref": "/schema/common#/$defs/usaPostalCode" },
+        "state": { "$ref": "#/$defs/states" }
       },
 
       "$defs": {


### PR DESCRIPTION
Some schemas in the 2020-12 release notes used `type` rather than `$ref` where the value was clearly a relative reference URI.
Reported: https://groups.google.com/g/json-schema/c/v1fwFPA2PFU?pli=1