### PR TITLE
Link directly to json-everything.net's validator

### DIFF
--- a/_data/validator-libraries-modern.yml
+++ b/_data/validator-libraries-modern.yml
@@ -364,7 +364,7 @@
         name: Hyperjump JSV
       last-updated: "2022-08-31"
     - name: json-everything
-      url: https://json-everything.net
+      url: https://json-everything.net/json-schema
       date-draft: [2020-12, 2019-09]
       draft: [7, 6]
       notes: Powered by JsonSchema.Net in Blazor WASM for client-side validation


### PR DESCRIPTION
In https://json-schema.org/implementations.html#validator-web%20(online), the entry for json-everything.net links to the home page, but IIUC it should instead link to the validator at https://json-everything.net/json-schema.