### PR TITLE
Rename the implementation schema.js to jema.js

### DIFF
--- a/_data/validator-libraries-modern.ymlschem
+++ b/_data/validator-libraries-modern.ymlschem
@@ -218,12 +218,12 @@
       draft: [6]
       license: MIT
       last-updated: "2022-08-31"
-    - name: schema.js
-      url: https://github.com/nuxodin/schema.js
+    - name: jema.js
+      url: https://github.com/nuxodin/jema.js
       date-draft: [2020-12]
       draft: []
       license: MIT
-      last-updated: "2023-03-23"
+      last-updated: "2023-03-28"
 - name: Kotlin
   implementations:
     - name: Medeia-validator


### PR DESCRIPTION
I have decided to use a more unique name.

Aside:

> Do you intend to release it as a package on a package manager (such as npm)?
done: https://www.npmjs.com/package/jema.js

> Do you intend to continue development to resolve outstanding bugs (highlighted by failing tests)?
I have continued the development and fixed some bugs.
