### PR TITLE
Adds OpenAPI JSON Schema Generator Implementation

### DIFF
--- a/implementations.md
+++ b/implementations.md
@@ -224,7 +224,7 @@ are the only keywords that changed.
 -   Python
     - [yacg](https://github.com/OkieOth/yacg) (MIT) - parse JSON Schema and OpenApi files to build a meta model from them. This meta model can be used in Mako templates to generate source code, other schemas or plantUml.
     - [statham](https://github.com/jacksmith15/statham-schema) (MIT) - generate type-annotated models from JSON Schema documents.
-    - [OpenAPI JSON Schmea Generator](https://github.com/openapi-json-schema-tools/openapi-json-schema-generator) (Apache-2.0) - Allows auto-generation of API client libraries (SDK generation) given an OpenAPI document. This project focuses on making the output 100% compliant with openapi + JSON schema specs.
+    - [OpenAPI JSON Schema Generator](https://github.com/openapi-json-schema-tools/openapi-json-schema-generator) (Apache-2.0) - Allows auto-generation of API client libraries (SDK generation) given an OpenAPI document. This project focuses on making the output 100% compliant with openapi + JSON schema specs.
 -   Rust
     - [schemafy](https://github.com/Marwes/schemafy/) - generates Rust types and serialization code from a JSON schema. *supports Draft 4*
 -   Scala

--- a/implementations.md
+++ b/implementations.md
@@ -224,6 +224,7 @@ are the only keywords that changed.
 -   Python
     - [yacg](https://github.com/OkieOth/yacg) (MIT) - parse JSON Schema and OpenApi files to build a meta model from them. This meta model can be used in Mako templates to generate source code, other schemas or plantUml.
     - [statham](https://github.com/jacksmith15/statham-schema) (MIT) - generate type-annotated models from JSON Schema documents.
+    - [OpenAPI JSON Schmea Generator](https://github.com/openapi-json-schema-tools/openapi-json-schema-generator) (Apache-2.0) - Allows auto-generation of API client libraries (SDK generation) given an OpenAPI document. This project focuses on making the output 100% compliant with openapi + JSON schema specs.
 -   Rust
     - [schemafy](https://github.com/Marwes/schemafy/) - generates Rust types and serialization code from a JSON schema. *supports Draft 4*
 -   Scala


### PR DESCRIPTION
Adds OpenAPI JSON Schema Generator Implementation
The project implements the majority of the draft 2020-12 json schema keywords per [the latest release](https://github.com/openapi-json-schema-tools/openapi-json-schema-generator/releases/tag/3.1.0) which runs the json schema test suite for verification