### PR TITLE
Implementations page: structure, compliant configs, last-updated tracking, built-on links

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,10 @@ sudo: false
 node_js:
 - node
 before_script:
-- npm install ajv-cli@3.1.0
+- npm install ajv-cli@5.0.0 ajv-formats@2.1.1
 - PATH="./node_modules/.bin/:$PATH"
 script:
 - bundle exec jekyll build
-- ajv test -s draft-07/schema -d "learn/examples/*.json" --valid --add-used-schema=false
+- ajv compile --spec=draft2020 --strict=false -s learn/examples/geographical-location.schema.json -s learn/examples/address.schema.json -s learn/examples/card.schema.json -s learn/examples/calendar.schema.json
+- ajv compile --spec=draft2020 --strict=false -c ajv-formats -s _data/schema.yml
+- ajv --spec=draft2020 --strict=false -c ajv-formats test -s _data/schema.yml -d "_data/*-libraries-*.yml" --valid

--- a/_data/hyper-libraries-modern.yml
+++ b/_data/hyper-libraries-modern.yml
@@ -3,11 +3,5 @@
     - name: mokkabonna/json-hyper-schema
       url: "https://github.com/mokkabonna/json-hyper-schema"
       license: MIT
+      date-draft: []
       draft: [7]
-- name: Python
-  implementations:
-    - name: Core API Hyper-Schema codec
-      url: "https://github.com/core-api/python-jsonhyperschema-codec"
-      notes: "Draft-06+ progress: issue [12](https://github.com/core-api/python-jsonhyperschema-codec/issues/12)"
-      draft: [4]
-      license: BSD-2-Clause

--- a/_data/hyper-libraries-modern.yml
+++ b/_data/hyper-libraries-modern.yml
@@ -5,3 +5,4 @@
       license: MIT
       date-draft: []
       draft: [7]
+      last-updated: "2022-08-31"

--- a/_data/hyper-libraries-obsolete.yml
+++ b/_data/hyper-libraries-obsolete.yml
@@ -3,4 +3,13 @@
     - name: Jsonary
       url: "http://jsonary.com/"
       license: MIT
+      date-draft: []
       draft: [4]
+- name: Python
+  implementations:
+    - name: Core API Hyper-Schema codec
+      url: "https://github.com/core-api/python-jsonhyperschema-codec"
+      notes: "Draft-06+ progress: issue [12](https://github.com/core-api/python-jsonhyperschema-codec/issues/12)"
+      date-draft: []
+      draft: [4]
+      license: BSD-2-Clause

--- a/_data/schema.yml
+++ b/_data/schema.yml
@@ -95,6 +95,8 @@ $defs:
                     Additional information.  Overly promotional (or critical)
                     wording should be avoided.
                 type: string
+            compliance:
+                $ref: "#/$defs/compliance"
             last-updated:
                 description: |
                     The date (in whatever timezone was relevant at the time)
@@ -108,3 +110,49 @@ $defs:
                 type: string
                 format: date
                 pattern: '^\d\d\d\d-[01]\d-[0123]\d$'
+    compliance:
+        description: |
+            The compliance section notes aspects of an implementation's
+            _default configuration_ that are non-compliant with the
+            specification in ways that are _not necessarily_ detected
+            by the test suite.  This information is provided based on
+            implementation documentation.
+        type: object
+        unevaluatedProperties: false
+        properties:
+            constraints:
+                description: |
+                    A brief note of design constraints that impacted choices
+                    regarding compliance.  This includes things like
+                    targeting memory-constrained environments, or trading
+                    off features for performance.  It does not include
+                    opinions regarding the value (or lack thereof) of
+                    the specification requirements.
+                type: string
+            config:
+                description: |
+                    Documents how to configure an implementation to produce
+                    the most specification-compliant behavior if it does
+                    not do so by default.  The resulting configuration
+                    may still have incomplete compliance (such as not
+                    having implemented all keywords), but will not
+                    have additional behavior that contradicts the
+                    specification (such as modifying the instance
+                    by filling in default values).
+                type: object
+                unevaluatedProperties: false
+                required: [instructions]
+                properties:
+                    docs:
+                        description: |
+                            A link to the implementation's configuration
+                            documentation, ideally to whatever part addresses
+                            configuration and compliance.
+                        type: string
+                        format: uri
+                    instructions:
+                        description: |
+                            Instructions to configure for compliance.  Will
+                            appear in a sentence after "you must" and before
+                            "to produce specification-compliant behavior."
+                        type: string

--- a/_data/schema.yml
+++ b/_data/schema.yml
@@ -1,0 +1,72 @@
+$schema: https://json-schema.org/draft/2020-12/schema
+$id: https://json-schema.org/implementations/schema
+type: array
+items:
+    $ref: "#/$defs/language"
+$defs:
+    language:
+        description: |
+            A group of implementations grouped by programming language or
+            runtime environment.
+        type: object
+        unevaluatedProperties: false
+        required: [name]
+        oneOf:
+          - required: [implementations]
+          - required: [notes]
+        properties:
+            name:
+                type: string
+            anchor-name:
+                type: string
+                description: A name suitable for us as an HTML id.
+            implementations:
+                description: |
+                    The list of implementations for this language/environment,
+                    sorted with those supporting the most recent
+                    drafts/versions first.
+                type: array
+                items:
+                    $ref: "#/$defs/implementation"
+            notes:
+                type: [string, "null"]
+    implementation:
+        description: |
+            An implementation and its associated information.
+        type: object
+        unevaluatedProperties: false
+        required: [name, url]
+        anyOf:
+          - required: [draft]
+          - required: [date-draft]
+        properties:
+            name:
+                description: The human-friendly name of the implementation
+                type: string
+            url:
+                description: |
+                    The URL of the implementation's repository or documentation
+                type: string
+                format: uri
+            draft:
+                description: The supported drafts (up through draft-07)
+                type: array
+                items:
+                    type: integer
+                    enum: [1, 2, 3, 4, 6, 7]
+            date-draft:
+                description: The supported drafts (2019-09+)
+                type: array
+                items:
+                    type: string
+                    enum: [2019-09, 2020-12]
+            license:
+                description: |
+                    The software license under which the implementation
+                    is available
+                type: string
+            notes:
+                description: |
+                    Additional information.  Overly promotional (or critical)
+                    wording should be avoided.
+                type: string

--- a/_data/schema.yml
+++ b/_data/schema.yml
@@ -31,12 +31,8 @@ $defs:
         oneOf:
           - required: [implementations]
           - required: [notes]
+        $ref: "#/$defs/name-and-anchor-name"
         properties:
-            name:
-                type: string
-            anchor-name:
-                type: string
-                description: A name suitable for us as an HTML id.
             implementations:
                 description: |
                     The list of implementations for this language/environment,
@@ -55,6 +51,30 @@ $defs:
                         required: [last-updated]
             notes:
                 type: [string, "null"]
+    name-and-anchor-name:
+        $comment: |
+            Require an anchor-name if the name is not suitable for
+            use as an anchor (HTML id attribute)
+        if:
+            required: [name]
+            not:
+                properties:
+                    name:
+                        $ref: "#/$defs/anchor-name"
+        then:
+            required: [anchor-name]
+        properties:
+            name:
+                type: string
+            anchor-name:
+                $ref: "#/$defs/anchor-name"
+    anchor-name:
+        description: |
+            A name suitable for us as an HTML id, if the regular name
+            is not a vald id.  The regex is looser than the HTML spec
+            but is based on what was already working on the page.
+        type: string
+        pattern: '^[A-Za-z][A-Za-z0-9+-_:./ ()]*$'
     implementation:
         description: |
             An implementation and its associated information.
@@ -64,10 +84,8 @@ $defs:
         anyOf:
           - required: [draft]
           - required: [date-draft]
+        $ref: "#/$defs/name-and-anchor-name"
         properties:
-            name:
-                description: The human-friendly name of the implementation
-                type: string
             url:
                 description: |
                     The URL of the implementation's repository or documentation
@@ -95,6 +113,13 @@ $defs:
                     Additional information.  Overly promotional (or critical)
                     wording should be avoided.
                 type: string
+            built-on:
+                description: |
+                    Indicates that this implementation is built on another
+                    implementation, typically to make it available through
+                    a web page, CLI, or a different programming language.
+                type: object
+                $ref: "#/$defs/name-and-anchor-name"
             compliance:
                 $ref: "#/$defs/compliance"
             last-updated:

--- a/_data/schema.yml
+++ b/_data/schema.yml
@@ -3,6 +3,23 @@ $id: https://json-schema.org/implementations/schema
 type: array
 items:
     $ref: "#/$defs/language"
+$comment: |
+    The following if/then ensures that if last-updated is used
+    anywhere, then it is required everywhere.  This allows it
+    to be required in the modern data files and unused in the
+    obsolete data files.
+if:
+   contains:
+       required: [implementations]
+       properties:
+           implementations:
+               contains:
+                   required: [last-updated]
+then:
+    properties:
+        implementations:
+            items:
+                required: [last-updated]
 $defs:
     language:
         description: |
@@ -28,6 +45,14 @@ $defs:
                 type: array
                 items:
                     $ref: "#/$defs/implementation"
+                $comment: |
+                    The following if/then ensures that if the first
+                if:
+                    prefixItems:
+                      - required: [last-updated]
+                then:
+                    items:
+                        required: [last-updated]
             notes:
                 type: [string, "null"]
     implementation:
@@ -70,3 +95,16 @@ $defs:
                     Additional information.  Overly promotional (or critical)
                     wording should be avoided.
                 type: string
+            last-updated:
+                description: |
+                    The date (in whatever timezone was relevant at the time)
+                    the information for this entry was last updated.  This
+                    should only be changed when the implementation's
+                    documentation has been checked against the entry, not
+                    when minor formatting or other updates are done.
+                $comment: |
+                    "pattern" does the validation work here, "format" is
+                    just for semantic clarity.
+                type: string
+                format: date
+                pattern: '^\d\d\d\d-[01]\d-[0123]\d$'

--- a/_data/validator-libraries-modern.yml
+++ b/_data/validator-libraries-modern.yml
@@ -52,7 +52,7 @@
       draft: [7]
       license: MIT
       last-updated: "2022-08-31"
-    - name: json-schema
+    - name: json-schema (luposlip)
       url: https://github.com/luposlip/json-schema
       date-draft: []
       draft: [4, 6, 7]
@@ -61,6 +61,7 @@
 - name: COM/ActiveX
   implementations:
     - name: JSON Essentials for COM/ActiveX
+      anchor-name: JSONEssentials
       url: https://pinery.systems/json-essentials-com/index.html
       draft: [7]
       license: proprietary
@@ -68,7 +69,7 @@
       last-updated: "2022-08-31"
 - name: Common Lisp
   implementations:
-    - name: json-schema
+    - name: json-schema (fisxoj)
       url: https://github.com/fisxoj/json-schema
       date-draft: [2019-09]
       draft: [7, 6, 4]
@@ -135,7 +136,7 @@
       last-updated: "2022-08-31"
     - name: networknt/json-schema-validator
       url: https://github.com/networknt/json-schema-validator
-      notes: Support OpenAPI 3.0 with Jackson parser 
+      notes: Support OpenAPI 3.0 with Jackson parser
       date-draft: [2020-12, 2019-09]
       draft: [7, 6, 4]
       license: Apache License 2.0
@@ -184,6 +185,7 @@
           instructions: "set option `strict: false`"
       last-updated: "2022-08-31"
     - name: "@cfworker/json-schema"
+      anchor-name: cfworker
       url: https://github.com/cfworker/cfworker/blob/master/packages/json-schema/README.md
       notes: "Built for Cloudflare workers, browsers, and Node.js"
       date-draft: [2019-09]
@@ -294,11 +296,13 @@
       draft: [7, 6, 4]
       license: BSD-3-Clause
       last-updated: "2022-08-31"
-    - name: jsonschema-rs
+    - name: jsonschema-rs (Python)
       url: https://github.com/Stranger6667/jsonschema-rs/tree/master/bindings/python
       notes: Python bindings to Rust's jsonschema crate
       date-draft: []
       draft: [7, 6, 4]
+      built-on:
+        name: jsonschema-rs
       license: MIT
       last-updated: "2022-08-31"
 - name: Ruby
@@ -351,43 +355,59 @@
       last-updated: "2022-08-31"
 - name: Web (Online)
   implementations:
-    - name: Hyperjump JSV
+    - name: Hyperjump JSV (online)
       url: https://json-schema.hyperjump.io
       date-draft: [2020-12, 2019-09]
       draft: [7, 6, 4]
       notes: Supports multiple schemas and multiple instances; client-side validation
+      built-on:
+        name: Hyperjump JSV
       last-updated: "2022-08-31"
     - name: json-everything
       url: https://json-everything.net
       date-draft: [2020-12, 2019-09]
       draft: [7, 6]
       notes: Powered by JsonSchema.Net in Blazor WASM for client-side validation
+      built-on:
+        name: JsonSchema.Net
       last-updated: "2022-08-31"
     - name: jschon.dev
       url: https://jschon.dev/
       date-draft: [2020-12, 2019-09]
       draft: []
+      built-on:
+        name: jschon
       last-updated: "2022-08-31"
     - name: JSON Schema Validator
       url: https://www.jsonschemavalidator.net/
       date-draft: [2019-09]
       draft: [7, 6, 4, 3]
-      notes: Powered by JSON.Net; server-side validation
+      notes: server-side validation
+      built-on:
+        name: Json.NET Schema
       last-updated: "2022-08-31"
     - name: jsonschema.dev
       url: https://jsonschema.dev
       draft: [7]
-      notes: Powered by ajv; client-side validation
+      notes: client-side validation
+      built-on:
+        name: ajv
       last-updated: "2022-08-31"
     - name: JSON Schema Lint
       url: http://jsonschemalint.com/
       date-draft: []
       draft: [7, 6, 4, 3, 2, 1]
+      built-on:
+        name: ajv
+      notes:  Uses JSV for draft-03 and earlier
       last-updated: "2022-08-31"
     - name: ExtendsClass's JSON Schema Validator
+      anchor-name: ExtendsClass
       url: https://extendsclass.com/json-schema-validator.html
       date-draft: []
       draft: [7]
+      built-on:
+        name: ajv
       last-updated: "2022-08-31"
 - name: Command Line
   implementations:
@@ -407,13 +427,16 @@
         config:
           docs: https://github.com/ajv-validator/ajv-cli#ajv-options
           instructions: "pass `--strict=false`"
+      built-on:
+        name: ajv
       last-updated: "2022-08-31"
     - name: yajsv
       license: MIT
       url: 'https://github.com/neilpa/yajsv'
       date-draft: []
       draft: [7, 6, 4]
-      notes: wraps [xeipuuv/gojsonschema](https://github.com/xeipuuv/gojsonschema)
+      built-on:
+        name: gojsonschema
       last-updated: "2022-08-31"
     - name: Polyglottal JSON Schema Validator
       license: MIT
@@ -422,3 +445,5 @@
       draft: [6, 4]
       notes: can be used with YAML and many other formats besides JSON
       last-updated: "2022-08-31"
+      built-on:
+        name: ajv

--- a/_data/validator-libraries-modern.yml
+++ b/_data/validator-libraries-modern.yml
@@ -7,11 +7,13 @@
       date-draft: [2020-12, 2019-09]
       draft: [7, 6]
       license: MIT
+      last-updated: "2022-08-31"
     - name: Json.NET Schema
       url: https://www.newtonsoft.com/jsonschema
       date-draft: [2019-09]
       draft: [7, 6, 4, 3]
       license: "AGPL-3.0-only"
+      last-updated: "2022-08-31"
 - name: C
   notes: No known implementations support draft-06 or later.
 - name: C++
@@ -21,23 +23,27 @@
       date-draft: []
       draft: [7]
       license: Boost Software License 1.0
+      last-updated: "2022-08-31"
     - name: JSON schema validator for JSON for Modern C++
       url: https://github.com/pboettch/json-schema-validator
       date-draft: []
       draft: [7]
       license: MIT
+      last-updated: "2022-08-31"
     - name: Valijson
       url: https://github.com/tristanpenman/valijson
       notes: header-only library, works with many JSON parser implementations
       date-draft: []
       draft: [7]
       license: BSD-2-Clause
+      last-updated: "2022-08-31"
     - name: jsoncons
       url: https://github.com/danielaparker/jsoncons/blob/master/doc/ref/jsonschema/jsonschema.md
       notes: Header-only library
       date-draft: []
       draft: [7]
       license: Boost Software License 1.0
+      last-updated: "2022-08-31"
 - name: Clojure
   implementations:
     - name: jinx
@@ -45,11 +51,13 @@
       date-draft: []
       draft: [7]
       license: MIT
+      last-updated: "2022-08-31"
     - name: json-schema
       url: https://github.com/luposlip/json-schema
       date-draft: []
       draft: [4, 6, 7]
       license: Apache License, Version 2.0
+      last-updated: "2022-08-31"
 - name: COM/ActiveX
   implementations:
     - name: JSON Essentials for COM/ActiveX
@@ -57,6 +65,7 @@
       draft: [7]
       license: proprietary
       notes: Language independent, includes JSON DOM parser, REST ready, 4 licensing options for free and business uses. For Windows platform only.
+      last-updated: "2022-08-31"
 - name: Common Lisp
   implementations:
     - name: json-schema
@@ -64,6 +73,7 @@
       date-draft: [2019-09]
       draft: [7, 6, 4]
       license: LGPL
+      last-updated: "2022-08-31"
 - name: Elixir
   implementations:
     - name: JsonXema
@@ -71,12 +81,14 @@
       date-draft: []
       draft: [7, 6, 4]
       license: MIT
+      last-updated: "2022-08-31"
 - name: Erlang
   implementations:
     - name: JeSSE
       url: https://github.com/for-GET/jesse
       draft: [6, 4, 3]
       license: "Apache 2.0"
+      last-updated: "2022-08-31"
 - name: Go
   implementations:
     - name: santhosh-tekuri/jsonschema
@@ -85,17 +97,20 @@
       date-draft: [2020-12, 2019-09]
       draft: [7, 6, 4]
       license: Apache License 2.0
+      last-updated: "2022-08-31"
     - name: qri-io/jsonschema
       url: https://github.com/qri-io/jsonschema
       date-draft: [2019-09]
       draft: [7]
       license: MIT
       notes: includes custom validator support, rich error returns
+      last-updated: "2022-08-31"
     - name: gojsonschema
       url: https://github.com/xeipuuv/gojsonschema
       date-draft: []
       draft: [7, 6, 4]
       license: "Apache 2.0"
+      last-updated: "2022-08-31"
 - name: Java
   implementations:
     - name: Vert.x Json Schema
@@ -106,33 +121,39 @@
       date-draft: [2020-12, 2019-09]
       draft: [4, 7]
       license: Apache License, Version 2.0
+      last-updated: "2022-08-31"
     - name: jsonschemafriend
       url: https://github.com/jimblackler/jsonschemafriend
       date-draft: [2020-12, 2019-09]
       draft: [7, 6, 4, 3]
       license: Apache License 2.0
+      last-updated: "2022-08-31"
     - name: networknt/json-schema-validator
       url: https://github.com/networknt/json-schema-validator
       notes: Support OpenAPI 3.0 with Jackson parser 
       date-draft: [2020-12, 2019-09]
       draft: [7, 6, 4]
       license: Apache License 2.0
+      last-updated: "2022-08-31"
     - name: Snow
       url: https://github.com/ssilverman/snowy-json
       notes: Uses Maven for the project and Gson under the hood.
       date-draft: [2019-09]
       draft: [7, 6]
       license: GNU Affero General Public License v3.0
+      last-updated: "2022-08-31"
     - name: everit-org/json-schema
       url: https://github.com/everit-org/json-schema
       date-draft: []
       draft: [7, 6, 4]
       license: Apache License 2.0
+      last-updated: "2022-08-31"
     - name: Justify
       url: https://github.com/leadpony/justify
       date-draft: []
       draft: [7, 6, 4]
       license: Apache License 2.0
+      last-updated: "2022-08-31"
 - name: JavaScript
   implementations:
     - name: Hyperjump JSV
@@ -141,35 +162,41 @@
       date-draft: [2019-09, 2020-12]
       draft: [7, 6, 4]
       license: MIT
+      last-updated: "2022-08-31"
     - name: ajv
       url: https://github.com/ajv-validator/ajv
       notes: "for Node.js and browsers - supports [user-defined keywords](https://github.com/ajv-validator/ajv/blob/master/docs/keywords.md) and [$data reference](https://github.com/json-schema-org/json-schema-spec/issues/51); _Only specification-compliant when [strict mode](https://ajv.js.org/strict-mode.html) is **disabled.**_"
       date-draft: [2019-09, 2020-12]
       draft: [7, 6, 4]
       license: MIT
+      last-updated: "2022-08-31"
     - name: "@cfworker/json-schema"
       url: https://github.com/cfworker/cfworker/blob/master/packages/json-schema/README.md
       notes: "Built for Cloudflare workers, browsers, and Node.js"
       date-draft: [2019-09]
       draft: [7, 6, 4]
       license: MIT
+      last-updated: "2022-08-31"
     - name: JSON Schema Library
       url: https://github.com/sagold/json-schema-library
       notes: "Built for Node.js and browsers. Customizable json-validator and json-schema utilities for traversal, data generation and validation"
       date-draft: []
       draft: [7, 6, 4]
       license: MIT
+      last-updated: "2022-08-31"
     - name: djv
       url: https://github.com/korzio/djv
       notes: "for Node.js and browsers"
       date-draft: []
       draft: [6, 4]
       license: MIT
+      last-updated: "2022-08-31"
     - name: vue-vuelidate-jsonschema
       url: https://github.com/mokkabonna/vue-vuelidate-jsonschema
       date-draft: []
       draft: [6]
       license: MIT
+      last-updated: "2022-08-31"
 - name: Kotlin
   implementations:
     - name: Medeia-validator
@@ -178,6 +205,7 @@
       date-draft: []
       draft: [7, 6, 4]
       license: Apache License 2.0
+      last-updated: "2022-08-31"
     - name: json-kotlin-schema
       url: https://github.com/pwall567/json-kotlin-schema
       notes: |
@@ -187,6 +215,7 @@
       date-draft: [2019-09]
       draft: [7]
       license: MIT
+      last-updated: "2022-08-31"
 - name: Perl
   implementations:
     - name: JSON::Schema::Modern
@@ -194,21 +223,25 @@
       date-draft: [2019-09, 2020-12]
       draft: [7]
       license: "GNU General Public License, Version 1 + The Artistic License 1.0"
+      last-updated: "2022-08-31"
     - name: JSON::Schema::Tiny
       url: https://github.com/karenetheridge/JSON-Schema-Tiny
       date-draft: [2019-09, 2020-12]
       draft: [7]
       license: "GNU General Public License, Version 1 + The Artistic License 1.0"
+      last-updated: "2022-08-31"
     - name: JSON::Validator
       url: https://github.com/mojolicious/json-validator
       date-draft: [2019-09]
       draft: [7, 6, 4]
       license: "The Artistic License 2.0 (GPL Compatible)"
+      last-updated: "2022-08-31"
     - name: JSONSchema::Validator
       url: https://github.com/skbkontur/perl-jsonschema-validator
       date-draft: []
       draft: [7, 6, 4]
       license: MIT
+      last-updated: "2022-08-31"
 - name: PHP
   implementations:
     - name: Opis Json Schema
@@ -216,11 +249,13 @@
       date-draft: [2020-12, 2019-09]
       draft: [7, 6]
       license: "Apache License 2.0"
+      last-updated: "2022-08-31"
     - name: Swaggest Json Schema
       url: https://github.com/swaggest/php-json-schema
       date-draft: []
       draft: [7, 6, 4]
       license: "MIT"
+      last-updated: "2022-08-31"
 - name: Python
   implementations:
     - name: jschon
@@ -228,23 +263,27 @@
       date-draft: [2019-09, 2020-12]
       draft: []
       license: MIT
+      last-updated: "2022-08-31"
     - name: jsonschema
       url: https://github.com/Julian/jsonschema
       date-draft: [2019-09, 2020-12]
       draft: [7, 6, 4, 3]
       license: "MIT"
+      last-updated: "2022-08-31"
     - name: fastjsonschema
       url: https://github.com/horejsek/python-fastjsonschema
       notes: Great performance thanks to code generation.
       date-draft: []
       draft: [7, 6, 4]
       license: BSD-3-Clause
+      last-updated: "2022-08-31"
     - name: jsonschema-rs
       url: https://github.com/Stranger6667/jsonschema-rs/tree/master/bindings/python
       notes: Python bindings to Rust's jsonschema crate
       date-draft: []
       draft: [7, 6, 4]
       license: MIT
+      last-updated: "2022-08-31"
 - name: Ruby
   implementations:
     - name: JSONSchemer
@@ -252,11 +291,13 @@
       date-draft: []
       draft: [7, 6, 4]
       license: MIT
+      last-updated: "2022-08-31"
     - name: JSI
       url: https://rubydoc.info/gems/jsi
       date-draft: []
       draft: [7, 6, 4]
       license: AGPL-3.0
+      last-updated: "2022-08-31"
 - name: Rust
   implementations:
     - name: jsonschema-rs
@@ -265,6 +306,7 @@
       date-draft: [2019-09, 2020-12]
       draft: [7, 6, 4]
       license: MIT
+      last-updated: "2022-08-31"
 - name: Scala
   implementations:
     - name: Reactive Core Circe JSON Validator
@@ -273,6 +315,7 @@
       date-draft: [2020-12, 2019-09]
       draft: []
       license: Apache License, Version 2.0
+      last-updated: "2022-08-31"
 - name: Objective-C
   implementations:
     - name: DSJSONSchemaValidation
@@ -280,6 +323,7 @@
       date-draft: []
       draft: [7, 6, 4]
       license: MIT
+      last-updated: "2022-08-31"
 - name: Lua/LuaJIT
   implementations:
     - name: lua-resty-jsonschema
@@ -287,6 +331,7 @@
       date-draft: []
       draft: [7, 6, 4]
       license: MIT
+      last-updated: "2022-08-31"
 - name: Web (Online)
   implementations:
     - name: Hyperjump JSV
@@ -294,32 +339,39 @@
       date-draft: [2020-12, 2019-09]
       draft: [7, 6, 4]
       notes: Supports multiple schemas and multiple instances; client-side validation
+      last-updated: "2022-08-31"
     - name: json-everything
       url: https://json-everything.net
       date-draft: [2020-12, 2019-09]
       draft: [7, 6]
       notes: Powered by JsonSchema.Net in Blazor WASM for client-side validation
+      last-updated: "2022-08-31"
     - name: jschon.dev
       url: https://jschon.dev/
       date-draft: [2020-12, 2019-09]
       draft: []
+      last-updated: "2022-08-31"
     - name: JSON Schema Validator
       url: https://www.jsonschemavalidator.net/
       date-draft: [2019-09]
       draft: [7, 6, 4, 3]
       notes: Powered by JSON.Net; server-side validation
+      last-updated: "2022-08-31"
     - name: jsonschema.dev
       url: https://jsonschema.dev
       draft: [7]
       notes: Powered by ajv; client-side validation
+      last-updated: "2022-08-31"
     - name: JSON Schema Lint
       url: http://jsonschemalint.com/
       date-draft: []
       draft: [7, 6, 4, 3, 2, 1]
+      last-updated: "2022-08-31"
     - name: ExtendsClass's JSON Schema Validator
       url: https://extendsclass.com/json-schema-validator.html
       date-draft: []
       draft: [7]
+      last-updated: "2022-08-31"
 - name: Command Line
   implementations:
     - name: valbuddy
@@ -328,20 +380,24 @@
       date-draft: [2019-09]
       draft: [7, 6, 4]
       notes: JSONBuddy cli tool. Windows platform. Support for large data and streaming validation.
+      last-updated: "2022-08-31"
     - name: ajv-cli
       license: MIT
       url: 'https://www.npmjs.com/package/ajv-cli'
       date-draft: [2020-12, 2019-09]
       draft: [7, 6, 4]
+      last-updated: "2022-08-31"
     - name: yajsv
       license: MIT
       url: 'https://github.com/neilpa/yajsv'
       date-draft: []
       draft: [7, 6, 4]
       notes: wraps [xeipuuv/gojsonschema](https://github.com/xeipuuv/gojsonschema)
+      last-updated: "2022-08-31"
     - name: Polyglottal JSON Schema Validator
       license: MIT
       url: 'https://www.npmjs.com/package/pajv'
       date-draft: []
       draft: [6, 4]
       notes: can be used with YAML and many other formats besides JSON
+      last-updated: "2022-08-31"

--- a/_data/validator-libraries-modern.yml
+++ b/_data/validator-libraries-modern.yml
@@ -73,6 +73,11 @@
       date-draft: [2019-09]
       draft: [7, 6, 4]
       license: LGPL
+      compliance:
+        config:
+          docs: https://github.com/fisxoj/json-schema/blob/master/README.rst
+          instructions: |
+            set `resolve-remote-references` to `nil`
       last-updated: "2022-08-31"
 - name: Elixir
   implementations:
@@ -134,6 +139,10 @@
       date-draft: [2020-12, 2019-09]
       draft: [7, 6, 4]
       license: Apache License 2.0
+      compliance:
+        config:
+            docs: https://github.com/networknt/json-schema-validator/blob/master/doc/config.md
+            instructions: "set `handleNullableField` to `false`"
       last-updated: "2022-08-31"
     - name: Snow
       url: https://github.com/ssilverman/snowy-json
@@ -165,10 +174,14 @@
       last-updated: "2022-08-31"
     - name: ajv
       url: https://github.com/ajv-validator/ajv
-      notes: "for Node.js and browsers - supports [user-defined keywords](https://github.com/ajv-validator/ajv/blob/master/docs/keywords.md) and [$data reference](https://github.com/json-schema-org/json-schema-spec/issues/51); _Only specification-compliant when [strict mode](https://ajv.js.org/strict-mode.html) is **disabled.**_"
+      notes: "for Node.js and browsers - supports [user-defined keywords](https://github.com/ajv-validator/ajv/blob/master/docs/keywords.md) and [$data reference](https://github.com/json-schema-org/json-schema-spec/issues/51)"
       date-draft: [2019-09, 2020-12]
       draft: [7, 6, 4]
       license: MIT
+      compliance:
+        config:
+          docs: https://ajv.js.org/strict-mode.html
+          instructions: "set option `strict: false`"
       last-updated: "2022-08-31"
     - name: "@cfworker/json-schema"
       url: https://github.com/cfworker/cfworker/blob/master/packages/json-schema/README.md
@@ -249,6 +262,10 @@
       date-draft: [2020-12, 2019-09]
       draft: [7, 6]
       license: "Apache License 2.0"
+      compliance:
+        config:
+          docs: https://opis.io/json-schema/2.x/php-loader.html#parser-options
+          instructions: 'set several options to their "vanilla" values'
       last-updated: "2022-08-31"
     - name: Swaggest Json Schema
       url: https://github.com/swaggest/php-json-schema
@@ -386,6 +403,10 @@
       url: 'https://www.npmjs.com/package/ajv-cli'
       date-draft: [2020-12, 2019-09]
       draft: [7, 6, 4]
+      compliance:
+        config:
+          docs: https://github.com/ajv-validator/ajv-cli#ajv-options
+          instructions: "pass `--strict=false`"
       last-updated: "2022-08-31"
     - name: yajsv
       license: MIT

--- a/_data/validator-libraries-modern.yml
+++ b/_data/validator-libraries-modern.yml
@@ -1,3 +1,4 @@
+# NOTE: See schema.yml in this directory for the structure of this file.
 - name: .NET
   anchor-name: dotnet
   implementations:
@@ -17,36 +18,36 @@
   implementations:
     - name: f5-json-schema
       url: https://github.com/KayEss/json-schema
-      date-draft:
+      date-draft: []
       draft: [7]
       license: Boost Software License 1.0
     - name: JSON schema validator for JSON for Modern C++
       url: https://github.com/pboettch/json-schema-validator
-      date-draft:
+      date-draft: []
       draft: [7]
       license: MIT
     - name: Valijson
       url: https://github.com/tristanpenman/valijson
       notes: header-only library, works with many JSON parser implementations
-      date-draft:
+      date-draft: []
       draft: [7]
       license: BSD-2-Clause
     - name: jsoncons
       url: https://github.com/danielaparker/jsoncons/blob/master/doc/ref/jsonschema/jsonschema.md
       notes: Header-only library
-      date-draft:
+      date-draft: []
       draft: [7]
       license: Boost Software License 1.0
 - name: Clojure
   implementations:
     - name: jinx
       url: https://github.com/juxt/jinx
-      date-draft:
+      date-draft: []
       draft: [7]
       license: MIT
     - name: json-schema
       url: https://github.com/luposlip/json-schema
-      date-draft:
+      date-draft: []
       draft: [7]
       license: Apache License, Version 2.0
 - name: COM/ActiveX
@@ -67,7 +68,7 @@
   implementations:
     - name: JsonXema
       url: https://github.com/hrzndhrn/json_xema
-      date-draft:
+      date-draft: []
       draft: [7, 6, 4]
       license: MIT
 - name: Erlang
@@ -92,21 +93,21 @@
       notes: includes custom validator support, rich error returns
     - name: gojsonschema
       url: https://github.com/xeipuuv/gojsonschema
-      date-draft:
+      date-draft: []
       draft: [7, 6, 4]
       license: "Apache 2.0"
 - name: Java
   implementations:
     - name: Vert.x Json Schema
       url: https://github.com/eclipse-vertx/vertx-json-schema
-      notes: Validator for Eclipse Vert.x project JSON types.
+      notes: |
+        Validator for Eclipse Vert.x project JSON types.
+        Includes custom keywords support, custom dialect support, asynchronous validation
       date-draft: [2020-12, 2019-09]
       draft: [7]
       license: Apache License, Version 2.0
-      notes: includes custom keywords support, custom dialect support, asynchronous validation
     - name: jsonschemafriend
       url: https://github.com/jimblackler/jsonschemafriend
-      notes:
       date-draft: [2020-12, 2019-09]
       draft: [7, 6, 4, 3]
       license: Apache License 2.0
@@ -124,14 +125,12 @@
       license: GNU Affero General Public License v3.0
     - name: everit-org/json-schema
       url: https://github.com/everit-org/json-schema
-      notes:
-      date-draft:
+      date-draft: []
       draft: [7, 6, 4]
       license: Apache License 2.0
     - name: Justify
       url: https://github.com/leadpony/justify
-      notes:
-      date-draft:
+      date-draft: []
       draft: [7, 6, 4]
       license: Apache License 2.0
 - name: JavaScript
@@ -157,18 +156,18 @@
     - name: JSON Schema Library
       url: https://github.com/sagold/json-schema-library
       notes: "Built for Node.js and browsers. Customizable json-validator and json-schema utilities for traversal, data generation and validation"
-      date-draft:
+      date-draft: []
       draft: [7, 6, 4]
       license: MIT
     - name: djv
       url: https://github.com/korzio/djv
       notes: "for Node.js and browsers"
-      date-draft:
+      date-draft: []
       draft: [6, 4]
       license: MIT
     - name: vue-vuelidate-jsonschema
       url: https://github.com/mokkabonna/vue-vuelidate-jsonschema
-      date-draft:
+      date-draft: []
       draft: [6]
       license: MIT
 - name: Kotlin
@@ -176,7 +175,7 @@
     - name: Medeia-validator
       url: https://github.com/worldturner/medeia-validator
       notes: streaming validator for Kotlin and Java clients; works with Jackson and Gson
-      date-draft:
+      date-draft: []
       draft: [7, 6, 4]
       license: Apache License 2.0
     - name: json-kotlin-schema
@@ -185,87 +184,77 @@
         Kotlin implementation of JSON Schema.
         (Currently supports most of Draft 7; see the README for details.
         Full compliance with Draft 7 and later drafts in progress.)
-      date-draft:
+      date-draft: []
       draft: [7]
       license: MIT
 - name: Perl
   implementations:
     - name: JSON::Schema::Modern
       url: https://github.com/karenetheridge/JSON-Schema-Modern
-      notes:
       date-draft: [2019-09, 2020-12]
       draft: [7]
       license: "GNU General Public License, Version 1 + The Artistic License 1.0"
     - name: JSON::Schema::Tiny
       url: https://github.com/karenetheridge/JSON-Schema-Tiny
-      notes:
       date-draft: [2019-09, 2020-12]
       draft: [7]
       license: "GNU General Public License, Version 1 + The Artistic License 1.0"
     - name: JSON::Validator
       url: https://github.com/mojolicious/json-validator
-      notes:
-      date-draft:
+      date-draft: []
       draft: [7, 6, 4]
       license: "The Artistic License 2.0 (GPL Compatible)"
     - name: JSONSchema::Validator
       url: https://github.com/skbkontur/perl-jsonschema-validator
-      notes:
-      date-draft:
+      date-draft: []
       draft: [7, 6, 4]
       license: MIT
 - name: PHP
   implementations:
     - name: Opis Json Schema
       url: https://github.com/opis/json-schema
-      notes:
-      date-draft:
+      date-draft: []
       draft: [7, 6]
       license: "Apache License 2.0"
     - name: Swaggest Json Schema
       url: https://github.com/swaggest/php-json-schema
-      notes:
-      date-draft:
+      date-draft: []
       draft: [7, 6, 4]
       license: "MIT"
 - name: Python
   implementations:
     - name: jschon
       url: https://github.com/marksparkza/jschon
-      notes:
       date-draft: [2019-09, 2020-12]
-      draft:
+      draft: []
       license: MIT
     - name: jsonschema
       url: https://github.com/Julian/jsonschema
-      notes:
       date-draft: [2019-09, 2020-12]
       draft: [7, 6, 4, 3]
       license: "MIT"
     - name: fastjsonschema
       url: https://github.com/horejsek/python-fastjsonschema
       notes: Great performance thanks to code generation.
-      date-draft:
+      date-draft: []
       draft: [7, 6, 4]
       license: BSD-3-Clause
     - name: jsonschema-rs
       url: https://github.com/Stranger6667/jsonschema-rs/tree/master/bindings/python
       notes: Python bindings to Rust's jsonschema crate
-      date-draft:
+      date-draft: []
       draft: [7, 6, 4]
       license: MIT
 - name: Ruby
   implementations:
     - name: JSONSchemer
       url: https://github.com/davishmcclurg/json_schemer
-      notes:
-      date-draft:
+      date-draft: []
       draft: [7, 6, 4]
       license: MIT
     - name: JSI
       url: https://rubydoc.info/gems/jsi
-      notes:
-      date-draft:
+      date-draft: []
       draft: [7, 6, 4]
       license: AGPL-3.0
 - name: Rust
@@ -273,7 +262,7 @@
     - name: jsonschema-rs
       url: https://github.com/Stranger6667/jsonschema-rs
       notes: Fast due to compiling schema into a validation tree
-      date-draft:
+      date-draft: []
       draft: [7, 6, 4]
       license: MIT
 - name: Scala
@@ -282,22 +271,20 @@
       url: https://github.com/reactivecore/rc-circe-json-schema
       notes: Based on Circe-Library -Early state and API may not be stable. Not yet produciton ready.
       date-draft: [2020-12, 2019-09]
-      draft:
+      draft: []
       license: Apache License, Version 2.0
 - name: Objective-C
   implementations:
     - name: DSJSONSchemaValidation
       url: https://github.com/dashevo/JSONSchemaValidation
-      notes:
-      date-draft:
+      date-draft: []
       draft: [7, 6, 4]
       license: MIT
 - name: Lua/LuaJIT
   implementations:
     - name: lua-resty-jsonschema
       url: https://github.com/iresty/lua-resty-jsonschema
-      notes:
-      date-draft:
+      date-draft: []
       draft: [7, 6, 4]
       license: MIT
 - name: Web (Online)
@@ -315,7 +302,7 @@
     - name: jschon.dev
       url: https://jschon.dev/
       date-draft: [2020-12, 2019-09]
-      draft:
+      draft: []
     - name: JSON Schema Validator
       url: https://www.jsonschemavalidator.net/
       date-draft: [2019-09]
@@ -327,11 +314,11 @@
       notes: Powered by ajv; client-side validation
     - name: JSON Schema Lint
       url: http://jsonschemalint.com/
-      date-draft:
+      date-draft: []
       draft: [7, 6, 4, 3, 2, 1]
     - name: ExtendsClass's JSON Schema Validator
       url: https://extendsclass.com/json-schema-validator.html
-      date-draft:
+      date-draft: []
       draft: [7]
 - name: Command Line
   implementations:
@@ -344,17 +331,17 @@
     - name: ajv-cli
       license: MIT
       url: 'https://www.npmjs.com/package/ajv-cli'
-      date-draft:
+      date-draft: [2020-12, 2019-09]
       draft: [7, 6, 4]
     - name: yajsv
       license: MIT
       url: 'https://github.com/neilpa/yajsv'
-      date-draft:
+      date-draft: []
       draft: [7, 6, 4]
       notes: wraps [xeipuuv/gojsonschema](https://github.com/xeipuuv/gojsonschema)
     - name: Polyglottal JSON Schema Validator
       license: MIT
       url: 'https://www.npmjs.com/package/pajv'
-      date-draft:
+      date-draft: []
       draft: [6, 4]
       notes: can be used with YAML and many other formats besides JSON

--- a/_data/validator-libraries-modern.yml
+++ b/_data/validator-libraries-modern.yml
@@ -48,7 +48,7 @@
     - name: json-schema
       url: https://github.com/luposlip/json-schema
       date-draft: []
-      draft: [7]
+      draft: [4, 6, 7]
       license: Apache License, Version 2.0
 - name: COM/ActiveX
   implementations:
@@ -104,7 +104,7 @@
         Validator for Eclipse Vert.x project JSON types.
         Includes custom keywords support, custom dialect support, asynchronous validation
       date-draft: [2020-12, 2019-09]
-      draft: [7]
+      draft: [4, 7]
       license: Apache License, Version 2.0
     - name: jsonschemafriend
       url: https://github.com/jimblackler/jsonschemafriend
@@ -184,7 +184,7 @@
         Kotlin implementation of JSON Schema.
         (Currently supports most of Draft 7; see the README for details.
         Full compliance with Draft 7 and later drafts in progress.)
-      date-draft: []
+      date-draft: [2019-09]
       draft: [7]
       license: MIT
 - name: Perl
@@ -201,7 +201,7 @@
       license: "GNU General Public License, Version 1 + The Artistic License 1.0"
     - name: JSON::Validator
       url: https://github.com/mojolicious/json-validator
-      date-draft: []
+      date-draft: [2019-09]
       draft: [7, 6, 4]
       license: "The Artistic License 2.0 (GPL Compatible)"
     - name: JSONSchema::Validator
@@ -213,7 +213,7 @@
   implementations:
     - name: Opis Json Schema
       url: https://github.com/opis/json-schema
-      date-draft: []
+      date-draft: [2020-12, 2019-09]
       draft: [7, 6]
       license: "Apache License 2.0"
     - name: Swaggest Json Schema
@@ -261,8 +261,8 @@
   implementations:
     - name: jsonschema-rs
       url: https://github.com/Stranger6667/jsonschema-rs
-      notes: Fast due to compiling schema into a validation tree
-      date-draft: []
+      notes: Fast due to compiling schema into a validation tree; 2019-09 and 2020-12 are partially supported
+      date-draft: [2019-09, 2020-12]
       draft: [7, 6, 4]
       license: MIT
 - name: Scala

--- a/_data/validator-libraries-obsolete.yml
+++ b/_data/validator-libraries-obsolete.yml
@@ -3,7 +3,7 @@
   implementations:
     - name: NJsonSchema
       url: http://NJsonSchema.org
-      notes:
+      date-draft: []
       draft: [4]
       license: Ms-PL
     - name: Manatee.Json
@@ -15,7 +15,7 @@
   implementations:
     - name: WJElement
       url: https://github.com/netmail-open/wjelement
-      date-draft:
+      date-draft: []
       draft: [4, 3]
       license: LGPL-3.0
       notes: "Draft-06+ progress: issue [17](https://github.com/netmail-open/wjelement/issues/17#issuecomment-390899432)"
@@ -24,17 +24,18 @@
   implementations:
     - name: wjelement-cpp
       url: https://github.com/petehug/wjelement-cpp
-      notes:
+      date-draft: []
       draft: [4]
       license: LGPLv3
     - name: Header-only C++ library for JSON Schema validation
       url: https://github.com/tristanpenman/valijson
-      notes:
+      date-draft: []
       draft: [4, 3]
       license: BSD-2-Clause
     - name: Modern C++ JSON schema validator
       url: https://github.com/pboettch/json-schema-validator
       notes: "based on JSON for Modern C++"
+      date-draft: []
       draft: [4]
       license: "MIT"
 - name: Clojure
@@ -42,30 +43,33 @@
     - name: scjsv
       url: https://github.com/metosin/scjsv
       notes: "(wrapper for [java-json-tools/json-schema-validator](https://github.com/java-json-tools/json-schema-validator))"
+      date-draft: []
       draft: [4]
       license: Eclipse Public License v1.0
     - name: json-schema validator
       url: https://github.com/tatut/json-schema
+      date-draft: []
       draft: [3, 4]
       license: MIT
 - name:  CoffeeScript
   implementations:
     - name: JSCK
       url: https://github.com/pandastrike/jsck
+      date-draft: []
       draft: [4, 3]
       license: MIT
 - name:  Dart
   implementations:
     - name: json_schema
       url: https://github.com/patefacio/json_schema
-      notes:
+      date-draft: []
       draft: [4]
       license: BSL-1.0
 - name: Elixir
   implementations:
     - name: Elixir JSON Schema validator
       url: https://github.com/jonasschmidt/ex_json_schema
-      date-draft:
+      date-draft: []
       draft: [4]
       notes: "Draft-06+ progress: issue [24](https://github.com/jonasschmidt/ex_json_schema/issues/24); branch [multi-draft-support](https://github.com/jonasschmidt/ex_json_schema/tree/multi-draft-support)"
       license: MIT
@@ -73,19 +77,21 @@
   implementations:
     - name: validate-json
       url: https://github.com/cesanta/validate-json
+      date-draft: []
       draft: [4]
       license: GPLv2
 - name: Haskell
   implementations:
     - name: hjsonschema
       url: https://github.com/seagreen/hjsonschema
-      notes:
+      date-draft: []
       draft: [4]
       license: MIT
 - name: Java
   implementations:
     - name: json-schema-validator
       url: https://github.com/java-json-tools/json-schema-validator
+      date-draft: []
       draft: [4]
       license: LGPLv3
 - name: JavaScript
@@ -93,95 +99,110 @@
     - name: jsonschema
       url: https://github.com/tdegrunt/jsonschema
       notes: "for Node.js"
+      date-draft: []
       draft: [4]
       license: MIT
     - name: tv4
       url: http://geraintluff.github.com/tv4/
-      notes:
+      date-draft: []
       draft: [4]
-      license: [Public Domain, MIT]
+      license: Public Domain, MIT
     - name: is-my-json-valid
       url: https://github.com/mafintosh/is-my-json-valid
-      notes:
+      date-draft: []
       draft: [4]
       license: MIT
     - name: JaySchema
       url: https://github.com/natesilva/jayschema
       notes: "for Node.js"
+      date-draft: []
       draft: [4]
       license: BSD
     - name: z-schema
       url: https://github.com/zaggino/z-schema
       notes: "for Node.js"
+      date-draft: []
       draft: [4]
       license: MIT
     - name: direct-schema
       url: http://github.com/IreneKnapp/direct-schema
+      date-draft: []
+      draft: [3]
       license: "BSD"
     - name: JSV
       url: http://github.com/garycourt/JSV
+      date-draft: []
       draft: [1, 2, 3]
       license: "BSD"
     - name: json-schema
       url: https://github.com/kriszyp/json-schema
+      date-draft: []
       draft: [4]
       notes: "part of the [Persevere](http://github.com/kriszyp/json-schema) project"
-      license: [AFL, BSD]
+      license: AFL, BSD
     - name: schema.js
       url: https://github.com/akidee/schema.js
+      date-draft: []
       draft: [2]
       license: "MIT"
     - name: json-gate
       url: https://github.com/oferei/json-gate
+      date-draft: []
       draft: [3]
       license: "MIT"
     - name: JSEN
       url: https://github.com/bugventure/jsen
       notes: "for Node.js"
+      date-draft: []
       draft: [4]
       license: "MIT"
     - name: Skeemas
       url: https://github.com/ericgj/json-schema-valid
+      date-draft: []
       draft: [3, 4]
       license: MIT
     - name: Jassi
       url: https://github.com/iclanzan/jassi
+      date-draft: []
       draft: [4]
       license: GPLv3
     - name: json-schema-valid
       url: https://github.com/ericgj/json-schema-valid
+      date-draft: []
       draft: [4]
       license: MIT
 - name: PHP
   implementations:
     - name: json-schema
       url: https://github.com/justinrainbow/json-schema
+      date-draft: []
       draft: [4, 3]
       license: "Berkeley"
     - name: jsv4-php
       url: https://github.com/geraintluff/jsv4-php
-      notes:
+      date-draft: []
       draft: [4]
-      license: [Public Domain, MIT]
+      license: Public Domain, MIT
     - name: JVal
       url: https://github.com/stefk/jval
-      notes:
+      date-draft: []
       draft: [4]
       license: "MIT"
     - name: JSON Guard
       url: https://github.com/thephpleague/json-guard
-      notes:
+      date-draft: []
       draft: [4]
       license: "MIT"
     - name: Swaggest Json Schema
       url: https://github.com/swaggest/php-json-schema
-      notes:
+      date-draft: []
       draft: [4]
       license: "MIT"
 - name: Perl
   implementations:
     - name: JSV::Validator
       url: https://metacpan.org/module/JSV::Validator
+      date-draft: []
       draft: [4]
       license: "MIT"
 - name: PostgreSQL
@@ -189,6 +210,7 @@
     - name: postgres-json-schema
       url: https://github.com/gavinwahl/postgres-json-schema
       notes: "PL/pgSQL implementation, no remote (http) references"
+      date-draft: []
       draft: [4]
       license: PostgreSQL
 - name: Ruby
@@ -196,18 +218,19 @@
     - name: json_schema
       url: https://github.com/brandur/json_schema
       notes: "Schema parser and validator, with hyper-schema support"
+      date-draft: []
       draft: [4]
       license: MIT
     - name: json-schema
       url: https://github.com/hoxworth/json-schema
-      notes:
+      date-draft: []
       draft: [4, 3, 2, 1]
       license: MIT
 - name: Rust
   implementations:
     - name: valico
       url: https://github.com/rustless/valico
-      notes:
+      date-draft: []
       draft: [4]
       license: MIT
 - name: Scala
@@ -215,11 +238,13 @@
     - name: json-schema-parser
       url: https://github.com/VoxSupplyChain/json-schema-parser
       notes: "Schema parser and validator"
+      date-draft: []
       draft: [4]
       license: Apache 2.0
 - name: Swift
   implementations:
     - name: JSONSchema
       url: https://github.com/kylef/JSONSchema.swift
+      date-draft: []
       draft: [4]
       license: BSD-3-Clause

--- a/implementations.md
+++ b/implementations.md
@@ -39,34 +39,42 @@ Validators
 <ul>
   {% for language in validator-libraries %}
   <li>
-    {{language.name}} <a id="validator-{% if language.anchor-name %}{{ language.anchor-name }}{% else %}{{ language.name | downcase }}{% endif %}"></a>
+    <strong>{{language.name}}</strong><a id="validator-{% if language.anchor-name %}{{ language.anchor-name }}{% else %}{{ language.name | downcase }}{% endif %}"></a>
     {% if language.notes %}
-        {{ implementation.notes }}
+        <p>{{ language.notes }}</p>
     {% endif %}
     <ul>
     {% for implementation in language.implementations %}
-        <li>
+      <li>
         <a href="{{implementation.url}}">{{ implementation.name }}</a>
-
-        <em>
-        {% if implementation.date-draft %}
-            {{ implementation.date-draft | sort | reverse | join: ", "}}{% if implementation.draft %}, {% endif %}
-        {% endif %}
-        {% if implementation.draft %}
-            draft-0{{ implementation.draft | sort | reverse | join: ", -0" }}
-        {% endif %}
-        </em>
-
-        {{implementation.notes | markdownify | remove: '<p>' | remove: '</p>'}}
+        <ul>
+          <li><em>Supports:</em>
+            {% if implementation.date-draft %}
+                {{ implementation.date-draft | sort | reverse | join: ", " }}
+            {% endif %}
+            {% if implementation.draft %}
+                draft-0{{ implementation.draft | sort | reverse | join: ", -0" }}
+            {% endif %}
+          </li>
 
         {% if implementation.license %}
-            ({{ implementation.license | join: ", " }})
+          <li><em>License:</em>
+            {{ implementation.license | join: ", " }}
+          </li>
         {% endif %}
 
-        </li>
+        {% if implementation.notes %}
+          <li><em>Notes:</em>
+            {{ implementation.notes | markdownify | remove: '<p>' | remove: '</p>' }}
+          </li>
+        {% endif %}
+
+        </ul>
+      </li>
     {% endfor %}
     </ul>
   </li>
+  <p />
   {% endfor %}
 </ul>
 

--- a/implementations.md
+++ b/implementations.md
@@ -57,6 +57,17 @@ Validators
             {% endif %}
           </li>
 
+        {% if implementation.compliance %}
+          <li><em>Compliance:</em>
+          {% if implementation.compliance.config.docs %}
+            This implementation <a href="{{ implementation.compliance.config.docs }}">documents</a> that you must
+          {% endif %}
+          {% if implementation.compliance.config.instructions %}
+            <strong>{{ implementation.compliance.config.instructions | markdownify | remove: '<p>' | remove: '</p>' }}</strong> to produce specification-compliant behavior.
+          </li>
+          {% endif %}
+        {% endif %}
+
         {% if implementation.license %}
           <li><em>License:</em>
             {{ implementation.license | join: ", " }}

--- a/implementations.md
+++ b/implementations.md
@@ -69,6 +69,12 @@ Validators
           </li>
         {% endif %}
 
+        {% if implementation.last-updated %}
+          <li><em>Information last updated:</em>
+            {{ implementation.last-updated }}
+          </li>
+        {% endif %}
+
         </ul>
       </li>
     {% endfor %}
@@ -337,6 +343,13 @@ Hyper-Schema
         {% if implementation.license %}
             ({{ implementation.license | join: ", " }})
         {% endif %}
+
+        {% if implementation.last-updated %}
+          <br />
+          <em>Information last updated:</em>
+          {{ implementation.last-updated }}
+        {% endif %}
+
 
         </li>
     {% endfor %}

--- a/implementations.md
+++ b/implementations.md
@@ -46,7 +46,8 @@ Validators
     <ul>
     {% for implementation in language.implementations %}
       <li>
-        <a href="{{implementation.url}}">{{ implementation.name }}</a>
+        <a name="{{ implementation.anchor-name | default: implementation.name }}"></a>
+        <a href="{{ implementation.url}}">{{ implementation.name }}</a>
         <ul>
           <li><em>Supports:</em>
             {% if implementation.date-draft %}
@@ -66,6 +67,12 @@ Validators
             <strong>{{ implementation.compliance.config.instructions | markdownify | remove: '<p>' | remove: '</p>' }}</strong> to produce specification-compliant behavior.
           </li>
           {% endif %}
+        {% endif %}
+
+        {% if implementation.built-on %}
+          <li><em>Built on:</em>
+            <a href="#{{ implementation.built-on.anchor-name | default: implementation.built-on.name }}">{{ implementation.built-on.name }}</a>
+          </li>
         {% endif %}
 
         {% if implementation.license %}


### PR DESCRIPTION
While this PR does a lot, its primary purpose is to add a structured way of tracking implementations that need configuration in order to be in compliance (or maximize compliance) with the specification, which fixes issue #390.  I believe this approach accomplishes that with appropriate neutral language.

Adding this information overloaded the layout we were using, so I have changed it to give each implementation a list of named fields and values, which is much easier to skim over as a casual reader, and allows us to add more information as needed.

At this point, it made sense to add a proper schema for the data files, which also involve tweaking the files to fit.  Since I was going through all the implementations to find configuration issues anyway, I updated the draft support, and took advantage of the new structure to add an "Information last updated field" as these sorts of lists always have issues with stale information.  While doing that, I noticed how some implementations build on each other, so I added a field to link those as well.

This was done over the course of several commits, the messages for which are included below from oldest to newest.  You can look at the individual commit diffs to see the steps.  The first commit is a bit noisy in the data files as I decided to forbid blank (`null`) fields and either deleted them or set them to empty arrays as appropriate.  The last-updated additions are verbose but boring as they are all the same- you have to quote the date strings as YAML will turn them into date objects otherwise, at least in some implementations.  The compliant config and built-on commits are fairly straightforward.

## Schema (with conformance fixes)

Schema for the impls data file, structured page

This does two things in preparation for showing more
information on this page in a way that is easy to see
when quickly skimming the list.

It adds a schema (in yaml because it will get pulled
in to the jekyll/liquid template in the future) which
documents the current fields.

It also makes the rendered form of the list more
structured by giving each implementation a field list.
I anticipate more fields as important information that
is currently inconsistenlty reported in the notes gets
pulled out, starting with the configuration compliance
information in the next commit.

This commit also fixes where the language-level notes
were not being rendered correctly, and updates the draft
list for ajv-cli because I happened to notice it was
out of date.

For hyper-schema, the updated layout is simpler because
there is only one modern implementation anyway.
The other was moved to obsolete following the similar
recent moves of validators that have not followed
through on draft-06 or newer support.

The obsolete data files are supported by changing a
handful of license values from arrays to strings,
which display identically.  Allowing arrays didn't
seem worth the trouble since the modern file doesn't
use them.  I did not change the layout of the obsolete
page because really we'd rather people not look at it
at all.  Also, one obsolete validator did not specify
which draft it supported, but from the last modified
date in the repo it must have been draft-03.  At this
point, I doubt it matters anyway.

## Drafts support updates

Update draft support values.

Since I just went through every implementation looking at
various things anyway.  I might have missed some updates,
but hopefully not.

## Last-updated tracking

Add last-updated tracking.

Since I just went through and looked at all of these, this adds
a date stamp for such things.  It is required throughout the data
file if it is used at all, but it can be left out entirely
(because I am not going to look through the obsolete files).

All four data files (validator/hyper + modern/obsolete) are valid
against the schema as of this commit.

## Compliant configurations

Add a compliance section to the impl data
This adds a structured section on compliance, specifically how
to configure for it.  This is *not* intended to be the same sort
of compliance information that the test suite provides.  Rather,
it is about things that implementations document that don't
necessarily show up in test suite results.

This format includes brief instructions and optionally
(ideally) a documentation link.  I think this langauge is
appropriately neutral, and particularly when there is a doc link
it feels more like calling attention to something that is already
advertised rather than being judgemental.

The AJV and Opis cases are straightfoward.

The Common Lisp implementation's case of needing to disable
automatic downloading is worth a bit of thought as that is a
SHOULD NOT rather than a MUST NOT, but this is why the schema
description notes that it is the _most_ compliant config,
and other configs may still be compliant.

Similary, the networknt Java implementation having `nullable`
on by default is not technically non-compliant, but it is more
compliant to not have it.

There may be other compliance configuration changes that need
documenting, but these were the ones that I could find with
a reasonable amount of effort.

## Built-on links

Add built-on field

Some implementations, particularly but not exclusively CLI and
web ones, are implemented on top of other validator libraries.

This adds a structured field to account for that, and updates
all known cases where it is relevant.

It was necessary to also support an anchor-name field for
implementations as with programming languages, and in the
process disambiguate a few duplicate names.
