### PR TITLE
fix specification reference links

### DIFF
--- a/learn/file-system.md
+++ b/learn/file-system.md
@@ -66,16 +66,16 @@ We will start with a base JSON Schema expressing the following constraints:
 
 Building out our JSON Schema from top to bottom:
 
-* The [`$id`](https://json-schema.org/draft/2020-12/json-schema-core.html#rfc.section.8.2.1) keyword.
-* The [`$schema`](https://json-schema.org/draft/2020-12/json-schema-core.html#rfc.section.8.1.1) keyword.
-* The [`type`](https://json-schema.org/draft/2020-12/json-schema-validation.html#rfc.section.6.1.1) validation keyword.
-* The [`required`](https://json-schema.org/draft/2020-12/json-schema-validation.html#rfc.section.6.5.3) validation keyword.
-* The [`properties`](https://json-schema.org/draft/2020-12/json-schema-core.html#rfc.section.10.3.2.1) validation keyword.
+* The [`$id`](https://json-schema.org/draft/2020-12/json-schema-core.html#section-8.2.1) keyword.
+* The [`$schema`](https://json-schema.org/draft/2020-12/json-schema-core.html#section-8.1.1) keyword.
+* The [`type`](https://json-schema.org/draft/2020-12/json-schema-validation.html#section-6.1.1) validation keyword.
+* The [`required`](https://json-schema.org/draft/2020-12/json-schema-validation.html#section-6.5.3) validation keyword.
+* The [`properties`](https://json-schema.org/draft/2020-12/json-schema-core.html#section-10.3.2.1) validation keyword.
   * The `/` key is empty now; We will fill it out later.
-* The [`patternProperties`](https://json-schema.org/draft/2020-12/json-schema-core.html#rfc.section.10.3.2.2) validation keyword.
+* The [`patternProperties`](https://json-schema.org/draft/2020-12/json-schema-core.html#section-10.3.2.2) validation keyword.
   * This matches other property names via a regular expression. Note: it does not match `/`.
   * The `^(/[^/]+)+$` key is empty now; We will fill it out later.
-* The [`additionalProperties`](https://json-schema.org/draft/2020-12/json-schema-core.html#rfc.section.10.3.2.3) validation keyword.
+* The [`additionalProperties`](https://json-schema.org/draft/2020-12/json-schema-core.html#section-10.3.2.3) validation keyword.
   * The value here is `false` to constrain object properties to be either `/` or to match the regular expression.
 
 > You will notice that the regular expression is explicitly anchored (with `^` and `$`): in JSON Schema, regular expressions (in `patternProperties` and in `pattern`) are not anchored by default.
@@ -104,11 +104,11 @@ We saw these keywords in the prior exercise: `$id`, `$schema`, `type`, `required
 
 To this we add:
 
-* The [`description`](https://json-schema.org/draft/2020-12/json-schema-validation.html#rfc.section.9.1) annotation keyword.
-* The [`oneOf`](https://json-schema.org/draft/2020-12/json-schema-core.html#rfc.section.10.2.1.3) keyword.
-* The [`$ref`](https://json-schema.org/draft/2020-12/json-schema-core.html#rfc.section.8.2.3.1) keyword.
+* The [`description`](https://json-schema.org/draft/2020-12/json-schema-validation.html#section-9.1) annotation keyword.
+* The [`oneOf`](https://json-schema.org/draft/2020-12/json-schema-core.html#section-10.2.1.3) keyword.
+* The [`$ref`](https://json-schema.org/draft/2020-12/json-schema-core.html#section-8.2.3.1) keyword.
   * In this case, all references used are local to the schema using a relative fragment URI (`#/...`).
-* The [`$defs`](https://json-schema.org/draft/2020-12/json-schema-core.html#rfc.section.8.2.4) keyword.
+* The [`$defs`](https://json-schema.org/draft/2020-12/json-schema-core.html#section-8.2.4) keyword.
   * Including several key names which we will define later.
 
 ```json
@@ -142,12 +142,12 @@ To this we add:
 
 Let's now extend this skeleton to add constraints to some of the properties.
 
-* Our `fstype` key uses the [`enum`](https://json-schema.org/draft/2020-12/json-schema-validation.html#rfc.section.6.1.2) validation keyword.
+* Our `fstype` key uses the [`enum`](https://json-schema.org/draft/2020-12/json-schema-validation.html#section-6.1.2) validation keyword.
 * Our `options` key uses the following:
   * The `type` validation keyword (see above).
-  * The [`minItems`](https://json-schema.org/draft/2020-12/json-schema-validation.html#rfc.section.6.4.2) validation keyword.
-  * The [`items`](https://json-schema.org/draft/2020-12/json-schema-core.html#rfc.section.10.3.1.2) validation keyword.
-  * The [`uniqueItems`](https://json-schema.org/draft/2020-12/json-schema-validation.html#rfc.section.6.4.3) validation keyword.
+  * The [`minItems`](https://json-schema.org/draft/2020-12/json-schema-validation.html#section-6.4.2) validation keyword.
+  * The [`items`](https://json-schema.org/draft/2020-12/json-schema-core.html#section-10.3.1.2) validation keyword.
+  * The [`uniqueItems`](https://json-schema.org/draft/2020-12/json-schema-validation.html#section-6.4.3) validation keyword.
   * Together these say: `options` must be an array, and the items therein must be strings, there must be at least one item, and all items should be unique.
 * We have a `readonly` key.
 
@@ -198,7 +198,7 @@ With these added constraints, the schema now looks like this:
 
 One new keyword is introduced here:
 
-* The [`pattern`](https://json-schema.org/draft/2020-12/json-schema-validation.html#rfc.section.6.3.3) validation keyword notes the `device` key must be an absolute path starting with */dev*.
+* The [`pattern`](https://json-schema.org/draft/2020-12/json-schema-validation.html#section-6.3.3) validation keyword notes the `device` key must be an absolute path starting with */dev*.
 
 ```json
 {
@@ -246,7 +246,7 @@ We do have a new key: `label` and the `pattern` validation keyword states it mus
 
 We find another new keyword:
 
-* The [`format`](https://json-schema.org/draft/2020-12/json-schema-validation.html#rfc.section.7) annotation and assertion keyword.
+* The [`format`](https://json-schema.org/draft/2020-12/json-schema-validation.html#section-7) annotation and assertion keyword.
 
 ```json
 {
@@ -276,8 +276,8 @@ We find another new keyword:
 
 Our last definition introduces two new keywords:
 
-* The [`minimum`](https://json-schema.org/draft/2020-12/json-schema-validation.html#rfc.section.6.2.4) validation keyword.
-* The [`maximum`](https://json-schema.org/draft/2020-12/json-schema-validation.html#rfc.section.6.2.2) validation keyword.
+* The [`minimum`](https://json-schema.org/draft/2020-12/json-schema-validation.html#section-6.2.4) validation keyword.
+* The [`maximum`](https://json-schema.org/draft/2020-12/json-schema-validation.html#section-6.2.2) validation keyword.
 * Together these require the size be between 16 and 512, inclusive.
 
 ```json

--- a/learn/getting-started-step-by-step.md
+++ b/learn/getting-started-step-by-step.md
@@ -50,10 +50,10 @@ We start with four properties called **keywords** which are expressed as [JSON](
 
 > Yes. the standard uses a JSON data document to describe data documents, most often that are also JSON data documents but could be in any number of other content types like `text/xml`.
 
-* The [`$schema`](https://json-schema.org/draft/2020-12/json-schema-core.html#rfc.section.8.1.1) keyword states that this schema is written according to a specific draft of the standard and used for a variety of reasons, primarily version control.
-* The [`$id`](https://json-schema.org/draft/2020-12/json-schema-core.html#rfc.section.8.2.1) keyword defines a URI for the schema, and the base URI that other URI references within the schema are resolved against.
-* The [`title`](https://json-schema.org/draft/2020-12/json-schema-validation.html#rfc.section.9.1) and [`description`](https://json-schema.org/draft/2020-12/json-schema-validation.html#rfc.section.9.1) annotation keywords are descriptive only. They do not add constraints to the data being validated. The intent of the schema is stated with these two keywords.
-* The [`type`](https://json-schema.org/draft/2020-12/json-schema-validation.html#rfc.section.6.1.1) validation keyword defines the first constraint on our JSON data and in this case it has to be a JSON Object.
+* The [`$schema`](https://json-schema.org/draft/2020-12/json-schema-core.html#section-8.1.1) keyword states that this schema is written according to a specific draft of the standard and used for a variety of reasons, primarily version control.
+* The [`$id`](https://json-schema.org/draft/2020-12/json-schema-core.html#section-8.2.1) keyword defines a URI for the schema, and the base URI that other URI references within the schema are resolved against.
+* The [`title`](https://json-schema.org/draft/2020-12/json-schema-validation.html#section-9.1) and [`description`](https://json-schema.org/draft/2020-12/json-schema-validation.html#section-9.1) annotation keywords are descriptive only. They do not add constraints to the data being validated. The intent of the schema is stated with these two keywords.
+* The [`type`](https://json-schema.org/draft/2020-12/json-schema-validation.html#section-6.1.1) validation keyword defines the first constraint on our JSON data and in this case it has to be a JSON Object.
 
 ```json
 {
@@ -67,9 +67,9 @@ We start with four properties called **keywords** which are expressed as [JSON](
 
 We introduce the following pieces of terminology when we start the schema:
 
-* [Schema Keyword](https://json-schema.org/draft/2020-12/json-schema-core.html#rfc.section.8.1.1): `$schema` and `$id`.
-* [Schema Annotations](https://json-schema.org/draft/2020-12/json-schema-validation.html#rfc.section.9.1): `title` and `description`.
-* [Validation Keyword](https://json-schema.org/draft/2020-12/json-schema-validation.html#rfc.section.6.1.1): `type`.
+* [Schema Keyword](https://json-schema.org/draft/2020-12/json-schema-core.html#section-8.1.1): `$schema` and `$id`.
+* [Schema Annotations](https://json-schema.org/draft/2020-12/json-schema-validation.html#section-9.1): `title` and `description`.
+* [Validation Keyword](https://json-schema.org/draft/2020-12/json-schema-validation.html#section-6.1.1): `type`.
 
 ## <a name="properties"></a>Defining the properties
 
@@ -77,10 +77,10 @@ We introduce the following pieces of terminology when we start the schema:
 
 In JSON Schema terms, we update our schema to add:
 
-* The [`properties`](https://json-schema.org/draft/2020-12/json-schema-core.html#rfc.section.10.3.2.1) validation keyword.
+* The [`properties`](https://json-schema.org/draft/2020-12/json-schema-core.html#section-10.3.2.1) validation keyword.
 * The `productId` key.
   * `description` schema annotation and `type` validation keyword is noted -- we covered both of these in the previous section.
-* The [`required`](https://json-schema.org/draft/2020-12/json-schema-validation.html#rfc.section.6.5.3) validation keyword listing `productId`.
+* The [`required`](https://json-schema.org/draft/2020-12/json-schema-validation.html#section-6.5.3) validation keyword listing `productId`.
 
 
 ```json
@@ -130,8 +130,8 @@ In JSON Schema terms, we update our schema to add:
 According to the store owner there are no free products. ;)
 
 * The `price` key is added with the usual `description` schema annotation and `type` validation keywords covered previously. It is also included in the array of keys defined by the `required` validation keyword.
-* We specify the value of `price` must be something other than zero using the [`exclusiveMinimum`](https://json-schema.org/draft/2020-12/json-schema-validation.html#rfc.section.6.2.5) validation keyword.
-  * If we wanted to include zero as a valid price we would have specified the [`minimum`](https://json-schema.org/draft/2020-12/json-schema-validation.html#rfc.section.6.2.4) validation keyword.
+* We specify the value of `price` must be something other than zero using the [`exclusiveMinimum`](https://json-schema.org/draft/2020-12/json-schema-validation.html#section-6.2.5) validation keyword.
+  * If we wanted to include zero as a valid price we would have specified the [`minimum`](https://json-schema.org/draft/2020-12/json-schema-validation.html#section-6.2.4) validation keyword.
 
 ```json
 {
@@ -172,9 +172,9 @@ Therefore:
 
 * The `tags` key is added with the usual annotations and keywords.
 * This time the `type` validation keyword is `array`.
-* We introduce the [`items`](https://json-schema.org/draft/2020-12/json-schema-core.html#rfc.section.10.3.1.2) validation keyword so we can define what appears in the array. In this case: `string` values via the `type` validation keyword.
-* The [`minItems`](https://json-schema.org/draft/2020-12/json-schema-validation.html#rfc.section.6.4.2) validation keyword is used to make sure there is at least one item in the array.
-* The [`uniqueItems`](https://json-schema.org/draft/2020-12/json-schema-validation.html#rfc.section.6.4.3) validation keyword notes all of the items in the array must be unique relative to one another.
+* We introduce the [`items`](https://json-schema.org/draft/2020-12/json-schema-core.html#section-10.3.1.2) validation keyword so we can define what appears in the array. In this case: `string` values via the `type` validation keyword.
+* The [`minItems`](https://json-schema.org/draft/2020-12/json-schema-validation.html#section-6.4.2) validation keyword is used to make sure there is at least one item in the array.
+* The [`uniqueItems`](https://json-schema.org/draft/2020-12/json-schema-validation.html#section-6.4.3) validation keyword notes all of the items in the array must be unique relative to one another.
 * We did not add this key to the `required` validation keyword array because it is optional.
 
 ```json
@@ -276,7 +276,7 @@ So far our JSON schema has been wholly self contained. It is very common to shar
 
 For this example we introduce a new JSON Schema resource and for both properties therein:
 * We use the `minimum` validation keyword noted earlier.
-* We add the [`maximum`](https://json-schema.org/draft/2020-12/json-schema-validation.html#rfc.section.6.2.2) validation keyword.
+* We add the [`maximum`](https://json-schema.org/draft/2020-12/json-schema-validation.html#section-6.2.2) validation keyword.
 * Combined, these give us a range to use in validation.
 
 ```json


### PR DESCRIPTION
Looks like the doc fragment links in json-schema-core and json-schema-validation changed, so fixing the references, in these super useful learning resources (thanks, btw!).
