### PR TITLE
Sort languages and drafts automatically

### DIFF
--- a/_data/validator-libraries-modern.yml
+++ b/_data/validator-libraries-modern.yml
@@ -134,23 +134,6 @@
       date-draft:
       draft: [7, 6, 4]
       license: Apache License 2.0
-- name: Kotlin
-  implementations:
-    - name: Medeia-validator
-      url: https://github.com/worldturner/medeia-validator
-      notes: streaming validator for Kotlin and Java clients; works with Jackson and Gson
-      date-draft:
-      draft: [7, 6, 4]
-      license: Apache License 2.0
-    - name: json-kotlin-schema
-      url: https://github.com/pwall567/json-kotlin-schema
-      notes: |
-        Kotlin implementation of JSON Schema.
-        (Currently supports most of Draft 7; see the README for details.
-        Full compliance with Draft 7 and later drafts in progress.)
-      date-draft:
-      draft: [7]
-      license: MIT
 - name: JavaScript
   implementations:
     - name: Hyperjump JSV
@@ -187,6 +170,23 @@
       url: https://github.com/mokkabonna/vue-vuelidate-jsonschema
       date-draft:
       draft: [6]
+      license: MIT
+- name: Kotlin
+  implementations:
+    - name: Medeia-validator
+      url: https://github.com/worldturner/medeia-validator
+      notes: streaming validator for Kotlin and Java clients; works with Jackson and Gson
+      date-draft:
+      draft: [7, 6, 4]
+      license: Apache License 2.0
+    - name: json-kotlin-schema
+      url: https://github.com/pwall567/json-kotlin-schema
+      notes: |
+        Kotlin implementation of JSON Schema.
+        (Currently supports most of Draft 7; see the README for details.
+        Full compliance with Draft 7 and later drafts in progress.)
+      date-draft:
+      draft: [7]
       license: MIT
 - name: Perl
   implementations:

--- a/_data/validator-libraries-modern.yml
+++ b/_data/validator-libraries-modern.yml
@@ -193,12 +193,14 @@
     - name: JSON::Schema::Modern
       url: https://github.com/karenetheridge/JSON-Schema-Modern
       notes:
-      date-draft: [7, 2019-09, 2020-12]
+      date-draft: [2019-09, 2020-12]
+      draft: [7]
       license: "GNU General Public License, Version 1 + The Artistic License 1.0"
     - name: JSON::Schema::Tiny
       url: https://github.com/karenetheridge/JSON-Schema-Tiny
       notes:
-      date-draft: [7, 2019-09, 2020-12]
+      date-draft: [2019-09, 2020-12]
+      draft: [7]
       license: "GNU General Public License, Version 1 + The Artistic License 1.0"
     - name: JSON::Validator
       url: https://github.com/mojolicious/json-validator
@@ -336,8 +338,8 @@
     - name: valbuddy
       license: Free and commercial versions (proprietary)
       url: 'https://www.json-buddy.com/json-validator-command-line-tool.htm'
-      date-draft:
-      draft: [2019-09, 7, 6, 4]
+      date-draft: [2019-09]
+      draft: [7, 6, 4]
       notes: JSONBuddy cli tool. Windows platform. Support for large data and streaming validation.
     - name: ajv-cli
       license: MIT

--- a/implementations.md
+++ b/implementations.md
@@ -26,7 +26,7 @@ Validators
 
 <nav class="intra" markdown="1">
 
-{% assign validator-libraries = site.data.validator-libraries-modern %}
+{% assign validator-libraries = site.data.validator-libraries-modern | sort: 'name' %}
 
 {% for language in validator-libraries %}
 -   [{{ language.name }}](#validator-{% if language.anchor-name %}{{ language.anchor-name }}{% else %}{{ language.name | downcase }}{% endif %})
@@ -50,10 +50,10 @@ Validators
 
         <em>
         {% if implementation.date-draft %}
-            {{ implementation.date-draft | join: ", "}}{% if implementation.draft %}, {% endif %}
+            {{ implementation.date-draft | sort | reverse | join: ", "}}{% if implementation.draft %}, {% endif %}
         {% endif %}
         {% if implementation.draft %}
-            draft-0{{ implementation.draft | join: ", -0" }}
+            draft-0{{ implementation.draft | sort | reverse | join: ", -0" }}
         {% endif %}
         </em>
 


### PR DESCRIPTION
Sort languages and drafts automatically

Several languages and date drafts were out of order.  Fix it in code instead of trying to keep the data file consistent.  Fix a few mixed draft/date-draft fields that this flushed out (Liquid can't sort the mixed numbers and strings).

Also put Kotlin in the right place because it was bugging me while working with the data file, even though it now displays properly either way.