### PR TITLE
Update slack invite link

### DIFF
--- a/slack.md
+++ b/slack.md
@@ -1,3 +1,3 @@
 ---
-redirect_to: https://join.slack.com/t/json-schema/shared_invite/zt-15ylccbuu-3T2bRia8uzhE157TSW6nXg
+redirect_to: https://join.slack.com/t/json-schema/shared_invite/zt-1tc77c02b-z~UiKXqpM2gHchClKbUoXw
 ---


### PR DESCRIPTION
Previous one expired, so new slack invite link!
The link doesn't have an expiery date, but sometimes expires after some number of uses... number unknown or not documented by Slack as far as I can tell.