### PR TITLE
Add 2020-12/2019-09 support to json_schemer (ruby)

### DIFF
--- a/_data/validator-libraries-modern.yml
+++ b/_data/validator-libraries-modern.yml
@@ -348,10 +348,10 @@
   implementations:
     - name: JSONSchemer
       url: https://github.com/davishmcclurg/json_schemer
-      date-draft: []
+      date-draft: [2020-12, 2019-09]
       draft: [7, 6, 4]
       license: MIT
-      last-updated: "2022-08-31"
+      last-updated: "2023-08-20"
     - name: JSI
       url: https://rubydoc.info/gems/jsi
       date-draft: []


### PR DESCRIPTION
Just released version 2.0.0 with support for these drafts: https://github.com/davishmcclurg/json_schemer/pull/135