### PR TITLE
Fix a couple schema hosting issues.

### DIFF
--- a/draft/2020-12/meta/hyper-schema
+++ b/draft/2020-12/meta/hyper-schema
@@ -1,0 +1,1 @@
+../../../_includes/draft/2020-12/meta/hyper-schema.json


### PR DESCRIPTION
https://github.com/orgs/json-schema-org/discussions/330 identified a couple of issues with schemas related to hyper-schema. Depends on https://github.com/json-schema-org/json-schema-spec/pull/1382

* The draft-07 hyper-schema-output `$id` was incorrect
* The 2020-12 hyper-schema vocabulary was not being hosted.