### PR TITLE
Remove 2019-09 / 2020-12 support from networknt implementation

### DIFF
--- a/_data/validator-libraries-modern.yml
+++ b/_data/validator-libraries-modern.yml
@@ -149,7 +149,7 @@
     - name: networknt/json-schema-validator
       url: https://github.com/networknt/json-schema-validator
       notes: Support OpenAPI 3.0 with Jackson parser
-      date-draft: [2020-12, 2019-09]
+      date-draft: []
       draft: [7, 6, 4]
       license: Apache License 2.0
       compliance:


### PR DESCRIPTION
The `networknt/json-schema-validator` Java implementation has some major [compliance gaps](https://github.com/networknt/json-schema-validator/blob/master/doc/compatibility.md) in 2019-09 and 2020-12 including only partial support for `$id` and `$ref` and no support for `$anchor`, `$dynamicRef`, or `$dynamicAnchor`. With that much missing, I don't think our implementations page should claim that implementation supports those dialect.