### PR TITLE
Update slack link

### DIFF
--- a/slack.md
+++ b/slack.md
@@ -1,3 +1,3 @@
 ---
-redirect_to: https://join.slack.com/t/json-schema/shared_invite/zt-1tc77c02b-z~UiKXqpM2gHchClKbUoXw
+redirect_to: https://join.slack.com/t/json-schema/shared_invite/zt-1ywpdj4yd-bXiBLjYEbKWUjzon0qiY9Q
 ---


### PR DESCRIPTION
Fixes https://github.com/json-schema-org/blog/issues/34 Should not expire.
Is limited to 400 uses per slack requirements.