### PR TITLE
Improve implementation draft list layout

### DIFF
--- a/implementations.md
+++ b/implementations.md
@@ -50,10 +50,11 @@ Validators
         <a href="{{ implementation.url}}">{{ implementation.name }}</a>
         <ul>
           <li><em>Supports:</em>
-            {% if implementation.date-draft %}
+            {% if implementation.date-draft and implementation.date-draft != empty %}
                 {{ implementation.date-draft | sort | reverse | join: ", " }}
+                {%- if implementation.draft and implementation.draft != empty %}, {% endif %}
             {% endif %}
-            {% if implementation.draft %}
+            {% if implementation.draft and implementation.draft != empty %}
                 draft-0{{ implementation.draft | sort | reverse | join: ", -0" }}
             {% endif %}
           </li>


### PR DESCRIPTION
This adds a comma between `draft` and `date-draft` items and checks for `empty` arrays to prevent stray "draft-0" output.

Before:

<img width="1552" alt="Screen Shot 2023-08-21 at 10 47 42 AM" src="https://github.com/json-schema-org/json-schema-org.github.io/assets/869489/4478c05e-34f5-4125-991d-924812eeec85">

After:

<img width="1552" alt="Screen Shot 2023-08-21 at 10 47 44 AM" src="https://github.com/json-schema-org/json-schema-org.github.io/assets/869489/b638cac0-3ce1-4c40-a3d0-2a526d257aca">